### PR TITLE
fix(pi-router): honor served context and resume compaction

### DIFF
--- a/install/npm/package.json
+++ b/install/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workweave/router",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "One-command installer that points Claude Code, Codex, opencode, or pi at the Weave Router. For pi it also ships the routing extension, loaded via pi.extensions.",
   "bin": {
     "weave-router": "bin.js",

--- a/install/pi-router/README.md
+++ b/install/pi-router/README.md
@@ -32,11 +32,11 @@ from npm on next start and loads this extension via its `pi.extensions` field.
   router validates and canonicalizes the requested model.
 - **Per-process routing bias.** Static `x-weave-routing-*` knob headers bias the
   router: quality on the main loop and speed + cheap on subagents.
-- **Long tool-loop compaction.** Pi 0.74 can cross its context threshold inside
-  an uninterrupted tool loop before its normal post-run compaction check. The
-  extension preserves a usable output budget for the real continuation and
-  compacts once the loop settles, while leaving ordinary threshold compaction
-  to Pi.
+- **Long tool-loop compaction.** Pi can cross its context threshold inside an
+  uninterrupted tool loop before its normal post-run compaction check. The
+  extension preserves a usable output budget for the real continuation,
+  compacts once the loop settles, and resumes that extension-owned tool loop.
+  Ordinary Pi threshold compaction remains under Pi's control.
 - **Sticky sessions.** `metadata.user_id = "pi:<sessionId>"` pins the main loop
   to one model for the session; subagents get their own pins.
 - **`dispatch` tool — parallel, context-isolated subagents.** pi has none

--- a/install/pi-router/src/compaction.ts
+++ b/install/pi-router/src/compaction.ts
@@ -171,7 +171,12 @@ export function registerCompaction(pi: ExtensionAPI, schedule: Schedule = (callb
 					// Pi only auto-retries an overflow compaction. This compaction is
 					// extension-owned and follows a routed tool loop, so queue the next
 					// turn after its summary is committed rather than leaving the agent idle.
-					pi.sendUserMessage(ROUTED_COMPACTION_CONTINUATION);
+					// A user may have started another turn while the compaction ran; in
+					// that case Pi requires an explicit follow-up delivery mode.
+					pi.sendUserMessage(
+						ROUTED_COMPACTION_CONTINUATION,
+						ctx.isIdle() ? undefined : { deliverAs: "followUp" },
+					);
 				},
 				onError: (error) => {
 					compactionScheduled = false;

--- a/install/pi-router/src/compaction.ts
+++ b/install/pi-router/src/compaction.ts
@@ -22,11 +22,14 @@ import type {
 } from "@mariozechner/pi-coding-agent";
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { ROUTED_CONTEXT_WINDOW_HEADER } from "./config.js";
+import { parseRoutedContextWindow } from "./context-window.js";
 
 const PROBE_MAX_TOKENS = 4;
 const CONTINUATION_MAX_TOKENS = 16_384;
 const COMPACTION_RESERVE_TOKENS = 16_384;
 const STATUS_KEY = "weave-compaction";
+/** Pi does not retry threshold compaction automatically, so resume our tool loop explicitly. */
+export const ROUTED_COMPACTION_CONTINUATION = "Continue from the compacted context. Pick up exactly where you left off.";
 
 interface ProviderPayload {
 	max_tokens?: unknown;
@@ -51,19 +54,6 @@ function containsToolResult(messages: unknown): boolean {
 		const content = (message as ProviderMessage).content;
 		return Array.isArray(content) && content.some((block: unknown) => isRecord(block) && block.type === "tool_result");
 	});
-}
-
-/**
- * Parse the router-served context window header, rejecting absent, fractional,
- * or out-of-range values. The header reflects what the router actually served
- * for a request, which can differ from the requested model's registered window
- * (reroutes to a smaller window, e.g. minimax-m2.7 204_800 or haiku 200_000).
- */
-export function parseRoutedContextWindow(value: string | undefined): number | undefined {
-	if (!value) return undefined;
-	if (!/^[1-9]\d*$/.test(value)) return undefined;
-	const contextWindow = Number(value);
-	return Number.isSafeInteger(contextWindow) && contextWindow > 0 ? contextWindow : undefined;
 }
 
 /**
@@ -176,7 +166,13 @@ export function registerCompaction(pi: ExtensionAPI, schedule: Schedule = (callb
 			}
 			if (ctx.hasUI) ctx.ui.setStatus(STATUS_KEY, "compacting routed context...");
 			ctx.compact({
-				onComplete: () => finishCompaction(ctx),
+				onComplete: () => {
+					finishCompaction(ctx);
+					// Pi only auto-retries an overflow compaction. This compaction is
+					// extension-owned and follows a routed tool loop, so queue the next
+					// turn after its summary is committed rather than leaving the agent idle.
+					pi.sendUserMessage(ROUTED_COMPACTION_CONTINUATION);
+				},
 				onError: (error) => {
 					compactionScheduled = false;
 					if (ctx.hasUI) ctx.ui.setStatus(STATUS_KEY, `compaction failed: ${error.message}`);

--- a/install/pi-router/src/context-window.ts
+++ b/install/pi-router/src/context-window.ts
@@ -1,0 +1,12 @@
+/**
+ * Router-served context-window parsing shared by the model registry and
+ * compaction guard. The response header is the source of truth for the model
+ * that actually served a routed request.
+ */
+
+/** Parse a router context-window header without accepting fractional or unsafe values. */
+export function parseRoutedContextWindow(value: string | undefined): number | undefined {
+	if (!value || !/^[1-9]\d*$/.test(value)) return undefined;
+	const contextWindow = Number(value);
+	return Number.isSafeInteger(contextWindow) ? contextWindow : undefined;
+}

--- a/install/pi-router/src/provider.ts
+++ b/install/pi-router/src/provider.ts
@@ -18,7 +18,20 @@ import {
 	WEAVE_MODELS,
 } from "./config.js";
 
-export function registerWeave(pi: ExtensionAPI): void {
+export interface ContextWindowOverride {
+	modelId: string;
+	contextWindow: number;
+}
+
+function modelsForContextWindow(override?: ContextWindowOverride): typeof WEAVE_MODELS {
+	if (!override) return WEAVE_MODELS;
+	return WEAVE_MODELS.map((model) =>
+		model.id === override.modelId ? { ...model, contextWindow: override.contextWindow } : model,
+	);
+}
+
+/** Register the Weave provider, optionally using the router-confirmed active context window. */
+export function registerWeave(pi: ExtensionAPI, contextWindowOverride?: ContextWindowOverride): void {
 	const key = resolveRouterKey();
 	const role = getRole();
 
@@ -46,6 +59,6 @@ export function registerWeave(pi: ExtensionAPI): void {
 		api: "anthropic-messages",
 		authHeader: false,
 		headers: providerHeaders(role, key),
-		models: WEAVE_MODELS,
+		models: modelsForContextWindow(contextWindowOverride),
 	});
 }

--- a/install/pi-router/src/routed-model.ts
+++ b/install/pi-router/src/routed-model.ts
@@ -13,10 +13,14 @@ import {
 	isSubagent,
 	ROUTED_MODEL_HEADER,
 	ROUTED_MODEL_STDERR_PREFIX,
+	ROUTED_CONTEXT_WINDOW_HEADER,
 	ROUTED_PROVIDER_HEADER,
 	ROUTER_DECISION_HEADER,
+	PROVIDER_NAME,
 } from "./config.js";
+import { parseRoutedContextWindow } from "./context-window.js";
 import { forcedModelFromBranch } from "./force-model.js";
+import { registerWeave } from "./provider.js";
 import {
 	aggregateSavings,
 	createSavingsEntry,
@@ -90,6 +94,9 @@ export function registerRoutedModel(pi: ExtensionAPI): void {
 	});
 
 	pi.on("model_select", (event, ctx: ExtensionContext) => {
+		// A new requested model has not yet received a router-confirmed window.
+		// Restore the conservative virtual-model default until its first response.
+		registerWeave(pi);
 		if (isSubagent()) return;
 		requestedModel = event.model.id;
 		routedModel = undefined;
@@ -100,6 +107,10 @@ export function registerRoutedModel(pi: ExtensionAPI): void {
 		if (event.status < 200 || event.status >= 300) return;
 		const model = event.headers?.[ROUTED_MODEL_HEADER];
 		if (!model) return;
+		const contextWindow = parseRoutedContextWindow(event.headers?.[ROUTED_CONTEXT_WINDOW_HEADER]);
+		if (contextWindow && ctx.model?.provider === PROVIDER_NAME) {
+			registerWeave(pi, { modelId: ctx.model.id, contextWindow });
+		}
 		const route: PendingRoute = {
 			...(ctx.model?.id ? { requestedModel: ctx.model.id } : {}),
 			routedModel: normalizeModelId(model),
@@ -130,6 +141,9 @@ export function registerRoutedModel(pi: ExtensionAPI): void {
 		const restoredForcedModel = forcedModelFromBranch(ctx.sessionManager.getBranch());
 		if (restoredForcedModel !== forcedModel) {
 			forcedModel = restoredForcedModel;
+			// Force-model directives take effect between responses, before the next
+			// served-window header can arrive. Fall back to the conservative value.
+			registerWeave(pi);
 			refresh(ctx);
 		}
 		const pending = pendingRoutes.shift();
@@ -153,6 +167,9 @@ export function registerRoutedModel(pi: ExtensionAPI): void {
 	});
 
 	pi.on("session_tree", (_event, ctx: ExtensionContext) => {
+		// A branch can have been served by another pinned model. Do not carry that
+		// window into the first request on the newly selected branch.
+		registerWeave(pi);
 		if (isSubagent()) return;
 		restore(ctx);
 		refresh(ctx);

--- a/install/pi-router/test/compaction.test.ts
+++ b/install/pi-router/test/compaction.test.ts
@@ -9,18 +9,19 @@ import {
 import { parseRoutedContextWindow } from "../src/context-window.js";
 
 type CapturedHandler = (event: any, ctx: ExtensionContext) => unknown;
+type SendOptions = Parameters<ExtensionAPI["sendUserMessage"]>[1];
 
 function extensionHarness(schedule?: (callback: () => void) => unknown) {
 	const handlers = new Map<string, CapturedHandler[]>();
-	const sentMessages: string[] = [];
+	const sentMessages: Array<{ content: string; options?: SendOptions }> = [];
 	const pi = {
 		on(event: string, handler: CapturedHandler) {
 			const eventHandlers = handlers.get(event) ?? [];
 			eventHandlers.push(handler);
 			handlers.set(event, eventHandlers);
 		},
-		sendUserMessage(message: string) {
-			sentMessages.push(message);
+		sendUserMessage(message: string, options?: SendOptions) {
+			sentMessages.push({ content: message, options });
 		},
 	} as unknown as ExtensionAPI;
 	registerCompaction(pi, schedule);
@@ -47,12 +48,13 @@ function assistant(totalTokens: number) {
 	};
 }
 
-function contextHarness(registeredWindow = 200_000) {
+function contextHarness(registeredWindow = 200_000, idle = true) {
 	let compactCalls = 0;
 	let status: string | undefined;
 	const branch: any[] = [];
 	const ctx = {
 		hasUI: true,
+		isIdle: () => idle,
 		model: { contextWindow: registeredWindow },
 		getContextUsage: () => ({ tokens: 0, contextWindow: registeredWindow, percent: 0 }),
 		sessionManager: { getBranch: () => branch },
@@ -112,7 +114,28 @@ test("compacts once after a routed tool loop crosses the virtual context window"
 	assert.equal(continuation.max_tokens, 16_384);
 	assert.equal(compactCalls(), 1);
 	assert.equal(status(), undefined);
-	assert.deepEqual(extension.sentMessages(), [ROUTED_COMPACTION_CONTINUATION]);
+	assert.deepEqual(extension.sentMessages(), [{ content: ROUTED_COMPACTION_CONTINUATION, options: undefined }]);
+});
+
+test("queues a manual-compaction continuation as a follow-up when Pi is active", () => {
+	const extension = extensionHarness((callback) => callback());
+	const { ctx, compactCalls } = contextHarness(200_000, false);
+	extension.emit("agent_start", { type: "agent_start" }, ctx);
+	extension.emit("turn_end", { type: "turn_end", message: assistant(210_910), toolResults: [] }, ctx);
+
+	const continuation = {
+		max_tokens: 1,
+		messages: [{ role: "user", content: [{ type: "tool_result", tool_use_id: "tool-1", content: "done" }] }],
+		tools: [{ name: "bash" }],
+	};
+	extension.emit("before_provider_request", { type: "before_provider_request", payload: continuation }, ctx);
+	extension.emit("turn_end", { type: "turn_end", message: assistant(135_652), toolResults: [] }, ctx);
+	extension.emit("agent_end", { type: "agent_end", messages: [] }, ctx);
+
+	assert.equal(compactCalls(), 1);
+	assert.deepEqual(extension.sentMessages(), [
+		{ content: ROUTED_COMPACTION_CONTINUATION, options: { deliverAs: "followUp" } },
+	]);
 });
 
 test("does not compact a run that stays below Pi's normal reserve threshold", () => {

--- a/install/pi-router/test/compaction.test.ts
+++ b/install/pi-router/test/compaction.test.ts
@@ -1,21 +1,31 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { registerCompaction, parseRoutedContextWindow, repairClampedToolContinuation } from "../src/compaction.js";
+import {
+	registerCompaction,
+	ROUTED_COMPACTION_CONTINUATION,
+	repairClampedToolContinuation,
+} from "../src/compaction.js";
+import { parseRoutedContextWindow } from "../src/context-window.js";
 
 type CapturedHandler = (event: any, ctx: ExtensionContext) => unknown;
 
 function extensionHarness(schedule?: (callback: () => void) => unknown) {
 	const handlers = new Map<string, CapturedHandler[]>();
+	const sentMessages: string[] = [];
 	const pi = {
 		on(event: string, handler: CapturedHandler) {
 			const eventHandlers = handlers.get(event) ?? [];
 			eventHandlers.push(handler);
 			handlers.set(event, eventHandlers);
 		},
+		sendUserMessage(message: string) {
+			sentMessages.push(message);
+		},
 	} as unknown as ExtensionAPI;
 	registerCompaction(pi, schedule);
 	return {
+		sentMessages: () => sentMessages,
 		emit(event: string, payload: unknown, ctx: ExtensionContext) {
 			for (const handler of handlers.get(event) ?? []) handler(payload, ctx);
 		},
@@ -102,6 +112,7 @@ test("compacts once after a routed tool loop crosses the virtual context window"
 	assert.equal(continuation.max_tokens, 16_384);
 	assert.equal(compactCalls(), 1);
 	assert.equal(status(), undefined);
+	assert.deepEqual(extension.sentMessages(), [ROUTED_COMPACTION_CONTINUATION]);
 });
 
 test("does not compact a run that stays below Pi's normal reserve threshold", () => {
@@ -112,6 +123,7 @@ test("does not compact a run that stays below Pi's normal reserve threshold", ()
 	extension.emit("agent_end", { type: "agent_end", messages: [] }, ctx);
 
 	assert.equal(compactCalls(), 0);
+	assert.deepEqual(extension.sentMessages(), []);
 });
 
 test("leaves an over-threshold final turn to Pi's built-in compaction", () => {
@@ -122,6 +134,20 @@ test("leaves an over-threshold final turn to Pi's built-in compaction", () => {
 	extension.emit("agent_end", { type: "agent_end", messages: [] }, ctx);
 
 	assert.equal(compactCalls(), 0);
+	assert.deepEqual(extension.sentMessages(), []);
+});
+
+test("does not inject a continuation for Pi-owned threshold compaction", () => {
+	const extension = extensionHarness((callback) => callback());
+	const { ctx } = contextHarness();
+
+	extension.emit(
+		"session_compact",
+		{ type: "session_compact", fromExtension: false, reason: "threshold", willRetry: false },
+		ctx,
+	);
+
+	assert.deepEqual(extension.sentMessages(), []);
 });
 
 test("parseRoutedContextWindow accepts only sane positive integers", () => {

--- a/install/pi-router/test/e2e.sh
+++ b/install/pi-router/test/e2e.sh
@@ -133,9 +133,9 @@ phase "Phase 2 — generated pricing + savings contract"
 if with_timeout 30 env PI_CODING_AGENT_DIR="$PI_DIR" \
   pi -e "$UNIT_SUITE" --no-session --offline --model weave/claude-sonnet-4-6 \
   -p "Run the unit suite." >"$WORK/unit.out" 2>&1 </dev/null; then
-  [ "$(grep -Ec '^(✔ |ok [0-9]+ - )' "$WORK/unit.out" || true)" = "28" ] \
-    && ok "pricing, force-model, UI, and compaction unit suite passed" \
-    || bad "unit suite did not report all 28 passes (see $WORK/unit.out)"
+  [ "$(grep -Ec '^(✔ |ok [0-9]+ - )' "$WORK/unit.out" || true)" = "33" ] \
+    && ok "pricing, force-model, UI, compaction, and served-window unit suite passed" \
+    || bad "unit suite did not report all 33 passes (see $WORK/unit.out)"
 else
   bad "unit suite failed to load through pi (see $WORK/unit.out)"
 fi

--- a/install/pi-router/test/e2e.sh
+++ b/install/pi-router/test/e2e.sh
@@ -133,9 +133,9 @@ phase "Phase 2 — generated pricing + savings contract"
 if with_timeout 30 env PI_CODING_AGENT_DIR="$PI_DIR" \
   pi -e "$UNIT_SUITE" --no-session --offline --model weave/claude-sonnet-4-6 \
   -p "Run the unit suite." >"$WORK/unit.out" 2>&1 </dev/null; then
-  [ "$(grep -Ec '^(✔ |ok [0-9]+ - )' "$WORK/unit.out" || true)" = "33" ] \
+  [ "$(grep -Ec '^(✔ |ok [0-9]+ - )' "$WORK/unit.out" || true)" = "34" ] \
     && ok "pricing, force-model, UI, compaction, and served-window unit suite passed" \
-    || bad "unit suite did not report all 33 passes (see $WORK/unit.out)"
+    || bad "unit suite did not report all 34 passes (see $WORK/unit.out)"
 else
   bad "unit suite failed to load through pi (see $WORK/unit.out)"
 fi

--- a/install/pi-router/test/routed-model.test.ts
+++ b/install/pi-router/test/routed-model.test.ts
@@ -62,7 +62,7 @@ function contextWindow(registration: ProviderRegistration, modelId: string): num
 	return registration.config.models?.find((model) => model.id === modelId)?.contextWindow;
 }
 
-test("uses the served context-window header for Pi's active Weave model", () => {
+test("uses the served context-window header only for Pi's active Weave model", () => {
 	withRouterKey(() => {
 		const extension = extensionHarness();
 		extension.emit(
@@ -79,7 +79,7 @@ test("uses the served context-window header for Pi's active Weave model", () => 
 		assert.equal(extension.registrations[0]?.name, PROVIDER_NAME);
 		assert.equal(extension.registrations[0]?.config.models?.length, WEAVE_MODELS.length);
 		assert.equal(contextWindow(extension.registrations[0]!, "claude-haiku-4-5"), 1_000_000);
-		assert.equal(contextWindow(extension.registrations[0]!, "claude-sonnet-4-6"), 1_000_000);
+		assert.equal(contextWindow(extension.registrations[0]!, "grok-4.6"), 500_000);
 		assert.equal(WEAVE_MODELS.find((model) => model.id === "claude-haiku-4-5")?.contextWindow, 200_000);
 	});
 });

--- a/install/pi-router/test/routed-model.test.ts
+++ b/install/pi-router/test/routed-model.test.ts
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import {
+	PROVIDER_NAME,
+	ROUTED_CONTEXT_WINDOW_HEADER,
+	ROUTED_MODEL_HEADER,
+	WEAVE_MODELS,
+} from "../src/config.js";
+import { parseRoutedContextWindow } from "../src/context-window.js";
+import { registerRoutedModel } from "../src/routed-model.js";
+
+type CapturedHandler = (event: any, ctx: ExtensionContext) => unknown;
+
+interface ProviderRegistration {
+	name: string;
+	config: { models?: Array<{ id: string; contextWindow: number }> };
+}
+
+function extensionHarness() {
+	const handlers = new Map<string, CapturedHandler[]>();
+	const registrations: ProviderRegistration[] = [];
+	const pi = {
+		on(event: string, handler: CapturedHandler) {
+			const eventHandlers = handlers.get(event) ?? [];
+			eventHandlers.push(handler);
+			handlers.set(event, eventHandlers);
+		},
+		registerProvider(name: string, config: ProviderRegistration["config"]) {
+			registrations.push({ name, config });
+		},
+	} as unknown as ExtensionAPI;
+	registerRoutedModel(pi);
+	return {
+		registrations,
+		emit(event: string, payload: unknown, ctx: ExtensionContext) {
+			for (const handler of handlers.get(event) ?? []) handler(payload, ctx);
+		},
+	};
+}
+
+function context({ modelId = "claude-haiku-4-5", provider = PROVIDER_NAME } = {}) {
+	return {
+		hasUI: false,
+		model: { provider, id: modelId },
+		sessionManager: { getBranch: () => [] },
+	} as unknown as ExtensionContext;
+}
+
+function withRouterKey<T>(callback: () => T): T {
+	const previous = process.env.WEAVE_ROUTER_KEY;
+	process.env.WEAVE_ROUTER_KEY = "rk_unit_test";
+	try {
+		return callback();
+	} finally {
+		if (previous === undefined) delete process.env.WEAVE_ROUTER_KEY;
+		else process.env.WEAVE_ROUTER_KEY = previous;
+	}
+}
+
+function contextWindow(registration: ProviderRegistration, modelId: string): number | undefined {
+	return registration.config.models?.find((model) => model.id === modelId)?.contextWindow;
+}
+
+test("uses the served context-window header for Pi's active Weave model", () => {
+	withRouterKey(() => {
+		const extension = extensionHarness();
+		extension.emit(
+			"after_provider_response",
+			{
+				type: "after_provider_response",
+				status: 200,
+				headers: { [ROUTED_MODEL_HEADER]: "qwen/qwen3.8-max", [ROUTED_CONTEXT_WINDOW_HEADER]: "1000000" },
+			},
+			context(),
+		);
+
+		assert.equal(extension.registrations.length, 1);
+		assert.equal(extension.registrations[0]?.name, PROVIDER_NAME);
+		assert.equal(extension.registrations[0]?.config.models?.length, WEAVE_MODELS.length);
+		assert.equal(contextWindow(extension.registrations[0]!, "claude-haiku-4-5"), 1_000_000);
+		assert.equal(contextWindow(extension.registrations[0]!, "claude-sonnet-4-6"), 1_000_000);
+		assert.equal(WEAVE_MODELS.find((model) => model.id === "claude-haiku-4-5")?.contextWindow, 200_000);
+	});
+});
+
+test("rejects malformed windows and windows from another provider", () => {
+	assert.equal(parseRoutedContextWindow("1000000"), 1_000_000);
+	for (const value of [undefined, "", "0", "-1", "1000.5", "1e6", "Infinity", "9007199254740992"]) {
+		assert.equal(parseRoutedContextWindow(value), undefined);
+	}
+
+	withRouterKey(() => {
+		const extension = extensionHarness();
+		extension.emit(
+			"after_provider_response",
+			{
+				type: "after_provider_response",
+				status: 200,
+				headers: { [ROUTED_MODEL_HEADER]: "qwen/qwen3.8-max", [ROUTED_CONTEXT_WINDOW_HEADER]: "1e6" },
+			},
+			context(),
+		);
+		extension.emit(
+			"after_provider_response",
+			{
+				type: "after_provider_response",
+				status: 200,
+				headers: { [ROUTED_MODEL_HEADER]: "qwen/qwen3.8-max", [ROUTED_CONTEXT_WINDOW_HEADER]: "1000000" },
+			},
+			context({ provider: "anthropic" }),
+		);
+		extension.emit(
+			"after_provider_response",
+			{ type: "after_provider_response", status: 200, headers: { [ROUTED_CONTEXT_WINDOW_HEADER]: "1000000" } },
+			context(),
+		);
+		extension.emit(
+			"after_provider_response",
+			{
+				type: "after_provider_response",
+				status: 503,
+				headers: { [ROUTED_MODEL_HEADER]: "qwen/qwen3.8-max", [ROUTED_CONTEXT_WINDOW_HEADER]: "1000000" },
+			},
+			context(),
+		);
+		assert.deepEqual(extension.registrations, []);
+	});
+});
+
+test("returns to the conservative virtual context window after model selection", () => {
+	withRouterKey(() => {
+		const extension = extensionHarness();
+		const ctx = context();
+		extension.emit(
+			"after_provider_response",
+			{
+				type: "after_provider_response",
+				status: 200,
+				headers: { [ROUTED_MODEL_HEADER]: "qwen/qwen3.8-max", [ROUTED_CONTEXT_WINDOW_HEADER]: "1000000" },
+			},
+			ctx,
+		);
+		extension.emit("model_select", { type: "model_select", model: { id: "claude-haiku-4-5" } }, ctx);
+
+		assert.equal(contextWindow(extension.registrations[0]!, "claude-haiku-4-5"), 1_000_000);
+		assert.equal(contextWindow(extension.registrations[1]!, "claude-haiku-4-5"), 200_000);
+	});
+});
+
+test("does not carry a served context window across a session-tree change", () => {
+	withRouterKey(() => {
+		const extension = extensionHarness();
+		const ctx = context();
+		extension.emit(
+			"after_provider_response",
+			{
+				type: "after_provider_response",
+				status: 200,
+				headers: { [ROUTED_MODEL_HEADER]: "qwen/qwen3.8-max", [ROUTED_CONTEXT_WINDOW_HEADER]: "1000000" },
+			},
+			ctx,
+		);
+		extension.emit("session_tree", { type: "session_tree" }, ctx);
+
+		assert.equal(contextWindow(extension.registrations[0]!, "claude-haiku-4-5"), 1_000_000);
+		assert.equal(contextWindow(extension.registrations[1]!, "claude-haiku-4-5"), 200_000);
+	});
+});

--- a/install/pi-router/test/unit-suite.ts
+++ b/install/pi-router/test/unit-suite.ts
@@ -5,6 +5,7 @@ import "./savings.test.js";
 import "./force-model.test.js";
 import "./ui.test.js";
 import "./compaction.test.js";
+import "./routed-model.test.js";
 
 // Pi 0.74 also requires an extension-shaped default export before evaluating
 // the module. Test registration itself happens through the side-effect imports.


### PR DESCRIPTION
## Summary
- Consume x-router-context-window from successful routed responses and refresh only the active virtual weave model.
- Reset that override on model and session-tree changes, preserving conservative static defaults.
- Resume only extension-owned routed tool-loop compaction after it completes.
- Bump @workweave/router to 0.2.11 for the Pi upgrade.

## 503 handling
This branch starts from current main, which includes the bounded policy-sidecar retry/deadline fix. It adds no fail-open policy fallback. Persistent production 503s after deployment would require a separate sidecar/deployment investigation.

## Validation
- GOCACHE=/tmp/workweave-pi-router-reliability-gocache go test ./internal/policyclient -count=1
- ./install/pi-router/test/e2e.sh