### PR TITLE
fix(translate): Responses API custom_tool_call items must carry ctc_ id prefix

### DIFF
--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -471,11 +471,9 @@ func newResponsesID(prefix string) string {
 	return prefix + "_" + strconv.FormatUint(responsesIDCounter.Add(1), 36) + strconv.FormatInt(time.Now().UnixNano()&0xffffff, 36)
 }
 
-// toolCallItemIDPrefix picks the Responses API item-id prefix a strict
-// consumer requires for the item's wire type: "ctc" for custom_tool_call,
-// "fc" for function_call. A client that stores the item and replays it next
-// turn (Codex) round-trips whichever prefix we mint, so getting this wrong
-// only surfaces as a 400 on the following turn.
+// toolCallItemIDPrefix returns "ctc" for custom_tool_call and "fc" for
+// function_call. A strict Responses client (e.g. Codex) replays the id on
+// the next turn, so a wrong prefix causes a 400 there.
 func toolCallItemIDPrefix(custom bool) string {
 	if custom {
 		return "ctc"
@@ -1195,9 +1193,8 @@ func (t *ResponsesWriter) appendToolCall(idx int, tc gjson.Result) error {
 			item.name = entry.Name
 		}
 		// Buffer nameless chunks; the mapping decides function_call vs
-		// custom_tool_call only once the name arrives from a later delta. The
-		// item ID is minted alongside emitFunctionCallItemAdded below, once
-		// mapping.Custom is settled, so it gets the matching ctc_/fc_ prefix.
+		// custom_tool_call only once the name arrives from a later delta;
+		// mint itemID here so mapping.Custom is settled and gets ctc_/fc_.
 		if len(t.toolMappings) == 0 || item.name != "" {
 			item.itemID = newResponsesID(toolCallItemIDPrefix(item.mapping.Custom))
 			if err := t.emitFunctionCallItemAdded(item); err != nil {

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -1193,8 +1193,7 @@ func (t *ResponsesWriter) appendToolCall(idx int, tc gjson.Result) error {
 			item.name = entry.Name
 		}
 		// Buffer nameless chunks; the mapping decides function_call vs
-		// custom_tool_call only once the name arrives from a later delta;
-		// mint itemID here so mapping.Custom is settled and gets ctc_/fc_.
+		// custom_tool_call only once the name arrives from a later delta.
 		if len(t.toolMappings) == 0 || item.name != "" {
 			item.itemID = newResponsesID(toolCallItemIDPrefix(item.mapping.Custom))
 			if err := t.emitFunctionCallItemAdded(item); err != nil {

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -471,9 +471,9 @@ func newResponsesID(prefix string) string {
 	return prefix + "_" + strconv.FormatUint(responsesIDCounter.Add(1), 36) + strconv.FormatInt(time.Now().UnixNano()&0xffffff, 36)
 }
 
-// toolCallItemIDPrefix returns "ctc" for custom_tool_call and "fc" for
-// function_call. A strict Responses client (e.g. Codex) replays the id on
-// the next turn, so a wrong prefix causes a 400 there.
+// toolCallItemIDPrefix returns the id prefix required by a strict Responses
+// client (e.g. Codex): ctc_ for custom_tool_call, fc_ for function_call;
+// wrong prefix causes a 400 on the next turn when the client replays the id.
 func toolCallItemIDPrefix(custom bool) string {
 	if custom {
 		return "ctc"

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -471,6 +471,18 @@ func newResponsesID(prefix string) string {
 	return prefix + "_" + strconv.FormatUint(responsesIDCounter.Add(1), 36) + strconv.FormatInt(time.Now().UnixNano()&0xffffff, 36)
 }
 
+// toolCallItemIDPrefix picks the Responses API item-id prefix a strict
+// consumer requires for the item's wire type: "ctc" for custom_tool_call,
+// "fc" for function_call. A client that stores the item and replays it next
+// turn (Codex) round-trips whichever prefix we mint, so getting this wrong
+// only surfaces as a 400 on the following turn.
+func toolCallItemIDPrefix(custom bool) string {
+	if custom {
+		return "ctc"
+	}
+	return "fc"
+}
+
 // NewResponsesWriter wraps w so chat-completions output is re-emitted as
 // Responses API events.
 func NewResponsesWriter(w http.ResponseWriter, model string) *ResponsesWriter {
@@ -1173,7 +1185,6 @@ func (t *ResponsesWriter) appendToolCall(idx int, tc gjson.Result) error {
 			mapping = mapped
 		}
 		item = &responsesToolItem{
-			itemID:  newResponsesID("fc"),
 			mapping: mapping,
 		}
 		t.toolItems[idx] = item
@@ -1184,8 +1195,11 @@ func (t *ResponsesWriter) appendToolCall(idx int, tc gjson.Result) error {
 			item.name = entry.Name
 		}
 		// Buffer nameless chunks; the mapping decides function_call vs
-		// custom_tool_call only once the name arrives from a later delta.
+		// custom_tool_call only once the name arrives from a later delta. The
+		// item ID is minted alongside emitFunctionCallItemAdded below, once
+		// mapping.Custom is settled, so it gets the matching ctc_/fc_ prefix.
 		if len(t.toolMappings) == 0 || item.name != "" {
+			item.itemID = newResponsesID(toolCallItemIDPrefix(item.mapping.Custom))
 			if err := t.emitFunctionCallItemAdded(item); err != nil {
 				return err
 			}
@@ -1204,6 +1218,7 @@ func (t *ResponsesWriter) appendToolCall(idx int, tc gjson.Result) error {
 		}
 	}
 	if !item.opened && item.name != "" {
+		item.itemID = newResponsesID(toolCallItemIDPrefix(item.mapping.Custom))
 		if err := t.emitFunctionCallItemAdded(item); err != nil {
 			return err
 		}
@@ -1676,7 +1691,7 @@ func chatCompletionToResponse(body []byte, responseID, model string, createdAt i
 				mapping = ResponsesToolMapping{Name: alias}
 			}
 			item := map[string]any{
-				"id":      newResponsesID("fc"),
+				"id":      newResponsesID(toolCallItemIDPrefix(mapping.Custom)),
 				"status":  "completed",
 				"call_id": tc.Get("id").Str,
 				"name":    mapping.Name,

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -471,8 +471,7 @@ func newResponsesID(prefix string) string {
 	return prefix + "_" + strconv.FormatUint(responsesIDCounter.Add(1), 36) + strconv.FormatInt(time.Now().UnixNano()&0xffffff, 36)
 }
 
-// toolCallItemIDPrefix returns the id prefix required by a strict Responses
-// client (e.g. Codex): ctc_ for custom_tool_call, fc_ for function_call;
+// toolCallItemIDPrefix returns ctc_ for custom_tool_call, fc_ for function_call;
 // wrong prefix causes a 400 on the next turn when the client replays the id.
 func toolCallItemIDPrefix(custom bool) string {
 	if custom {

--- a/internal/translate/responses_codex_egress_test.go
+++ b/internal/translate/responses_codex_egress_test.go
@@ -3,6 +3,7 @@ package translate_test
 import (
 	"encoding/json"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"workweave/router/internal/translate"
@@ -63,9 +64,14 @@ func TestResponsesWriter_RestoresCodexCustomToolFromSplitChatArguments(t *testin
 	assert.Equal(t, "exec", item["name"])
 	assert.Equal(t, "call_exec", item["call_id"])
 	assert.Equal(t, "const x = 1;", item["input"])
+	// A custom_tool_call item's own id must carry the ctc_ prefix the
+	// Responses API requires for this type, not fc_ (reserved for
+	// function_call) — Codex stores and replays this id next turn.
+	assert.Truef(t, strings.HasPrefix(item["id"].(string), "ctc_"), "custom_tool_call id %q must start with ctc_", item["id"])
 	output := completed["response"].(map[string]any)["output"].([]any)
 	assert.Equal(t, "custom_tool_call", output[0].(map[string]any)["type"])
 	assert.Equal(t, "const x = 1;", output[0].(map[string]any)["input"])
+	assert.Truef(t, strings.HasPrefix(output[0].(map[string]any)["id"].(string), "ctc_"), "response.completed custom_tool_call id %q must start with ctc_", output[0].(map[string]any)["id"])
 }
 
 func TestResponsesWriter_RestoresCodexFunctionNamespace(t *testing.T) {
@@ -94,6 +100,7 @@ func TestResponsesWriter_RestoresCodexFunctionNamespace(t *testing.T) {
 		assert.Equal(t, "send_message", item["name"])
 		assert.Equal(t, "collaboration", item["namespace"])
 		assert.JSONEq(t, `{"target":"/root"}`, item["arguments"].(string))
+		assert.Truef(t, strings.HasPrefix(item["id"].(string), "fc_"), "function_call id %q must start with fc_", item["id"])
 		return
 	}
 	t.Fatal("missing namespaced function_call output item")
@@ -128,6 +135,7 @@ func TestResponsesWriter_NonStreamingRestoresCodexCustomTool(t *testing.T) {
 	assert.Equal(t, "custom_tool_call", output[0].(map[string]any)["type"])
 	assert.Equal(t, "exec", output[0].(map[string]any)["name"])
 	assert.Equal(t, "return 1;", output[0].(map[string]any)["input"])
+	assert.Truef(t, strings.HasPrefix(output[0].(map[string]any)["id"].(string), "ctc_"), "non-streaming custom_tool_call id %q must start with ctc_", output[0].(map[string]any)["id"])
 }
 
 func TestResponsesWriter_RejectsMalformedCodexCustomWrapperAndTerminatesFailed(t *testing.T) {
@@ -181,6 +189,10 @@ func TestResponsesWriter_PortableCodexBuffersUntilLateCustomToolName(t *testing.
 		item := event["item"].(map[string]any)
 		assert.NotEmpty(t, item["name"])
 		assert.Equal(t, "custom_tool_call", item["type"])
+		// The item is created on the first (nameless) delta, before
+		// mapping.Custom is knowable from tool_call name alone here — the id
+		// must still land on ctc_, minted once the name arrives.
+		assert.Truef(t, strings.HasPrefix(item["id"].(string), "ctc_"), "late-named custom_tool_call id %q must start with ctc_", item["id"])
 		customAdded = customAdded || event["type"] == "response.output_item.added"
 		customDone = customDone || event["type"] == "response.output_item.done"
 		if event["type"] == "response.output_item.done" {

--- a/internal/translate/responses_codex_egress_test.go
+++ b/internal/translate/responses_codex_egress_test.go
@@ -64,9 +64,7 @@ func TestResponsesWriter_RestoresCodexCustomToolFromSplitChatArguments(t *testin
 	assert.Equal(t, "exec", item["name"])
 	assert.Equal(t, "call_exec", item["call_id"])
 	assert.Equal(t, "const x = 1;", item["input"])
-	// A custom_tool_call item's own id must carry the ctc_ prefix the
-	// Responses API requires for this type, not fc_ (reserved for
-	// function_call) — Codex stores and replays this id next turn.
+	// ctc_ required for custom_tool_call; Codex replays this id next turn.
 	assert.Truef(t, strings.HasPrefix(item["id"].(string), "ctc_"), "custom_tool_call id %q must start with ctc_", item["id"])
 	output := completed["response"].(map[string]any)["output"].([]any)
 	assert.Equal(t, "custom_tool_call", output[0].(map[string]any)["type"])
@@ -189,9 +187,7 @@ func TestResponsesWriter_PortableCodexBuffersUntilLateCustomToolName(t *testing.
 		item := event["item"].(map[string]any)
 		assert.NotEmpty(t, item["name"])
 		assert.Equal(t, "custom_tool_call", item["type"])
-		// The item is created on the first (nameless) delta, before
-		// mapping.Custom is knowable from tool_call name alone here — the id
-		// must still land on ctc_, minted once the name arrives.
+		// id must be ctc_ even though name (and thus mapping.Custom) arrives late.
 		assert.Truef(t, strings.HasPrefix(item["id"].(string), "ctc_"), "late-named custom_tool_call id %q must start with ctc_", item["id"])
 		customAdded = customAdded || event["type"] == "response.output_item.added"
 		customDone = customDone || event["type"] == "response.output_item.done"


### PR DESCRIPTION
## What

The Chat Completions → Responses re-emit path was minting every tool-call
item id with the **`fc_`** prefix via `newResponsesID("fc")`, regardless of
whether the underlying tool resolved to `function_call` or `custom_tool_call`.

A strict Responses consumer (the real OpenAI `/v1/responses` backend, and any
strict client such as Codex CLI ≥ 0.47) rejects `custom_tool_call` items
whose id does not begin with `ctc_` — required on round-trip because the
client (Codex) stores the returned item and replays it as input on the next
turn.

**Symptom:** HTTP `400 Invalid input[N].id: fc_99i35o. Expected an ID that
begins with ctc` on turn 2 once a mid-session model switch routes the
previous turn's stored item against an OpenAI reasoning model (e.g. on
`deepseek-v4-flash → openai/gpt-5.x` switches).

## How

Two sites in `internal/translate/responses.go`:

- **`ResponsesWriter.appendToolCall` (streaming):** the
  `ResponsesToolMapping.Custom` flag isn't always knowable on the very
  first upstream delta (the existing comment at the use site already calls
  this out — nameless first delta is buffered until the function name
  arrives). Defer `itemID` minting from the struct init to the two
  subsequent open points (immediate-open when name is known, late-name
  open when it arrives in a later delta). Both call
  `newResponsesID(toolCallItemIDPrefix(item.mapping.Custom))` so the id
  carries `ctc_` for `custom_tool_call` and `fc_` for `function_call`.
- **`chatCompletionToResponse` (non-streaming JSON):** `mapping.Custom` is
  already known at id mint time, so a one-line prefix swap.

A small helper `toolCallItemIDPrefix(custom bool) string` documents the
id-prefix ↔ wire-type contract in one place.

## What is **not** touched

- **Anthropic ingress** (`emit_openai_responses.go` `writeResponsesInputFromAnthropic`):
  hardcodes `"type": "function_call"" for replayed history and never emits
  `custom_tool_call`. Anthropic has no custom-tool concept, so this path is
  unaffected and requires no change.
- **Legacy default** (no Codex mappings, `Custom=false`) continues to mint
  `fc_`.

## Tests

Existing tests extended with `strings.HasPrefix(...,"ctc_"/"fc_")` assertions
locking the prefix contract in:

- `TestResponsesWriter_RestoresCodexCustomToolFromSplitChatArguments`
  — streaming custom_tool_call (ctc_)
- `TestResponsesWriter_PortableCodexBuffersUntilLateCustomToolName`
  — streaming custom_tool_call with name arriving late (ctc_)
  — exercises the deferred mint path
- `TestResponsesWriter_NonStreamingRestoresCodexCustomTool`
  — non-streaming custom_tool_call (ctc_)
- `TestResponsesWriter_RestoresCodexFunctionNamespace`
  — streaming function_call (fc_)

Test output:
```
ok  workweave/router/internal/translate  0.222s
```

## Validation

- `go vet ./...` — clean
- `gofmt -l` — clean on changed files
- `go build ./...` — clean
- `go test -count=1 ./...` — full router suite passes (no failures)
