### PR TITLE
Add deleted_by to model_router_external_api_keys

### DIFF
--- a/db/migrations/0061_external-key-deleted-by.down.sql
+++ b/db/migrations/0061_external-key-deleted-by.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE router.model_router_external_api_keys
+  DROP COLUMN deleted_by;
+
+COMMIT;

--- a/db/migrations/0061_external-key-deleted-by.up.sql
+++ b/db/migrations/0061_external-key-deleted-by.up.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+-- Attribute who soft-deleted a BYOK provider key or who replaced it during an
+-- upsert. Complements the existing created_by. NULL deliberately mirrors the
+-- created_by convention: rows soft-deleted internally by the router (rather
+-- than by an admin in Weave settings) have no account to record.
+ALTER TABLE router.model_router_external_api_keys
+  ADD COLUMN deleted_by VARCHAR(36);
+
+COMMENT ON COLUMN router.model_router_external_api_keys.deleted_by IS 'Weave account that soft-deleted or replaced this key; NULL when the router deleted it internally or attribution predates the column';
+
+COMMIT;

--- a/internal/sqlc/model_router_external_api_keys.sql.go
+++ b/internal/sqlc/model_router_external_api_keys.sql.go
@@ -48,7 +48,7 @@ VALUES (
     $15::text,
     $16
 )
-RETURNING id, installation_id, external_id, provider, key_ciphertext, key_prefix, key_suffix, key_fingerprint, name, last_used_at, created_at, updated_at, deleted_at, created_by, base_url, model_aliases, identity_header_name, identity_header_format, auth_type, auth_account, auth_user
+RETURNING id, installation_id, external_id, provider, key_ciphertext, key_prefix, key_suffix, key_fingerprint, name, last_used_at, created_at, updated_at, deleted_at, created_by, base_url, model_aliases, identity_header_name, identity_header_format, auth_type, auth_account, auth_user, deleted_by
 `
 
 type CreateExternalAPIKeyParams struct {
@@ -110,7 +110,7 @@ type CreateExternalAPIKeyParams struct {
 //	    $15::text,
 //	    $16
 //	)
-//	RETURNING id, installation_id, external_id, provider, key_ciphertext, key_prefix, key_suffix, key_fingerprint, name, last_used_at, created_at, updated_at, deleted_at, created_by, base_url, model_aliases, identity_header_name, identity_header_format, auth_type, auth_account, auth_user
+//	RETURNING id, installation_id, external_id, provider, key_ciphertext, key_prefix, key_suffix, key_fingerprint, name, last_used_at, created_at, updated_at, deleted_at, created_by, base_url, model_aliases, identity_header_name, identity_header_format, auth_type, auth_account, auth_user, deleted_by
 func (q *Queries) CreateExternalAPIKey(ctx context.Context, arg CreateExternalAPIKeyParams) (RouterModelRouterExternalAPIKey, error) {
 	row := q.db.QueryRow(ctx, createExternalAPIKey,
 		arg.InstallationID,
@@ -153,12 +153,13 @@ func (q *Queries) CreateExternalAPIKey(ctx context.Context, arg CreateExternalAP
 		&i.AuthType,
 		&i.AuthAccount,
 		&i.AuthUser,
+		&i.DeletedBy,
 	)
 	return i, err
 }
 
 const getActiveExternalAPIKeysForInstallation = `-- name: GetActiveExternalAPIKeysForInstallation :many
-SELECT id, installation_id, external_id, provider, key_ciphertext, key_prefix, key_suffix, key_fingerprint, name, last_used_at, created_at, updated_at, deleted_at, created_by, base_url, model_aliases, identity_header_name, identity_header_format, auth_type, auth_account, auth_user
+SELECT id, installation_id, external_id, provider, key_ciphertext, key_prefix, key_suffix, key_fingerprint, name, last_used_at, created_at, updated_at, deleted_at, created_by, base_url, model_aliases, identity_header_name, identity_header_format, auth_type, auth_account, auth_user, deleted_by
 FROM router.model_router_external_api_keys
 WHERE installation_id = $1::uuid
   AND deleted_at IS NULL
@@ -168,7 +169,7 @@ ORDER BY provider, created_at DESC
 // Returns all active external API keys for an installation. Used by the auth
 // cache to populate the ExternalKeys map on cache miss.
 //
-//	SELECT id, installation_id, external_id, provider, key_ciphertext, key_prefix, key_suffix, key_fingerprint, name, last_used_at, created_at, updated_at, deleted_at, created_by, base_url, model_aliases, identity_header_name, identity_header_format, auth_type, auth_account, auth_user
+//	SELECT id, installation_id, external_id, provider, key_ciphertext, key_prefix, key_suffix, key_fingerprint, name, last_used_at, created_at, updated_at, deleted_at, created_by, base_url, model_aliases, identity_header_name, identity_header_format, auth_type, auth_account, auth_user, deleted_by
 //	FROM router.model_router_external_api_keys
 //	WHERE installation_id = $1::uuid
 //	  AND deleted_at IS NULL
@@ -204,6 +205,7 @@ func (q *Queries) GetActiveExternalAPIKeysForInstallation(ctx context.Context, i
 			&i.AuthType,
 			&i.AuthAccount,
 			&i.AuthUser,
+			&i.DeletedBy,
 		); err != nil {
 			return nil, err
 		}
@@ -289,7 +291,7 @@ SET model_aliases = $1::jsonb, updated_at = CURRENT_TIMESTAMP
 WHERE id = $2::uuid
   AND installation_id = $3::uuid
   AND deleted_at IS NULL
-RETURNING id, installation_id, external_id, provider, key_ciphertext, key_prefix, key_suffix, key_fingerprint, name, last_used_at, created_at, updated_at, deleted_at, created_by, base_url, model_aliases, identity_header_name, identity_header_format, auth_type, auth_account, auth_user
+RETURNING id, installation_id, external_id, provider, key_ciphertext, key_prefix, key_suffix, key_fingerprint, name, last_used_at, created_at, updated_at, deleted_at, created_by, base_url, model_aliases, identity_header_name, identity_header_format, auth_type, auth_account, auth_user, deleted_by
 `
 
 type UpdateExternalAPIKeyModelAliasesParams struct {
@@ -307,7 +309,7 @@ type UpdateExternalAPIKeyModelAliasesParams struct {
 //	WHERE id = $2::uuid
 //	  AND installation_id = $3::uuid
 //	  AND deleted_at IS NULL
-//	RETURNING id, installation_id, external_id, provider, key_ciphertext, key_prefix, key_suffix, key_fingerprint, name, last_used_at, created_at, updated_at, deleted_at, created_by, base_url, model_aliases, identity_header_name, identity_header_format, auth_type, auth_account, auth_user
+//	RETURNING id, installation_id, external_id, provider, key_ciphertext, key_prefix, key_suffix, key_fingerprint, name, last_used_at, created_at, updated_at, deleted_at, created_by, base_url, model_aliases, identity_header_name, identity_header_format, auth_type, auth_account, auth_user, deleted_by
 func (q *Queries) UpdateExternalAPIKeyModelAliases(ctx context.Context, arg UpdateExternalAPIKeyModelAliasesParams) (RouterModelRouterExternalAPIKey, error) {
 	row := q.db.QueryRow(ctx, updateExternalAPIKeyModelAliases, arg.ModelAliases, arg.ID, arg.InstallationID)
 	var i RouterModelRouterExternalAPIKey
@@ -333,6 +335,7 @@ func (q *Queries) UpdateExternalAPIKeyModelAliases(ctx context.Context, arg Upda
 		&i.AuthType,
 		&i.AuthAccount,
 		&i.AuthUser,
+		&i.DeletedBy,
 	)
 	return i, err
 }

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -90,6 +90,8 @@ type RouterModelRouterExternalAPIKey struct {
 	AuthAccount *string
 	// User the minted JWT authenticates as; NULL unless auth_type is keypair_jwt
 	AuthUser *string
+	// Weave account that soft-deleted or replaced this key; NULL when the router deleted it internally or attribution predates the column
+	DeletedBy *string
 }
 
 // Customer router installations; owns API keys


### PR DESCRIPTION
## Context

Weave's provider-key settings page now shows the change history of BYOK provider keys (WorkWeave PR #12100 — surfaced `created_by`/`deleted_at`). It surfaced a gap: deletion/replacement attributes the actor nowhere on the key row. `SoftDeleteExternalAPIKey` / `SoftDeleteExternalAPIKeyByProvider` stamp only `deleted_at`/`updated_at`.

This is migration-only. The actor is written by the Weave platform backend (the only caller that soft-deletes these rows on the managed/SaaS side) as part of WorkWeave PR #12101 the moment this lands; the router's own internal deletes (firewall/router rows) continue to leave it NULL, matching the existing `created_by` convention.

## Change

- `0061_external-key-deleted-by.up.sql` / `.down.sql` — adds `deleted_by VARCHAR(36)` to `router.model_router_external_api_keys` (complements `created_by`; NULL = router-internal delete / predates attribution) with a column comment.

No router SQLC / Go changes — the column is only read and written by WorkWeave's `weaverouter` package (which uses hand-written pgx, not this repo's SQLC). The router's SQLC soft-delete queries are intentionally untouched.

## Why migration-only

The router's `SoftDeleteExternalAPIKey*` SQLC queries are used by router-internal paths that have no admin actor concept; forcing `@deleted_by` into them would require threading a phantom argument through router Go callers. WorkWeave writes the column directly in the same transaction that already writes `created_by`.