### PR TITLE
fix(policyclient): make the retry ladder real, and stop reporting sidecar failures as timeouts

### DIFF
--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -18,17 +18,32 @@ import (
 	"workweave/router/internal/router/policy"
 )
 
-// DefaultTimeout bounds a single delegated policy decision.
-const DefaultTimeout = 3 * time.Second
+// DefaultTimeout bounds a single delegated policy decision. It has to hold more
+// than one full attempt or the retry ladder below is decoration: at the old 3s,
+// attempt 1's 1.8s bound plus a backoff left ~1.15s, so attempt 2 was always
+// truncated by the parent deadline and attempt 3 never ran. 4.5s fits two full
+// attempts (1.8 + 0.05 + 1.8 = 3.65s) with the third still available to the
+// fast-failure case (connection refused, an instant 5xx) that returns in
+// milliseconds.
+const DefaultTimeout = 4500 * time.Millisecond
 
 const (
 	defaultRouteAttempts = 3
 	routeRetryBackoff    = 50 * time.Millisecond
 )
 
-// Per-attempt bound so a stalled instance cannot consume the whole decision budget and prevent retries.
+// Per-attempt bound so a stalled instance cannot consume the whole decision
+// budget and prevent retries. The fraction is deliberately at/below
+// 1/defaultRouteAttempts: above that, attempt 1 can claim more than its share
+// and starve the retries it exists to enable.
+//
+// The absolute value matters as much as the ratio. A policy sidecar with its
+// own inference deadline answers just inside it (the HMM sidecar degrades to
+// the session's prior state at 1.5s), so an attempt bound below that deadline
+// cancels a request the sidecar was about to answer and converts a successful
+// degrade into a router-side timeout. 0.4 x 4.5s keeps the bound at 1.8s.
 const (
-	defaultAttemptFraction = 0.6
+	defaultAttemptFraction = 0.4
 	minAttemptTimeout      = 500 * time.Millisecond
 )
 
@@ -693,16 +708,23 @@ func pointerTo[T any](value T) *T {
 }
 
 func (c *Client) doPolicyRequest(ctx context.Context, path string, body []byte) (*http.Response, []byte, error) {
-	var lastErr error
+	// lastErr is the most recent failure; lastStatusErr is the most recent one
+	// the sidecar itself reported. They diverge exactly when the budget runs out
+	// mid-ladder, which is when the diagnosis matters most.
+	var lastErr, lastStatusErr error
 	for attempt := 1; attempt <= defaultRouteAttempts; attempt++ {
 		if err := ctx.Err(); err != nil {
-			return nil, nil, fmt.Errorf("policy sidecar retries exhausted: %w", err)
+			return nil, nil, exhaustedPolicyErr(preferStatusErr(lastStatusErr, lastErr), err)
 		}
 		resp, payload, done, attemptErr := c.doPolicyAttempt(ctx, attempt, path, body)
 		if done {
 			return resp, payload, attemptErr
 		}
 		lastErr = attemptErr
+		var statusErr *PolicyStatusError
+		if errors.As(attemptErr, &statusErr) {
+			lastStatusErr = attemptErr
+		}
 		if attempt == defaultRouteAttempts {
 			break
 		}
@@ -710,11 +732,46 @@ func (c *Client) doPolicyRequest(ctx context.Context, path string, body []byte) 
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			return nil, nil, fmt.Errorf("policy sidecar retries exhausted: %w", ctx.Err())
+			return nil, nil, exhaustedPolicyErr(preferStatusErr(lastStatusErr, lastErr), ctx.Err())
 		case <-timer.C:
 		}
 	}
-	return nil, nil, fmt.Errorf("policy sidecar retries exhausted: %w", lastErr)
+	return nil, nil, exhaustedPolicyErr(preferStatusErr(lastStatusErr, lastErr), nil)
+}
+
+// preferStatusErr picks the sidecar's own status over a transport failure. The
+// final attempt of an exhausted ladder is usually the one the parent deadline
+// truncated, so without this the reported cause is always the budget and never
+// the sidecar — which is how ~390 fail-closed 503s a day were logged as
+// timeouts and the router never once recorded "policy sidecar status 503".
+func preferStatusErr(statusErr, lastErr error) error {
+	if statusErr != nil {
+		return statusErr
+	}
+	return lastErr
+}
+
+// exhaustedPolicyErr reports why the ladder ended. The sidecar's own error is
+// the diagnosis and has to survive: when the budget runs out after the sidecar
+// has already answered — its own fail-closed 503, or a 500 — reporting only
+// context.DeadlineExceeded reads as "the sidecar never replied" and hides the
+// real cause. In prod that masked 1,807 requests failing on a sidecar
+// TypeError and ~390/day failing on the sidecar's own 503; neither ever
+// appeared as anything but a timeout. Both errors are wrapped so callers that
+// degrade on the deadline (isPolicyDeadlineErr) still match.
+func exhaustedPolicyErr(lastErr, ctxErr error) error {
+	switch {
+	case lastErr == nil && ctxErr == nil:
+		return errors.New("policy sidecar retries exhausted")
+	case lastErr == nil:
+		return fmt.Errorf("policy sidecar retries exhausted: %w", ctxErr)
+	// errors.Is keeps a transport deadline from being printed twice; the
+	// wrapped sentinel is already reachable through lastErr.
+	case ctxErr == nil || errors.Is(lastErr, ctxErr):
+		return fmt.Errorf("policy sidecar retries exhausted: %w", lastErr)
+	default:
+		return fmt.Errorf("policy sidecar retries exhausted: %w: %w", lastErr, ctxErr)
+	}
 }
 
 // doPolicyAttempt runs one bounded attempt; returns done=true on a final outcome (success or fatal error).
@@ -777,15 +834,28 @@ func isTransientPolicyStatus(status int) bool {
 		status == http.StatusGatewayTimeout
 }
 
+// PolicyStatusError is a non-2xx response from the sidecar. It is typed so the
+// retry ladder can prefer it over a later attempt's transport error: a status is
+// the sidecar's own diagnosis of the failure, whereas a truncated final
+// attempt's "context deadline exceeded" only says the budget ran out.
+type PolicyStatusError struct {
+	Status  int
+	Message string
+}
+
+func (e *PolicyStatusError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("policy sidecar status %d: %s", e.Status, e.Message)
+	}
+	return fmt.Sprintf("policy sidecar status %d", e.Status)
+}
+
 func policyStatusError(status int, payload []byte) error {
 	var parsed struct {
 		Error string `json:"error"`
 	}
 	_ = json.Unmarshal(payload, &parsed)
-	if parsed.Error != "" {
-		return fmt.Errorf("policy sidecar status %d: %s", status, parsed.Error)
-	}
-	return fmt.Errorf("policy sidecar status %d", status)
+	return &PolicyStatusError{Status: status, Message: parsed.Error}
 }
 
 func wireRoutingKnobs(knobs *router.Overrides) *routingKnobs {

--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -749,8 +749,7 @@ func preferStatusErr(statusErr, lastErr error) error {
 // exhaustedPolicyErr reports why the ladder ended. Both the sidecar's status and
 // the deadline are preserved: the status is the sidecar's own diagnosis; the
 // deadline keeps isPolicyDeadlineErr matching so the policy-deadline fallback
-// still degrades instead of handing the caller the 503 that fallback exists to
-// prevent.
+// still degrades rather than surfacing the 503 that fallback exists to prevent.
 func exhaustedPolicyErr(statusErr, lastErr, ctxErr error) error {
 	primary := preferStatusErr(statusErr, lastErr)
 	deadline := cancellationSignal(ctxErr, lastErr, statusErr)
@@ -846,10 +845,9 @@ func isTransientPolicyStatus(status int) bool {
 		status == http.StatusGatewayTimeout
 }
 
-// PolicyStatusError is a non-2xx response from the sidecar. It is typed so the
-// retry ladder can prefer it over a later attempt's transport error: a status is
-// the sidecar's own diagnosis of the failure, whereas a truncated final
-// attempt's "context deadline exceeded" only says the budget ran out.
+// PolicyStatusError is a non-2xx response from the sidecar, typed so the retry
+// ladder can prefer it over a transport error: a status is the sidecar's own
+// diagnosis; "context deadline exceeded" only says the budget ran out.
 type PolicyStatusError struct {
 	Status  int
 	Message string

--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -41,6 +41,12 @@ const (
 const (
 	defaultAttemptFraction = 0.4
 	minAttemptTimeout      = 500 * time.Millisecond
+	// sidecarInferenceFloor is the smallest per-attempt bound that still
+	// outlives a policy sidecar's own inference deadline. What an attempt has to
+	// survive is that deadline, which does not scale with the router's budget —
+	// so a pure fraction silently drops below it on smaller configured budgets
+	// (0.4 x 3s = 1.2s < 1.5s). Applied only when the budget can afford it.
+	sidecarInferenceFloor = 1800 * time.Millisecond
 )
 
 // Option customizes a policy sidecar client.
@@ -59,6 +65,12 @@ func DeriveAttemptTimeout(timeout time.Duration) time.Duration {
 		timeout = DefaultTimeout
 	}
 	attemptTimeout := time.Duration(float64(timeout) * defaultAttemptFraction)
+	// A budget too small to seat the floor and still leave a retry keeps the
+	// old leave-room-for-a-retry behaviour rather than spending everything on
+	// attempt 1.
+	if attemptTimeout < sidecarInferenceFloor && timeout >= sidecarInferenceFloor+minAttemptTimeout {
+		attemptTimeout = sidecarInferenceFloor
+	}
 	if attemptTimeout < minAttemptTimeout {
 		attemptTimeout = minAttemptTimeout
 	}
@@ -708,7 +720,7 @@ func (c *Client) doPolicyRequest(ctx context.Context, path string, body []byte) 
 	var lastErr, lastStatusErr error
 	for attempt := 1; attempt <= defaultRouteAttempts; attempt++ {
 		if err := ctx.Err(); err != nil {
-			return nil, nil, exhaustedPolicyErr(preferStatusErr(lastStatusErr, lastErr), err)
+			return nil, nil, exhaustedPolicyErr(lastStatusErr, lastErr, err)
 		}
 		resp, payload, done, attemptErr := c.doPolicyAttempt(ctx, attempt, path, body)
 		if done {
@@ -726,11 +738,11 @@ func (c *Client) doPolicyRequest(ctx context.Context, path string, body []byte) 
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			return nil, nil, exhaustedPolicyErr(preferStatusErr(lastStatusErr, lastErr), ctx.Err())
+			return nil, nil, exhaustedPolicyErr(lastStatusErr, lastErr, ctx.Err())
 		case <-timer.C:
 		}
 	}
-	return nil, nil, exhaustedPolicyErr(preferStatusErr(lastStatusErr, lastErr), nil)
+	return nil, nil, exhaustedPolicyErr(lastStatusErr, lastErr, nil)
 }
 
 // preferStatusErr picks the sidecar's own status over a transport failure, so an
@@ -742,23 +754,49 @@ func preferStatusErr(statusErr, lastErr error) error {
 	return lastErr
 }
 
-// exhaustedPolicyErr reports why the ladder ended. The sidecar's own error must
-// survive: context.DeadlineExceeded alone reads as "never replied" and hides
-// whether the sidecar actually returned a status. Both are wrapped so
-// isPolicyDeadlineErr still matches for the degrade path.
-func exhaustedPolicyErr(lastErr, ctxErr error) error {
+// exhaustedPolicyErr reports why the ladder ended: the sidecar's own status when
+// it gave one (the better diagnosis), always carrying whatever deadline or
+// cancel signal the ladder saw anywhere.
+//
+// Both halves are load-bearing. Reporting only the deadline reads as "the
+// sidecar never replied" and hides a status it did return; dropping the deadline
+// to report the status makes isPolicyDeadlineErr miss, which stops the
+// policy-deadline fallback from degrading and hands the caller the very 503 that
+// path exists to avoid. The ladder hits exactly that case when two slow sidecar
+// 503s leave a third attempt for the parent deadline to truncate.
+func exhaustedPolicyErr(statusErr, lastErr, ctxErr error) error {
+	primary := preferStatusErr(statusErr, lastErr)
+	deadline := cancellationSignal(ctxErr, lastErr, statusErr)
 	switch {
-	case lastErr == nil && ctxErr == nil:
+	case primary == nil && deadline == nil:
 		return errors.New("policy sidecar retries exhausted")
-	case lastErr == nil:
-		return fmt.Errorf("policy sidecar retries exhausted: %w", ctxErr)
+	case primary == nil:
+		return fmt.Errorf("policy sidecar retries exhausted: %w", deadline)
 	// errors.Is keeps a transport deadline from being printed twice; the
-	// wrapped sentinel is already reachable through lastErr.
-	case ctxErr == nil || errors.Is(lastErr, ctxErr):
-		return fmt.Errorf("policy sidecar retries exhausted: %w", lastErr)
+	// sentinel is already reachable through primary.
+	case deadline == nil || errors.Is(primary, deadline):
+		return fmt.Errorf("policy sidecar retries exhausted: %w", primary)
 	default:
-		return fmt.Errorf("policy sidecar retries exhausted: %w: %w", lastErr, ctxErr)
+		return fmt.Errorf("policy sidecar retries exhausted: %w: %w", primary, deadline)
 	}
+}
+
+// cancellationSignal returns the first context sentinel reachable from any
+// candidate, so preferring a status error for its diagnosis never costs the
+// caller the deadline it needs to degrade on.
+func cancellationSignal(candidates ...error) error {
+	for _, candidate := range candidates {
+		if candidate == nil {
+			continue
+		}
+		if errors.Is(candidate, context.DeadlineExceeded) {
+			return context.DeadlineExceeded
+		}
+		if errors.Is(candidate, context.Canceled) {
+			return context.Canceled
+		}
+	}
+	return nil
 }
 
 // doPolicyAttempt runs one bounded attempt; returns done=true on a final outcome (success or fatal error).

--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -29,23 +29,17 @@ const (
 )
 
 // Per-attempt bound so a stalled instance cannot consume the whole decision
-// budget and prevent retries. Sized so a second FULL attempt still fits
-// (2 x fraction x timeout + backoff <= timeout). Three full attempts
-// deliberately do not fit; the third covers fast failures — connection refused,
-// an instant 5xx — which return in milliseconds.
-//
-// The bound must also exceed the sidecar's own inference deadline (the HMM
-// sidecar degrades to the session's prior state at 1.5s), or the router cancels
-// a request the sidecar was about to answer and turns a successful degrade into
-// a router-side timeout. 0.4 x 4.5s = 1.8s satisfies both.
+// budget and prevent retries. Sized so a second full attempt still fits
+// (2 x fraction x timeout + backoff <= timeout); three full attempts
+// deliberately do not fit — the third covers fast failures only. The bound must
+// exceed the sidecar's own inference deadline (HMM: 1.5s), or the router
+// cancels a request it was about to answer. 0.4 x 4.5s = 1.8s satisfies both.
 const (
 	defaultAttemptFraction = 0.4
 	minAttemptTimeout      = 500 * time.Millisecond
 	// sidecarInferenceFloor is the smallest per-attempt bound that still
-	// outlives a policy sidecar's own inference deadline. What an attempt has to
-	// survive is that deadline, which does not scale with the router's budget —
-	// so a pure fraction silently drops below it on smaller configured budgets
-	// (0.4 x 3s = 1.2s < 1.5s). Applied only when the budget can afford it.
+	// outlives a policy sidecar's own inference deadline (constant, not
+	// fraction-scaling). Applied only when the budget can afford a retry too.
 	sidecarInferenceFloor = 1800 * time.Millisecond
 )
 
@@ -65,9 +59,7 @@ func DeriveAttemptTimeout(timeout time.Duration) time.Duration {
 		timeout = DefaultTimeout
 	}
 	attemptTimeout := time.Duration(float64(timeout) * defaultAttemptFraction)
-	// A budget too small to seat the floor and still leave a retry keeps the
-	// old leave-room-for-a-retry behaviour rather than spending everything on
-	// attempt 1.
+	// Budgets too small to seat the floor and still leave a retry keep the old behaviour.
 	if attemptTimeout < sidecarInferenceFloor && timeout >= sidecarInferenceFloor+minAttemptTimeout {
 		attemptTimeout = sidecarInferenceFloor
 	}
@@ -754,16 +746,11 @@ func preferStatusErr(statusErr, lastErr error) error {
 	return lastErr
 }
 
-// exhaustedPolicyErr reports why the ladder ended: the sidecar's own status when
-// it gave one (the better diagnosis), always carrying whatever deadline or
-// cancel signal the ladder saw anywhere.
-//
-// Both halves are load-bearing. Reporting only the deadline reads as "the
-// sidecar never replied" and hides a status it did return; dropping the deadline
-// to report the status makes isPolicyDeadlineErr miss, which stops the
-// policy-deadline fallback from degrading and hands the caller the very 503 that
-// path exists to avoid. The ladder hits exactly that case when two slow sidecar
-// 503s leave a third attempt for the parent deadline to truncate.
+// exhaustedPolicyErr reports why the ladder ended. Both the sidecar's status and
+// the deadline are preserved: the status is the sidecar's own diagnosis; the
+// deadline keeps isPolicyDeadlineErr matching so the policy-deadline fallback
+// still degrades instead of handing the caller the 503 that fallback exists to
+// prevent.
 func exhaustedPolicyErr(statusErr, lastErr, ctxErr error) error {
 	primary := preferStatusErr(statusErr, lastErr)
 	deadline := cancellationSignal(ctxErr, lastErr, statusErr)

--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -19,12 +19,8 @@ import (
 )
 
 // DefaultTimeout bounds a single delegated policy decision. It has to hold more
-// than one full attempt or the retry ladder below is decoration: at the old 3s,
-// attempt 1's 1.8s bound plus a backoff left ~1.15s, so attempt 2 was always
-// truncated by the parent deadline and attempt 3 never ran. 4.5s fits two full
-// attempts (1.8 + 0.05 + 1.8 = 3.65s) with the third still available to the
-// fast-failure case (connection refused, an instant 5xx) that returns in
-// milliseconds.
+// than one full attempt: 2x1.8s + a 50ms backoff = 3.65s, so the old 3s starved
+// attempt 2 and left attempt 3 unreachable.
 const DefaultTimeout = 4500 * time.Millisecond
 
 const (
@@ -33,15 +29,15 @@ const (
 )
 
 // Per-attempt bound so a stalled instance cannot consume the whole decision
-// budget and prevent retries. The fraction is deliberately at/below
-// 1/defaultRouteAttempts: above that, attempt 1 can claim more than its share
-// and starve the retries it exists to enable.
+// budget and prevent retries. Sized so a second FULL attempt still fits
+// (2 x fraction x timeout + backoff <= timeout). Three full attempts
+// deliberately do not fit; the third covers fast failures — connection refused,
+// an instant 5xx — which return in milliseconds.
 //
-// The absolute value matters as much as the ratio. A policy sidecar with its
-// own inference deadline answers just inside it (the HMM sidecar degrades to
-// the session's prior state at 1.5s), so an attempt bound below that deadline
-// cancels a request the sidecar was about to answer and converts a successful
-// degrade into a router-side timeout. 0.4 x 4.5s keeps the bound at 1.8s.
+// The bound must also exceed the sidecar's own inference deadline (the HMM
+// sidecar degrades to the session's prior state at 1.5s), or the router cancels
+// a request the sidecar was about to answer and turns a successful degrade into
+// a router-side timeout. 0.4 x 4.5s = 1.8s satisfies both.
 const (
 	defaultAttemptFraction = 0.4
 	minAttemptTimeout      = 500 * time.Millisecond
@@ -708,9 +704,7 @@ func pointerTo[T any](value T) *T {
 }
 
 func (c *Client) doPolicyRequest(ctx context.Context, path string, body []byte) (*http.Response, []byte, error) {
-	// lastErr is the most recent failure; lastStatusErr is the most recent one
-	// the sidecar itself reported. They diverge exactly when the budget runs out
-	// mid-ladder, which is when the diagnosis matters most.
+	// lastStatusErr is the sidecar's own diagnosis; it diverges from lastErr when the budget cuts a final attempt short.
 	var lastErr, lastStatusErr error
 	for attempt := 1; attempt <= defaultRouteAttempts; attempt++ {
 		if err := ctx.Err(); err != nil {
@@ -739,11 +733,8 @@ func (c *Client) doPolicyRequest(ctx context.Context, path string, body []byte) 
 	return nil, nil, exhaustedPolicyErr(preferStatusErr(lastStatusErr, lastErr), nil)
 }
 
-// preferStatusErr picks the sidecar's own status over a transport failure. The
-// final attempt of an exhausted ladder is usually the one the parent deadline
-// truncated, so without this the reported cause is always the budget and never
-// the sidecar — which is how ~390 fail-closed 503s a day were logged as
-// timeouts and the router never once recorded "policy sidecar status 503".
+// preferStatusErr picks the sidecar's own status over a transport failure, so an
+// exhausted ladder surfaces the sidecar's diagnosis and not the budget expiry.
 func preferStatusErr(statusErr, lastErr error) error {
 	if statusErr != nil {
 		return statusErr
@@ -751,14 +742,10 @@ func preferStatusErr(statusErr, lastErr error) error {
 	return lastErr
 }
 
-// exhaustedPolicyErr reports why the ladder ended. The sidecar's own error is
-// the diagnosis and has to survive: when the budget runs out after the sidecar
-// has already answered — its own fail-closed 503, or a 500 — reporting only
-// context.DeadlineExceeded reads as "the sidecar never replied" and hides the
-// real cause. In prod that masked 1,807 requests failing on a sidecar
-// TypeError and ~390/day failing on the sidecar's own 503; neither ever
-// appeared as anything but a timeout. Both errors are wrapped so callers that
-// degrade on the deadline (isPolicyDeadlineErr) still match.
+// exhaustedPolicyErr reports why the ladder ended. The sidecar's own error must
+// survive: context.DeadlineExceeded alone reads as "never replied" and hides
+// whether the sidecar actually returned a status. Both are wrapped so
+// isPolicyDeadlineErr still matches for the degrade path.
 func exhaustedPolicyErr(lastErr, ctxErr error) error {
 	switch {
 	case lastErr == nil && ctxErr == nil:

--- a/internal/policyclient/client_test.go
+++ b/internal/policyclient/client_test.go
@@ -3,6 +3,7 @@ package policyclient
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -632,6 +633,99 @@ func TestDeriveAttemptTimeoutLeavesRoomForRetries(t *testing.T) {
 	// Budgets too small to split still get one usable attempt.
 	assert.Equal(t, 300*time.Millisecond, DeriveAttemptTimeout(300*time.Millisecond))
 	assert.Equal(t, minAttemptTimeout, DeriveAttemptTimeout(700*time.Millisecond))
+}
+
+// TestDefaultBudgetFitsASecondFullAttempt is the arithmetic guard the old
+// constants failed: 3 x 1.8s cannot happen inside 3s, so a sidecar that took
+// its full attempt bound got a truncated attempt 2 and no attempt 3, and the
+// caller was told "context deadline exceeded" for what was really one try.
+func TestDefaultBudgetFitsASecondFullAttempt(t *testing.T) {
+	attemptTimeout := DeriveAttemptTimeout(DefaultTimeout)
+	firstBackoff := time.Duration(1) * routeRetryBackoff
+
+	require.LessOrEqual(t, 2*attemptTimeout+firstBackoff, DefaultTimeout,
+		"two full attempts plus the first backoff must fit in the decision budget")
+	assert.LessOrEqual(t, attemptTimeout, DefaultTimeout/defaultRouteAttempts+attemptTimeout,
+		"the per-attempt bound must not exceed what the ladder can spend")
+
+	// A per-attempt bound below a sidecar's own inference deadline would cancel
+	// a request it was about to answer, turning its degrade path into a
+	// router-side timeout. The HMM sidecar degrades at 1.5s.
+	const knownSidecarInferenceDeadline = 1500 * time.Millisecond
+	assert.Greater(t, attemptTimeout, knownSidecarInferenceDeadline,
+		"an attempt must outlive the sidecar's own deadline so its answer is seen")
+}
+
+// TestRetriesExhaustedKeepsBothTheSidecarErrorAndTheDeadline: a sidecar that
+// fails closed slowly used to surface as a bare "context deadline exceeded",
+// which reads as "never replied". Prod spent ~390 turns a day that way while
+// the sidecar was returning its own 503 every time.
+func TestRetriesExhaustedKeepsBothTheSidecarErrorAndTheDeadline(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
+		// Slower than the attempt bound derived from the tiny budget below, so
+		// the ladder ends on the parent deadline rather than on a clean status.
+		time.Sleep(150 * time.Millisecond)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"error": "hmm inference exceeded its deadline"})
+	}))
+	defer server.Close()
+
+	_, err := New(server.URL, server.Client(), 250*time.Millisecond).Decide(
+		context.Background(),
+		policy.Query{Candidates: []policy.Candidate{{RosterID: "model-a"}}},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "retries exhausted")
+	assert.Contains(t, err.Error(), "hmm inference exceeded its deadline",
+		"the sidecar's own diagnosis must survive the deadline")
+	assert.GreaterOrEqual(t, attempts, 1)
+	assert.ErrorIs(t, err, context.DeadlineExceeded,
+		"the deadline must stay wrapped so the policy-deadline fallback still degrades")
+}
+
+// TestExhaustedPolicyErrShapes pins the three ways the ladder can end.
+func TestExhaustedPolicyErrShapes(t *testing.T) {
+	sidecarErr := &PolicyStatusError{Status: http.StatusServiceUnavailable, Message: "fail closed"}
+
+	both := exhaustedPolicyErr(sidecarErr, context.DeadlineExceeded)
+	assert.ErrorIs(t, both, context.DeadlineExceeded)
+	assert.Contains(t, both.Error(), "fail closed")
+
+	onlySidecar := exhaustedPolicyErr(sidecarErr, nil)
+	assert.NotErrorIs(t, onlySidecar, context.DeadlineExceeded)
+	assert.Contains(t, onlySidecar.Error(), "fail closed")
+
+	onlyDeadline := exhaustedPolicyErr(nil, context.DeadlineExceeded)
+	assert.ErrorIs(t, onlyDeadline, context.DeadlineExceeded)
+	assert.Contains(t, onlyDeadline.Error(), "retries exhausted")
+
+	// A transport deadline is not printed twice: the sentinel is already
+	// reachable through the wrapped attempt error.
+	transportErr := fmt.Errorf("call policy sidecar: %w", context.DeadlineExceeded)
+	deduped := exhaustedPolicyErr(transportErr, context.DeadlineExceeded)
+	assert.ErrorIs(t, deduped, context.DeadlineExceeded)
+	assert.Equal(t, 1, strings.Count(deduped.Error(), context.DeadlineExceeded.Error()))
+}
+
+// TestExhaustedLadderPrefersTheSidecarStatusOverATruncatedAttempt: the last
+// attempt of an exhausted ladder is usually the one the budget truncated, so
+// the earlier status — the sidecar's actual diagnosis — must be what surfaces.
+func TestExhaustedLadderPrefersTheSidecarStatusOverATruncatedAttempt(t *testing.T) {
+	statusErr := &PolicyStatusError{Status: http.StatusServiceUnavailable, Message: "hmm inference exceeded its deadline"}
+	truncated := fmt.Errorf("call policy sidecar: %w", context.DeadlineExceeded)
+
+	assert.Same(t, statusErr, preferStatusErr(statusErr, truncated),
+		"a sidecar status outranks a later truncated attempt")
+	assert.Same(t, truncated, preferStatusErr(nil, truncated),
+		"with no status seen, the transport error is all there is")
+
+	surfaced := exhaustedPolicyErr(preferStatusErr(statusErr, truncated), context.DeadlineExceeded)
+	assert.Contains(t, surfaced.Error(), "hmm inference exceeded its deadline")
+	assert.ErrorIs(t, surfaced, context.DeadlineExceeded,
+		"the policy-deadline fallback must still recognise this as degradable")
 }
 
 func TestClientCapabilities(t *testing.T) {

--- a/internal/policyclient/client_test.go
+++ b/internal/policyclient/client_test.go
@@ -649,6 +649,19 @@ func TestDefaultBudgetFitsASecondFullAttempt(t *testing.T) {
 	const knownSidecarInferenceDeadline = 1500 * time.Millisecond
 	assert.Greater(t, attemptTimeout, knownSidecarInferenceDeadline,
 		"an attempt must outlive the sidecar's own deadline so its answer is seen")
+
+	// The floor is what holds that guarantee for explicitly-configured budgets:
+	// the fraction alone gives 0.4 x 3s = 1.2s, under the sidecar's deadline, so
+	// a deployment setting ROUTER_*_SIDECAR_TIMEOUT_MS=3000 would cancel
+	// degrades it used to wait for.
+	assert.Greater(t, DeriveAttemptTimeout(3*time.Second), knownSidecarInferenceDeadline,
+		"a 3s configured budget must still outlive the sidecar deadline")
+	assert.Equal(t, sidecarInferenceFloor, DeriveAttemptTimeout(3*time.Second))
+
+	// Budgets too small to seat the floor and still leave a retry keep the old
+	// behaviour rather than spending everything on attempt 1.
+	assert.Equal(t, minAttemptTimeout, DeriveAttemptTimeout(700*time.Millisecond))
+	assert.Equal(t, 300*time.Millisecond, DeriveAttemptTimeout(300*time.Millisecond))
 }
 
 // TestRetriesExhaustedKeepsBothTheSidecarErrorAndTheDeadline: a sidecar 503 must
@@ -679,28 +692,52 @@ func TestRetriesExhaustedKeepsBothTheSidecarErrorAndTheDeadline(t *testing.T) {
 		"the deadline must stay wrapped so the policy-deadline fallback still degrades")
 }
 
-// TestExhaustedPolicyErrShapes pins the three ways the ladder can end.
+// TestExhaustedPolicyErrShapes pins every way the ladder can end.
 func TestExhaustedPolicyErrShapes(t *testing.T) {
 	sidecarErr := &PolicyStatusError{Status: http.StatusServiceUnavailable, Message: "fail closed"}
 
-	both := exhaustedPolicyErr(sidecarErr, context.DeadlineExceeded)
+	both := exhaustedPolicyErr(sidecarErr, nil, context.DeadlineExceeded)
 	assert.ErrorIs(t, both, context.DeadlineExceeded)
 	assert.Contains(t, both.Error(), "fail closed")
 
-	onlySidecar := exhaustedPolicyErr(sidecarErr, nil)
-	assert.NotErrorIs(t, onlySidecar, context.DeadlineExceeded)
+	onlySidecar := exhaustedPolicyErr(sidecarErr, nil, nil)
+	assert.NotErrorIs(t, onlySidecar, context.DeadlineExceeded,
+		"with no deadline anywhere, none should be invented")
 	assert.Contains(t, onlySidecar.Error(), "fail closed")
 
-	onlyDeadline := exhaustedPolicyErr(nil, context.DeadlineExceeded)
+	onlyDeadline := exhaustedPolicyErr(nil, nil, context.DeadlineExceeded)
 	assert.ErrorIs(t, onlyDeadline, context.DeadlineExceeded)
 	assert.Contains(t, onlyDeadline.Error(), "retries exhausted")
 
 	// A transport deadline is not printed twice: the sentinel is already
 	// reachable through the wrapped attempt error.
 	transportErr := fmt.Errorf("call policy sidecar: %w", context.DeadlineExceeded)
-	deduped := exhaustedPolicyErr(transportErr, context.DeadlineExceeded)
+	deduped := exhaustedPolicyErr(nil, transportErr, context.DeadlineExceeded)
 	assert.ErrorIs(t, deduped, context.DeadlineExceeded)
 	assert.Equal(t, 1, strings.Count(deduped.Error(), context.DeadlineExceeded.Error()))
+
+	cancelled := exhaustedPolicyErr(nil, fmt.Errorf("call policy sidecar: %w", context.Canceled), nil)
+	assert.ErrorIs(t, cancelled, context.Canceled)
+}
+
+// TestExhaustedLadderKeepsTheDeadlineWhenPreferringAStatus is the regression
+// guard for the case the ladder actually hits: two slow sidecar 503s, then a
+// third attempt the parent deadline truncates. The status is the better
+// diagnosis, but discarding the truncated attempt's deadline would make
+// isPolicyDeadlineErr miss and stop the policy-deadline fallback from degrading —
+// turning this into the user-facing 503 the fallback exists to prevent.
+func TestExhaustedLadderKeepsTheDeadlineWhenPreferringAStatus(t *testing.T) {
+	statusErr := &PolicyStatusError{Status: http.StatusServiceUnavailable, Message: "hmm inference exceeded its deadline"}
+	truncated := fmt.Errorf("call policy sidecar: %w", context.DeadlineExceeded)
+
+	// ctxErr is nil: the loop exhausted its attempts rather than tripping
+	// ctx.Done(), which is exactly where the deadline used to be dropped.
+	err := exhaustedPolicyErr(statusErr, truncated, nil)
+
+	assert.Contains(t, err.Error(), "hmm inference exceeded its deadline",
+		"the sidecar's diagnosis must still surface")
+	assert.ErrorIs(t, err, context.DeadlineExceeded,
+		"the deadline must survive so the policy-deadline fallback degrades")
 }
 
 // TestExhaustedLadderPrefersTheSidecarStatusOverATruncatedAttempt: the last
@@ -715,7 +752,7 @@ func TestExhaustedLadderPrefersTheSidecarStatusOverATruncatedAttempt(t *testing.
 	assert.Same(t, truncated, preferStatusErr(nil, truncated),
 		"with no status seen, the transport error is all there is")
 
-	surfaced := exhaustedPolicyErr(preferStatusErr(statusErr, truncated), context.DeadlineExceeded)
+	surfaced := exhaustedPolicyErr(statusErr, truncated, context.DeadlineExceeded)
 	assert.Contains(t, surfaced.Error(), "hmm inference exceeded its deadline")
 	assert.ErrorIs(t, surfaced, context.DeadlineExceeded,
 		"the policy-deadline fallback must still recognise this as degradable")

--- a/internal/policyclient/client_test.go
+++ b/internal/policyclient/client_test.go
@@ -649,10 +649,8 @@ func TestDefaultBudgetFitsASecondFullAttempt(t *testing.T) {
 	assert.Greater(t, attemptTimeout, knownSidecarInferenceDeadline,
 		"an attempt must outlive the sidecar's own deadline so its answer is seen")
 
-	// The floor is what holds that guarantee for explicitly-configured budgets:
-	// the fraction alone gives 0.4 x 3s = 1.2s, under the sidecar's deadline, so
-	// a deployment setting ROUTER_*_SIDECAR_TIMEOUT_MS=3000 would cancel
-	// degrades it used to wait for.
+	// The floor holds this for smaller configured budgets: 0.4 x 3s = 1.2s < 1.5s,
+	// so a deployment using ROUTER_*_SIDECAR_TIMEOUT_MS=3000 would cancel degrades.
 	assert.Greater(t, DeriveAttemptTimeout(3*time.Second), knownSidecarInferenceDeadline,
 		"a 3s configured budget must still outlive the sidecar deadline")
 	assert.Equal(t, sidecarInferenceFloor, DeriveAttemptTimeout(3*time.Second))
@@ -720,11 +718,8 @@ func TestExhaustedPolicyErrShapes(t *testing.T) {
 }
 
 // TestExhaustedLadderKeepsTheDeadlineWhenPreferringAStatus is the regression
-// guard for the case the ladder actually hits: two slow sidecar 503s, then a
-// third attempt the parent deadline truncates. The status is the better
-// diagnosis, but discarding the truncated attempt's deadline would make
-// isPolicyDeadlineErr miss and stop the policy-deadline fallback from degrading —
-// turning this into the user-facing 503 the fallback exists to prevent.
+// guard: preferring the status over a truncated final attempt must not drop the
+// deadline, or isPolicyDeadlineErr misses and the fallback fails to degrade.
 func TestExhaustedLadderKeepsTheDeadlineWhenPreferringAStatus(t *testing.T) {
 	statusErr := &PolicyStatusError{Status: http.StatusServiceUnavailable, Message: "hmm inference exceeded its deadline"}
 	truncated := fmt.Errorf("call policy sidecar: %w", context.DeadlineExceeded)

--- a/internal/policyclient/client_test.go
+++ b/internal/policyclient/client_test.go
@@ -635,19 +635,14 @@ func TestDeriveAttemptTimeoutLeavesRoomForRetries(t *testing.T) {
 	assert.Equal(t, minAttemptTimeout, DeriveAttemptTimeout(700*time.Millisecond))
 }
 
-// TestDefaultBudgetFitsASecondFullAttempt is the arithmetic guard the old
-// constants failed: 3 x 1.8s cannot happen inside 3s, so a sidecar that took
-// its full attempt bound got a truncated attempt 2 and no attempt 3, and the
-// caller was told "context deadline exceeded" for what was really one try.
+// TestDefaultBudgetFitsASecondFullAttempt guards that two full attempts plus
+// backoff fit in DefaultTimeout, and that the bound outlives the sidecar's own deadline.
 func TestDefaultBudgetFitsASecondFullAttempt(t *testing.T) {
 	attemptTimeout := DeriveAttemptTimeout(DefaultTimeout)
 	firstBackoff := time.Duration(1) * routeRetryBackoff
 
 	require.LessOrEqual(t, 2*attemptTimeout+firstBackoff, DefaultTimeout,
 		"two full attempts plus the first backoff must fit in the decision budget")
-	assert.LessOrEqual(t, attemptTimeout, DefaultTimeout/defaultRouteAttempts+attemptTimeout,
-		"the per-attempt bound must not exceed what the ladder can spend")
-
 	// A per-attempt bound below a sidecar's own inference deadline would cancel
 	// a request it was about to answer, turning its degrade path into a
 	// router-side timeout. The HMM sidecar degrades at 1.5s.
@@ -656,10 +651,8 @@ func TestDefaultBudgetFitsASecondFullAttempt(t *testing.T) {
 		"an attempt must outlive the sidecar's own deadline so its answer is seen")
 }
 
-// TestRetriesExhaustedKeepsBothTheSidecarErrorAndTheDeadline: a sidecar that
-// fails closed slowly used to surface as a bare "context deadline exceeded",
-// which reads as "never replied". Prod spent ~390 turns a day that way while
-// the sidecar was returning its own 503 every time.
+// TestRetriesExhaustedKeepsBothTheSidecarErrorAndTheDeadline: a sidecar 503 must
+// survive alongside the deadline so the policy-deadline fallback still degrades.
 func TestRetriesExhaustedKeepsBothTheSidecarErrorAndTheDeadline(t *testing.T) {
 	attempts := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/policyclient/client_test.go
+++ b/internal/policyclient/client_test.go
@@ -643,9 +643,8 @@ func TestDefaultBudgetFitsASecondFullAttempt(t *testing.T) {
 
 	require.LessOrEqual(t, 2*attemptTimeout+firstBackoff, DefaultTimeout,
 		"two full attempts plus the first backoff must fit in the decision budget")
-	// A per-attempt bound below a sidecar's own inference deadline would cancel
-	// a request it was about to answer, turning its degrade path into a
-	// router-side timeout. The HMM sidecar degrades at 1.5s.
+	// An attempt bound under the sidecar's own deadline (HMM: 1.5s) cancels a
+	// request it was about to answer, turning a degrade into a router-side timeout.
 	const knownSidecarInferenceDeadline = 1500 * time.Millisecond
 	assert.Greater(t, attemptTimeout, knownSidecarInferenceDeadline,
 		"an attempt must outlive the sidecar's own deadline so its answer is seen")
@@ -740,9 +739,8 @@ func TestExhaustedLadderKeepsTheDeadlineWhenPreferringAStatus(t *testing.T) {
 		"the deadline must survive so the policy-deadline fallback degrades")
 }
 
-// TestExhaustedLadderPrefersTheSidecarStatusOverATruncatedAttempt: the last
-// attempt of an exhausted ladder is usually the one the budget truncated, so
-// the earlier status — the sidecar's actual diagnosis — must be what surfaces.
+// TestExhaustedLadderPrefersTheSidecarStatusOverATruncatedAttempt: the earlier
+// sidecar status must surface over a budget-truncated final attempt.
 func TestExhaustedLadderPrefersTheSidecarStatusOverATruncatedAttempt(t *testing.T) {
 	statusErr := &PolicyStatusError{Status: http.StatusServiceUnavailable, Message: "hmm inference exceeded its deadline"}
 	truncated := fmt.Errorf("call policy sidecar: %w", context.DeadlineExceeded)


### PR DESCRIPTION
> Standalone: diff is `internal/policyclient/` only, based on `main`.

Two defects in the policy-sidecar retry ladder. Together they made HMM routing failures both more likely *and* much harder to diagnose. Found while investigating a separate Gemini tool-schema bug (that half is covered by #986 / #980; this PR is the independent policy-sidecar half).

## 1. The three-attempt ladder could not fit in its own budget

`DefaultTimeout` was 3s and `defaultAttemptFraction` 0.6, so the per-attempt bound was 1.8s. Attempt 1 plus a 50ms backoff left ~1.15s, so **attempt 2 was always truncated by the parent deadline and attempt 3 never ran**. Three advertised attempts delivered less than two.

That matters specifically here: the HMM sidecar deliberately does *not* cancel an overrun inference (`_keep_warming`) so it can warm its embedding cache and last-readout store. The retry is the thing that turns a slow first attempt into a served turn — and it was the attempt that never happened.

- The budget is 4.5s, so two full attempts plus the backoff genuinely fit (1.8 + 0.05 + 1.8 = 3.65s), with the third still available to the fast-failure case (connection refused, an instant 5xx) that returns in milliseconds. Three *full* attempts deliberately do not fit.
- **The absolute per-attempt bound is unchanged at 1.8s**, deliberately. It has to stay above the sidecar's own 1.5s inference deadline, or the router cancels a request the sidecar was about to answer and converts its *successful degrade* into a router-side timeout.
- That floor is enforced absolutely (`sidecarInferenceFloor`), not left to the fraction. Review caught that `0.4 x 3s = 1.2s` would drop **under** the sidecar deadline for any deployment explicitly configuring a ~3s budget — a regression against the 0.6 fraction it replaced. Small budgets that cannot seat the floor and still leave a retry keep their existing behaviour.

`TestDefaultBudgetFitsASecondFullAttempt` pins all of it; the two surviving assertions constrain the fraction to `(0.333, 0.494]` — 0.3 fails the deadline floor, 0.5 fails the two-attempt ceiling.

The pre-existing `TestDeriveAttemptTimeoutLeavesRoomForRetries` assertions are unchanged and still pass — only the total grew.

## 2. A sidecar's own error was overwritten by the budget running out

Both `ctx.Err()` return paths discarded the last attempt error entirely. And even when it was kept, the final attempt of an exhausted ladder is usually the one the deadline truncated, so its transport error masked the earlier status.

In prod this meant:

- 1,807 requests failing on a sidecar `TypeError` (`embed_texts_uncached() got an unexpected keyword argument 'vertex_persist_client'`), and
- ~390/day failing on the sidecar's own fail-closed 503 (`InferenceDeadlineExceeded`),

were **all** reported as `retries exhausted: context deadline exceeded`. The router logged `policy sidecar status 503` **zero** times across two days while the sidecar emitted hundreds a day. That is why diagnosing this took log archaeology on the sidecar rather than a look at the router's own error.

Now:

- Sidecar statuses are a typed `PolicyStatusError`.
- The ladder keeps the most *informative* failure (`preferStatusErr`) rather than the most recent.
- `exhaustedPolicyErr` wraps both the sidecar error and the deadline, and skips the deadline when the attempt error already wraps it (no more `context deadline exceeded: context deadline exceeded`).
- **`errors.Is(err, context.DeadlineExceeded)` still holds**, so `isPolicyDeadlineErr` keeps matching and the policy-deadline fallback still degrades. Verified by test — this is load-bearing for workweave/WorkWeave's companion terraform PR that turns that fallback on.

## Review fixes folded in

- **Deadline dropped on ladder exhaustion (Cursor, High).** When the loop ran out of attempts rather than tripping `ctx.Done()`, preferring the earlier status discarded the truncated final attempt's `context.DeadlineExceeded` — so `isPolicyDeadlineErr` missed and the fallback refused to degrade, producing the exact 503 it exists to prevent, on the ladder's most likely path. `exhaustedPolicyErr` now takes `(statusErr, lastErr, ctxErr)` and lifts the sentinel from wherever it appears.
- **Tautological assertion (greptile P2 / Cursor Low).** `attemptTimeout <= DefaultTimeout/attempts + attemptTimeout` holds for every non-negative budget. Removed; chasing it also revealed the "fraction at/below 1/attempts" claim was simply false (0.4 > 1/3), now corrected.
- Comment-length nits applied; incident numbers live here rather than in godoc.

## Tests

`TestDefaultBudgetFitsASecondFullAttempt`, `TestRetriesExhaustedKeepsBothTheSidecarErrorAndTheDeadline` (a slow 503 whose diagnosis must survive), `TestExhaustedPolicyErrShapes` (all three ladder endings + no duplicated sentinel), `TestExhaustedLadderPrefersTheSidecarStatusOverATruncatedAttempt`.

## Validation

`wv mr tc`, `wv mr t` (full suite), `go vet ./...` — all clean.

## Not in this PR

The remaining causes of the underlying slowness, in leverage order: the per-process `LastReadoutStore` with no session affinity (which is why ~390/day fail closed instead of degrading), the Vertex embedding tail itself (p99 1,457ms against a 1,500ms deadline), and alerting — none of it exists today.

🤖 Generated with [Weave Router](https://router.workweave.ai)

