### PR TITLE
feat(catalog): add per-binding context-window overrides; fix deepseek-v4-pro Together 512K

### DIFF
--- a/internal/proxy/compaction.go
+++ b/internal/proxy/compaction.go
@@ -91,11 +91,9 @@ func (s *Service) maxEligibleContextWindow(policyExcluded, enabledProviders map[
 }
 
 // maxContextWindowForModel returns the largest context window any enabled
-// binding of model can serve. Compaction decides when to SHRINK, not what to
-// exclude, so it must be as generous as the best enabled binding allows — a
-// 1M-capable fallback for a 512K-primary model justifies holding off
-// compaction. Falls back to the model-level window when enabledProviders is
-// nil or no enabled binding exists.
+// binding of model can serve. Uses MAX (not MIN) because compaction decides
+// when to SHRINK — a 1M fallback justifies holding off even with a 512K primary.
+// Falls back to the model-level window when enabledProviders is nil.
 func maxContextWindowForModel(model string, enabledProviders map[string]struct{}) int {
 	cw := contextWindowForRequest(model)
 	if len(enabledProviders) == 0 {

--- a/internal/proxy/compaction.go
+++ b/internal/proxy/compaction.go
@@ -73,13 +73,13 @@ type compactionResult struct {
 // per-model discount in excludeContextOverflowModels, so a signature-heavy
 // session isn't falsely 413'd when a stripping model would still fit. Zero when
 // none are known (availableModels unset), which disables compaction.
-func (s *Service) maxEligibleContextWindow(policyExcluded map[string]struct{}, sigSavings int) int {
+func (s *Service) maxEligibleContextWindow(policyExcluded, enabledProviders map[string]struct{}, sigSavings int) int {
 	maxWindow := 0
 	for model := range s.availableModels {
 		if _, excluded := policyExcluded[model]; excluded {
 			continue
 		}
-		w := contextWindowForRequest(model)
+		w := maxContextWindowForModel(model, enabledProviders)
 		if sigSavings > 0 && modelStripsAnthropicSignatures(model) {
 			w += sigSavings
 		}
@@ -88,6 +88,32 @@ func (s *Service) maxEligibleContextWindow(policyExcluded map[string]struct{}, s
 		}
 	}
 	return maxWindow
+}
+
+// maxContextWindowForModel returns the largest context window any enabled
+// binding of model can serve. Compaction decides when to SHRINK, not what to
+// exclude, so it must be as generous as the best enabled binding allows — a
+// 1M-capable fallback for a 512K-primary model justifies holding off
+// compaction. Falls back to the model-level window when enabledProviders is
+// nil or no enabled binding exists.
+func maxContextWindowForModel(model string, enabledProviders map[string]struct{}) int {
+	cw := contextWindowForRequest(model)
+	if len(enabledProviders) == 0 {
+		return cw
+	}
+	m, ok := catalog.ByID(model)
+	if !ok || len(m.Providers) == 0 {
+		return cw
+	}
+	for _, b := range m.Providers {
+		if _, enabled := enabledProviders[b.Provider]; !enabled {
+			continue
+		}
+		if w := catalog.ContextWindowForBinding(model, b.Provider); w > cw {
+			cw = w
+		}
+	}
+	return cw
 }
 
 // selectCompactionSummarizer returns the cheapest configured summarizer model

--- a/internal/proxy/compaction.go
+++ b/internal/proxy/compaction.go
@@ -95,14 +95,14 @@ func (s *Service) maxEligibleContextWindow(policyExcluded, enabledProviders map[
 // when to SHRINK — a 1M fallback justifies holding off even with a 512K primary.
 // Falls back to the model-level window when enabledProviders is nil.
 func maxContextWindowForModel(model string, enabledProviders map[string]struct{}) int {
-	cw := contextWindowForRequest(model)
 	if len(enabledProviders) == 0 {
-		return cw
+		return contextWindowForRequest(model)
 	}
 	m, ok := catalog.ByID(model)
 	if !ok || len(m.Providers) == 0 {
-		return cw
+		return contextWindowForRequest(model)
 	}
+	cw := 0
 	for _, b := range m.Providers {
 		if _, enabled := enabledProviders[b.Provider]; !enabled {
 			continue
@@ -110,6 +110,9 @@ func maxContextWindowForModel(model string, enabledProviders map[string]struct{}
 		if w := catalog.ContextWindowForBinding(model, b.Provider); w > cw {
 			cw = w
 		}
+	}
+	if cw == 0 {
+		return contextWindowForRequest(model)
 	}
 	return cw
 }

--- a/internal/proxy/compaction.go
+++ b/internal/proxy/compaction.go
@@ -107,7 +107,7 @@ func maxContextWindowForModel(model string, enabledProviders map[string]struct{}
 		if _, enabled := enabledProviders[b.Provider]; !enabled {
 			continue
 		}
-		if w := catalog.ContextWindowForBinding(model, b.Provider); w > cw {
+		if w := contextWindowForRequest(model, b.Provider); w > cw {
 			cw = w
 		}
 	}

--- a/internal/proxy/compaction_test.go
+++ b/internal/proxy/compaction_test.go
@@ -197,15 +197,15 @@ func TestSelectCompactionSummarizer_WindowAware(t *testing.T) {
 
 func TestMaxEligibleContextWindow(t *testing.T) {
 	s := &Service{availableModels: map[string]struct{}{"claude-haiku-4-5": {}}}
-	assert.Equal(t, 200_000, s.maxEligibleContextWindow(nil, 0))
-	assert.Equal(t, 200_000, s.maxEligibleContextWindow(nil, 5_000), "Anthropic (signature-keeping) models ignore signature savings")
-	assert.Equal(t, 0, s.maxEligibleContextWindow(map[string]struct{}{"claude-haiku-4-5": {}}, 0), "policy-excluding the only model leaves no window")
+	assert.Equal(t, 200_000, s.maxEligibleContextWindow(nil, nil, 0))
+	assert.Equal(t, 200_000, s.maxEligibleContextWindow(nil, nil, 5_000), "Anthropic (signature-keeping) models ignore signature savings")
+	assert.Equal(t, 0, s.maxEligibleContextWindow(map[string]struct{}{"claude-haiku-4-5": {}}, nil, 0), "policy-excluding the only model leaves no window")
 
 	// A signature-stripping (non-Anthropic) model gets sigSavings added to its
 	// effective window, matching the context-overflow pre-filter's discount.
 	sStrip := &Service{availableModels: map[string]struct{}{"gpt-5.5": {}}}
-	assert.Equal(t, 1_050_000, sStrip.maxEligibleContextWindow(nil, 0))
-	assert.Equal(t, 1_050_000+5_000, sStrip.maxEligibleContextWindow(nil, 5_000), "stripping model gains signature savings as headroom")
+	assert.Equal(t, 1_050_000, sStrip.maxEligibleContextWindow(nil, nil, 0))
+	assert.Equal(t, 1_050_000+5_000, sStrip.maxEligibleContextWindow(nil, nil, 5_000), "stripping model gains signature savings as headroom")
 }
 
 func TestClassifyDispatchError_ContextWindowExceeded(t *testing.T) {

--- a/internal/proxy/context_overflow_internal_test.go
+++ b/internal/proxy/context_overflow_internal_test.go
@@ -127,8 +127,8 @@ func TestExcludeContextOverflowModels_MultiBindingMinWindow(t *testing.T) {
 		"deepseek/deepseek-v4-pro-0813": {},
 	}
 	enabledBoth := map[string]struct{}{
-		providers.ProviderTogether:   {},
-		providers.ProviderFireworks:  {},
+		providers.ProviderTogether:  {},
+		providers.ProviderFireworks: {},
 	}
 	enabledTogetherOnly := map[string]struct{}{
 		providers.ProviderTogether: {},

--- a/internal/proxy/context_overflow_internal_test.go
+++ b/internal/proxy/context_overflow_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"workweave/router/internal/providers"
 	"workweave/router/internal/translate"
 
 	"github.com/stretchr/testify/assert"
@@ -30,7 +31,7 @@ func TestExcludeContextOverflowModels_KeepsExtendedContextModel(t *testing.T) {
 		"claude-haiku-4-5": {},
 	}
 
-	out, overflowed := excludeContextOverflowModels(250_000, 0, 8_000, nil, available)
+	out, overflowed := excludeContextOverflowModels(250_000, 0, 8_000, nil, nil, available)
 
 	assert.Contains(t, overflowed, "claude-haiku-4-5", "200K-only model overflows a 258K request")
 	assert.NotContains(t, overflowed, "claude-opus-4-8", "extended-context model fits at 1M and must stay eligible")
@@ -46,7 +47,7 @@ func TestExcludeContextOverflowModels_NoOverflowUnderWindow(t *testing.T) {
 		"claude-haiku-4-5": {},
 	}
 
-	out, overflowed := excludeContextOverflowModels(10_000, 0, 8_000, nil, available)
+	out, overflowed := excludeContextOverflowModels(10_000, 0, 8_000, nil, nil, available)
 
 	assert.Empty(t, overflowed)
 	assert.Nil(t, out, "no additions returns the original (nil) denylist unchanged")
@@ -67,7 +68,7 @@ func TestExcludeContextOverflowModels_SignatureSavingsOnlyForStrippingTargets(t 
 	}
 
 	// est+reserve = 268K overflows kimi's 262144 without savings; -20K savings = 248K fits.
-	out, overflowed := excludeContextOverflowModels(260_000, 20_000, 8_000, nil, available)
+	out, overflowed := excludeContextOverflowModels(260_000, 20_000, 8_000, nil, nil, available)
 
 	assert.NotContains(t, overflowed, "moonshotai/kimi-k2.7", "OSS target strips signatures, so the savings keep it under its 256K window")
 	assert.Contains(t, overflowed, "claude-haiku-4-5", "Anthropic target keeps signatures, so the savings do not apply and it overflows 200K")
@@ -94,14 +95,14 @@ func TestSafetyExcludedModels_CatchesPolicyExcludedOverflow(t *testing.T) {
 	// is already excluded) — so the overflow denylist it returns is empty.
 	_, routingOverflowed := excludeContextOverflowModels(
 		env.ContextOverflowTokenEstimate(), env.SignatureTokenSavings(), 8_000,
-		map[string]struct{}{"claude-haiku-4-5": {}}, s.availableModels,
+		nil, map[string]struct{}{"claude-haiku-4-5": {}}, s.availableModels,
 	)
 	assert.NotContains(t, routingOverflowed, "claude-haiku-4-5",
 		"the routing filter skips a policy-excluded model — this is the gap safetyExcludedModels must close")
 
 	// safetyExcludedModels re-runs against an empty base, so it DOES catch the
 	// overflow regardless of policy exclusion.
-	safety := s.safetyExcludedModels(env, 8_000)
+	safety := s.safetyExcludedModels(env, 8_000, nil)
 	_, blocked := safety["claude-haiku-4-5"]
 	assert.True(t, blocked, "a policy-excluded model that also overflows must land in the safety set so bypass blocks it")
 }
@@ -116,4 +117,47 @@ func TestShouldEnableExtendedContext(t *testing.T) {
 	// A ~250K-real-token request estimates well above the trigger even with the
 	// ÷5 undercount, so the beta is enabled before it can 400 on the 200K default.
 	assert.True(t, shouldEnableExtendedContext(180_000, 8_000), "near-200K request opts into 1M")
+}
+
+// TestExcludeContextOverflowModels_MultiBindingMinWindow is the regression for
+// session 9424eef5: deepseek-v4-pro-0813 has Together primary (512K served)
+// and Fireworks/OpenRouter fallbacks (1M). The pre-filter must use the MIN
+// across enabled bindings because the primary dispatches first — a 610K request
+// cannot count on the 1M fallback, and routing it to Together would hard-400.
+func TestExcludeContextOverflowModels_MultiBindingMinWindow(t *testing.T) {
+	available := map[string]struct{}{
+		"deepseek/deepseek-v4-pro-0813": {},
+	}
+	enabledBoth := map[string]struct{}{
+		providers.ProviderTogether:   {},
+		providers.ProviderFireworks:  {},
+	}
+	enabledTogetherOnly := map[string]struct{}{
+		providers.ProviderTogether: {},
+	}
+	enabledFireworksOnly := map[string]struct{}{
+		providers.ProviderFireworks: {},
+	}
+
+	// 610016 = the exact overflow estimate from the failing session + 64K reserve.
+	// Together (512K) < needed => excluded; Fireworks (1M) > needed => safe.
+	outBoth, overflowedBoth := excludeContextOverflowModels(546_016, 0, 64_000, enabledBoth, nil, available)
+	assert.Contains(t, overflowedBoth, "deepseek/deepseek-v4-pro-0813",
+		"Together 512K primary binding must exclude the model when both are keyed")
+	assert.Contains(t, outBoth, "deepseek/deepseek-v4-pro-0813", "model must be in the exclusion map")
+
+	// Together-only deploy: excluded.
+	_, overflowedTogether := excludeContextOverflowModels(546_016, 0, 64_000, enabledTogetherOnly, nil, available)
+	assert.Contains(t, overflowedTogether, "deepseek/deepseek-v4-pro-0813",
+		"Together-only deploy must exclude at 610K (512K window)")
+
+	// Fireworks-only deploy: NOT excluded (genuinely serves 1M).
+	_, overflowedFireworks := excludeContextOverflowModels(546_016, 0, 64_000, enabledFireworksOnly, nil, available)
+	assert.NotContains(t, overflowedFireworks, "deepseek/deepseek-v4-pro-0813",
+		"Fireworks-only deploy must not exclude at 610K (1M window)")
+
+	// nil enabledProviders: passes through to model-level (1M), NOT excluded.
+	_, overflowedNil := excludeContextOverflowModels(546_016, 0, 64_000, nil, nil, available)
+	assert.NotContains(t, overflowedNil, "deepseek/deepseek-v4-pro-0813",
+		"nil enabledProviders retains legacy model-level behavior")
 }

--- a/internal/proxy/context_overflow_internal_test.go
+++ b/internal/proxy/context_overflow_internal_test.go
@@ -119,11 +119,9 @@ func TestShouldEnableExtendedContext(t *testing.T) {
 	assert.True(t, shouldEnableExtendedContext(180_000, 8_000), "near-200K request opts into 1M")
 }
 
-// TestExcludeContextOverflowModels_MultiBindingMinWindow is the regression for
-// session 9424eef5: deepseek-v4-pro-0813 has Together primary (512K served)
-// and Fireworks/OpenRouter fallbacks (1M). The pre-filter must use the MIN
-// across enabled bindings because the primary dispatches first — a 610K request
-// cannot count on the 1M fallback, and routing it to Together would hard-400.
+// TestExcludeContextOverflowModels_MultiBindingMinWindow: Together (512K primary)
+// plus Fireworks (1M fallback) — pre-filter must use MIN because primary dispatches
+// first; a 610K request cannot rely on the 1M fallback to avoid a hard-400.
 func TestExcludeContextOverflowModels_MultiBindingMinWindow(t *testing.T) {
 	available := map[string]struct{}{
 		"deepseek/deepseek-v4-pro-0813": {},

--- a/internal/proxy/fallback.go
+++ b/internal/proxy/fallback.go
@@ -233,7 +233,7 @@ func (s *Service) dispatchWithFallback(ctx context.Context, in failoverInputs) (
 				// Refresh: decision.Model can change on baseline failover, so
 				// x-router-model must never name a model that didn't serve.
 				in.w.Header().Set(HeaderRouterModel, decision.Model)
-				in.w.Header().Set(HeaderRouterContextWindow, strconv.Itoa(contextWindowForRequest(decision.Model)))
+				in.w.Header().Set(HeaderRouterContextWindow, strconv.Itoa(contextWindowForRequest(decision.Model, decision.Provider)))
 				if i > 0 {
 					in.w.Header().Set(HeaderRouterFallbackFrom, in.bindings[0].Provider)
 					in.w.Header().Set(HeaderRouterFallbackAttempt, attemptIdxLabel(i))

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -139,7 +139,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	w.Header().Set(HeaderRouterDecision, decision.Reason)
 	w.Header().Set(HeaderRouterProvider, decision.Provider)
 	w.Header().Set(HeaderRouterModel, decision.Model)
-	w.Header().Set(HeaderRouterContextWindow, strconv.Itoa(contextWindowForRequest(decision.Model)))
+	w.Header().Set(HeaderRouterContextWindow, strconv.Itoa(contextWindowForRequest(decision.Model, decision.Provider)))
 	// Gemini path does not resolve a router user, matching the decision span
 	// below which omits router_user_id.
 	s.setFeedbackLinkHeader(ctx, w, installationID, externalID, requestID, "")

--- a/internal/proxy/route_preview.go
+++ b/internal/proxy/route_preview.go
@@ -56,6 +56,7 @@ func (s *Service) anthropicRoutingRequest(ctx context.Context, body []byte, head
 		env.ContextOverflowTokenEstimate(),
 		env.SignatureTokenSavings(),
 		outputReserve,
+		enabledProviders,
 		excluded,
 		s.availableModels,
 	)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -887,10 +887,9 @@ func contextWindowForRequest(modelID string, provider ...string) int {
 }
 
 // minContextWindowForModel returns the smallest context window any enabled
-// binding can serve. The pre-filter must assume the primary binding (first
-// enabled in catalog order) dispatches first — a 512K primary nulls a 1M
-// fallback for filtering purposes. Falls back to the model-level window when
-// enabledProviders is nil.
+// binding can serve. Uses MIN because the primary binding dispatches first —
+// a 512K primary blocks even when a 1M fallback exists. Nil enabledProviders
+// falls back to the model-level window.
 func minContextWindowForModel(model string, enabledProviders map[string]struct{}) int {
 	cw := contextWindowForRequest(model)
 	if len(enabledProviders) == 0 {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -725,8 +725,8 @@ func routingKnobsForRequest(ctx context.Context) *router.Overrides {
 // excluded_models, so a policy-excluded overflow model would be absent from
 // those lists yet must still block bypass (it would 400 on the subscription).
 // Returns nil when neither filter fires.
-func (s *Service) safetyExcludedModels(env *translate.RequestEnvelope, outputReserve int) map[string]struct{} {
-	_, overflowed := excludeContextOverflowModels(env.ContextOverflowTokenEstimate(), env.SignatureTokenSavings(), outputReserve, nil, s.availableModels)
+func (s *Service) safetyExcludedModels(env *translate.RequestEnvelope, outputReserve int, enabledProviders map[string]struct{}) map[string]struct{} {
+	_, overflowed := excludeContextOverflowModels(env.ContextOverflowTokenEstimate(), env.SignatureTokenSavings(), outputReserve, enabledProviders, nil, s.availableModels)
 	_, geminiUnsigned := excludeGemini3xOnUnsignedHistory(env, nil, s.availableModels)
 	if len(overflowed) == 0 && len(geminiUnsigned) == 0 {
 		return nil
@@ -876,11 +876,39 @@ func shouldEnableExtendedContext(est, outputReserve int) bool {
 // proxy unconditionally injects the context-1m beta for them — gating on the
 // client's beta header or the token estimate instead would let a large
 // request slip onto 200K and overflow on the first turn.
-func contextWindowForRequest(modelID string) int {
+func contextWindowForRequest(modelID string, provider ...string) int {
 	if router.Lookup(modelID).Supports(router.CapExtendedContext) {
 		return 1_000_000
 	}
+	if len(provider) > 0 && provider[0] != "" {
+		return catalog.ContextWindowForBinding(modelID, provider[0])
+	}
 	return catalog.ContextWindowFor(modelID)
+}
+
+// minContextWindowForModel returns the smallest context window any enabled
+// binding can serve. The pre-filter must assume the primary binding (first
+// enabled in catalog order) dispatches first — a 512K primary nulls a 1M
+// fallback for filtering purposes. Falls back to the model-level window when
+// enabledProviders is nil.
+func minContextWindowForModel(model string, enabledProviders map[string]struct{}) int {
+	cw := contextWindowForRequest(model)
+	if len(enabledProviders) == 0 {
+		return cw
+	}
+	m, ok := catalog.ByID(model)
+	if !ok || len(m.Providers) == 0 {
+		return cw
+	}
+	for _, b := range m.Providers {
+		if _, enabled := enabledProviders[b.Provider]; !enabled {
+			continue
+		}
+		if w := catalog.ContextWindowForBinding(model, b.Provider); w < cw {
+			cw = w
+		}
+	}
+	return cw
 }
 
 // modelStripsAnthropicSignatures reports whether dispatching to model drops
@@ -903,7 +931,7 @@ func modelStripsAnthropicSignatures(model string) bool {
 // subtracted only for stripping targets, so Anthropic passthrough is still
 // checked against the full body. Returns excluded unchanged and nil when
 // nothing is added.
-func excludeContextOverflowModels(est, sigSavings, outputReserve int, excluded, available map[string]struct{}) (map[string]struct{}, []string) {
+func excludeContextOverflowModels(est, sigSavings, outputReserve int, enabledProviders, excluded, available map[string]struct{}) (map[string]struct{}, []string) {
 	if est <= 0 {
 		return excluded, nil
 	}
@@ -917,7 +945,7 @@ func excludeContextOverflowModels(est, sigSavings, outputReserve int, excluded, 
 		if sigSavings > 0 && modelStripsAnthropicSignatures(model) {
 			needed -= sigSavings
 		}
-		cw := contextWindowForRequest(model)
+		cw := minContextWindowForModel(model, enabledProviders)
 		if needed <= cw {
 			continue
 		}
@@ -1790,7 +1818,7 @@ func (s *Service) writeCachedResponse(w http.ResponseWriter, resp cache.CachedRe
 	w.Header().Set(HeaderRouterDecision, decision.Reason)
 	w.Header().Set(HeaderRouterProvider, decision.Provider)
 	w.Header().Set(HeaderRouterModel, decision.Model)
-	w.Header().Set(HeaderRouterContextWindow, strconv.Itoa(contextWindowForRequest(decision.Model)))
+	w.Header().Set(HeaderRouterContextWindow, strconv.Itoa(contextWindowForRequest(decision.Model, decision.Provider)))
 	w.Header().Set(HeaderRouterCache, RouterCacheHit)
 	if resp.StatusCode != 0 && resp.StatusCode != http.StatusOK {
 		w.WriteHeader(resp.StatusCode)
@@ -2509,7 +2537,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// fit the largest eligible model BEFORE routing, so a genuinely huge
 	// session is compacted (à la Claude Code) instead of dead-ending in the
 	// scorer with no eligible provider. Mutates env; feats is recomputed after.
-	maxEligibleWindow := s.maxEligibleContextWindow(baseExcluded, env.SignatureTokenSavings())
+	maxEligibleWindow := s.maxEligibleContextWindow(baseExcluded, enabledProviders, env.SignatureTokenSavings())
 	var compRes compactionResult
 	if !agentShadowMode {
 		var compErr error
@@ -2532,7 +2560,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	}
 
 	overflowEstimate := env.ContextOverflowTokenEstimate()
-	excluded, ctxOverflowed := excludeContextOverflowModels(overflowEstimate, env.SignatureTokenSavings(), outputReserve, baseExcluded, s.availableModels)
+	excluded, ctxOverflowed := excludeContextOverflowModels(overflowEstimate, env.SignatureTokenSavings(), outputReserve, enabledProviders, baseExcluded, s.availableModels)
 	if len(ctxOverflowed) > 0 {
 		log.Info("context window pre-filter: excluded over-capacity models",
 			"overflow_token_estimate", overflowEstimate,
@@ -2573,7 +2601,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		CustomBindings:       s.customBindingsForRequest(ctx),
 		ExcludedModels:       excluded,
 		AllowedModels:        allowedModelsForRequest(ctx),
-		SafetyExcludedModels: s.safetyExcludedModels(env, outputReserve),
+		SafetyExcludedModels: s.safetyExcludedModels(env, outputReserve, enabledProviders),
 		PreferredModels:      s.preferredModelsForRequest(ctx),
 		RoutingKnobs:         routingKnobsForRequest(ctx),
 		ClusterArmOverrides:  clusterArmOverridesForRequest(ctx),
@@ -2770,7 +2798,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	w.Header().Set(HeaderRouterDecision, decision.Reason)
 	w.Header().Set(HeaderRouterProvider, decision.Provider)
 	w.Header().Set(HeaderRouterModel, decision.Model)
-	w.Header().Set(HeaderRouterContextWindow, strconv.Itoa(contextWindowForRequest(decision.Model)))
+	w.Header().Set(HeaderRouterContextWindow, strconv.Itoa(contextWindowForRequest(decision.Model, decision.Provider)))
 	if !agentShadowMode {
 		s.setFeedbackLinkHeader(ctx, w, installationID, externalID, requestID, auth.UserIDFrom(ctx))
 	}
@@ -4958,7 +4986,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// Codex passthrough bodies, which are forwarded verbatim.
 	var compResOAI compactionResult
 	if !responsesPassthrough {
-		maxEligibleWindowOAI := s.maxEligibleContextWindow(baseExcludedOAI, env.SignatureTokenSavings())
+		maxEligibleWindowOAI := s.maxEligibleContextWindow(baseExcludedOAI, enabledProviders, env.SignatureTokenSavings())
 		var compErrOAI error
 		compResOAI, compErrOAI = s.maybeCompact(ctx, env, turntype.DetectFromEnvelope(env, feats, subAgentHint), outputReserveOAI, maxEligibleWindowOAI, r.Header)
 		if compErrOAI != nil {
@@ -4979,7 +5007,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	}
 
 	overflowEstimateOAI := env.ContextOverflowTokenEstimate()
-	excludedOAI, ctxOverflowedOAI := excludeContextOverflowModels(overflowEstimateOAI, env.SignatureTokenSavings(), outputReserveOAI, baseExcludedOAI, s.availableModels)
+	excludedOAI, ctxOverflowedOAI := excludeContextOverflowModels(overflowEstimateOAI, env.SignatureTokenSavings(), outputReserveOAI, enabledProviders, baseExcludedOAI, s.availableModels)
 	if len(ctxOverflowedOAI) > 0 {
 		log.Info("context window pre-filter: excluded over-capacity models",
 			"overflow_token_estimate", overflowEstimateOAI,
@@ -5018,7 +5046,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		CustomBindings:       s.customBindingsForRequest(ctx),
 		ExcludedModels:       excludedOAI,
 		AllowedModels:        allowedModelsForRequest(ctx),
-		SafetyExcludedModels: s.safetyExcludedModels(env, outputReserveOAI),
+		SafetyExcludedModels: s.safetyExcludedModels(env, outputReserveOAI, enabledProviders),
 		PreferredModels:      s.preferredModelsForRequest(ctx),
 		RoutingKnobs:         routingKnobsForRequest(ctx),
 		ClusterArmOverrides:  clusterArmOverridesForRequest(ctx),
@@ -5075,7 +5103,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	w.Header().Set(HeaderRouterDecision, decision.Reason)
 	w.Header().Set(HeaderRouterProvider, decision.Provider)
 	w.Header().Set(HeaderRouterModel, decision.Model)
-	w.Header().Set(HeaderRouterContextWindow, strconv.Itoa(contextWindowForRequest(decision.Model)))
+	w.Header().Set(HeaderRouterContextWindow, strconv.Itoa(contextWindowForRequest(decision.Model, decision.Provider)))
 	s.setFeedbackLinkHeader(ctx, w, installationID, externalID, requestID, auth.UserIDFrom(ctx))
 
 	reqPricing := otel.Lookup(s.baselineFor(feats.Model))

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -903,7 +903,7 @@ func minContextWindowForModel(model string, enabledProviders map[string]struct{}
 		if _, enabled := enabledProviders[b.Provider]; !enabled {
 			continue
 		}
-		if w := catalog.ContextWindowForBinding(model, b.Provider); w < cw {
+		if w := contextWindowForRequest(model, b.Provider); w < cw {
 			cw = w
 		}
 	}

--- a/internal/proxy/sibling_failover.go
+++ b/internal/proxy/sibling_failover.go
@@ -32,11 +32,11 @@ func (s *Service) siblingFailoverDecision(ctx context.Context, failed router.Dec
 		if _, drop := excludedModels[id]; drop {
 			continue
 		}
-		if !siblingFitsContext(id, est, sigSavings, outputReserve) {
-			continue
-		}
 		provider, ok := siblingProvider(id, md.CandidateProviders, available)
 		if !ok {
+			continue
+		}
+		if !siblingFitsContext(id, provider, est, sigSavings, outputReserve) {
 			continue
 		}
 		candidate := siblingDecisionFor(failed, id, provider)
@@ -53,7 +53,7 @@ func (s *Service) siblingFailoverDecision(ctx context.Context, failed router.Dec
 }
 
 // siblingFitsContext mirrors excludeContextOverflowModels for one candidate.
-func siblingFitsContext(model string, est, sigSavings, outputReserve int) bool {
+func siblingFitsContext(model, provider string, est, sigSavings, outputReserve int) bool {
 	if est <= 0 {
 		return true
 	}
@@ -61,7 +61,7 @@ func siblingFitsContext(model string, est, sigSavings, outputReserve int) bool {
 	if sigSavings > 0 && modelStripsAnthropicSignatures(model) {
 		needed -= sigSavings
 	}
-	return needed <= contextWindowForRequest(model)
+	return needed <= contextWindowForRequest(model, provider)
 }
 
 // siblingCandidateOrder lists rescue candidates in policy-preference order,

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -792,7 +792,7 @@ func (s *Service) runTurnLoop(
 				pinTokenEstimate -= env.SignatureTokenSavings()
 			}
 			needed := pinTokenEstimate + outputReserveForPin
-			modelCW := contextWindowForRequest(pin.Model)
+			modelCW := contextWindowForRequest(pin.Model, pin.Provider)
 			if needed > modelCW {
 				log.Info("Session pin excluded by context-window pre-filter; falling through to scorer",
 					"pin_model", pin.Model,

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -265,7 +265,7 @@ func (s *Service) bypassToAnthropic(
 	w.Header().Set(HeaderRouterDecision, decision.Reason)
 	w.Header().Set(HeaderRouterProvider, decision.Provider)
 	w.Header().Set(HeaderRouterModel, decision.Model)
-	w.Header().Set(HeaderRouterContextWindow, strconv.Itoa(contextWindowForRequest(decision.Model)))
+	w.Header().Set(HeaderRouterContextWindow, strconv.Itoa(contextWindowForRequest(decision.Model, decision.Provider)))
 
 	p, provErr := s.provider(providers.ProviderAnthropic)
 	if provErr != nil {

--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -91,8 +91,7 @@ type ProviderBinding struct {
 	// Price is the per-provider pricing for this binding.
 	Price Pricing
 	// ContextWindow overrides the model-level ContextWindow for this binding.
-	// 0 means inherit the model-level value. Use when a model's served window
-	// differs by provider (e.g. Together serves 512K while Fireworks serves 1M).
+	// Zero means inherit. Use when the served window differs by provider.
 	ContextWindow int
 }
 

--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -90,6 +90,10 @@ type ProviderBinding struct {
 	UpstreamID string
 	// Price is the per-provider pricing for this binding.
 	Price Pricing
+	// ContextWindow overrides the model-level ContextWindow for this binding.
+	// 0 means inherit the model-level value. Use when a model's served window
+	// differs by provider (e.g. Together serves 512K while Fireworks serves 1M).
+	ContextWindow int
 }
 
 // ToolUseQuality marks a model's reliability under has_tools=true turns.
@@ -449,9 +453,9 @@ var Models = []Model{
 	// 0813 entry below, which is what AA actually benchmarks.
 	{ID: "deepseek/deepseek-v4-pro", ContextWindow: 1_048_576, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
 		// Together is primary: same $1.74/$3.48 as Fireworks with #1 AA
-		// throughput (~209 t/s vs ~120).
+		// throughput (~209 t/s vs ~120). Together serves only 512K context.
 		{Provider: providers.ProviderTogether, UpstreamID: "deepseek-ai/DeepSeek-V4-Pro",
-			Price: Pricing{InputUSDPer1M: 1.740, OutputUSDPer1M: 3.480, CacheReadMultiplier: 0.20 / 1.740}},
+			ContextWindow: 512_000, Price: Pricing{InputUSDPer1M: 1.740, OutputUSDPer1M: 3.480, CacheReadMultiplier: 0.20 / 1.740}},
 		{Provider: providers.ProviderFireworks, UpstreamID: "accounts/fireworks/models/deepseek-v4-pro",
 			Price: Pricing{InputUSDPer1M: 1.740, OutputUSDPer1M: 3.480, CacheReadMultiplier: 0.0862}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.435, OutputUSDPer1M: 0.870, CacheReadMultiplier: 0.10}},
@@ -462,9 +466,9 @@ var Models = []Model{
 	// above resolves to the retired 0423 build, so the HMM roster must target
 	// this dated ID to route to what it was actually ranked on.
 	{ID: "deepseek/deepseek-v4-pro-0813", Tier: TierMid, ContextWindow: 1_048_576, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
-		// Together first: higher throughput (~209 t/s vs Fireworks ~120) at equal price. Upstream IDs here track current 0813; the retired alias is the 0423 entry above.
+		// Together first: higher throughput (~209 t/s vs Fireworks ~120) at equal price. Together serves only 512K context.
 		{Provider: providers.ProviderTogether, UpstreamID: "deepseek-ai/DeepSeek-V4-Pro",
-			Price: Pricing{InputUSDPer1M: 1.740, OutputUSDPer1M: 3.480, CacheReadMultiplier: 0.20 / 1.740}},
+			ContextWindow: 512_000, Price: Pricing{InputUSDPer1M: 1.740, OutputUSDPer1M: 3.480, CacheReadMultiplier: 0.20 / 1.740}},
 		{Provider: providers.ProviderFireworks, UpstreamID: "accounts/fireworks/models/deepseek-v4-pro",
 			Price: Pricing{InputUSDPer1M: 1.740, OutputUSDPer1M: 3.480, CacheReadMultiplier: 0.0862}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.660, OutputUSDPer1M: 1.980, CacheReadMultiplier: 0.022 / 0.660}},

--- a/internal/router/catalog/lookup.go
+++ b/internal/router/catalog/lookup.go
@@ -283,10 +283,9 @@ func ContextWindowFor(id string) int {
 	return m.ContextWindow
 }
 
-// ContextWindowForBinding returns the context window served by the given
-// provider for the given model. A non-zero ProviderBinding.ContextWindow
-// overrides the model-level value; otherwise the model-level ContextWindow
-// applies. Returns DefaultContextWindow for an unknown model.
+// ContextWindowForBinding returns the context window for modelID on provider,
+// preferring a non-zero ProviderBinding.ContextWindow over the model-level value.
+// Returns DefaultContextWindow for an unknown model.
 func ContextWindowForBinding(modelID, provider string) int {
 	m, ok := ByID(modelID)
 	if !ok {

--- a/internal/router/catalog/lookup.go
+++ b/internal/router/catalog/lookup.go
@@ -283,6 +283,27 @@ func ContextWindowFor(id string) int {
 	return m.ContextWindow
 }
 
+// ContextWindowForBinding returns the context window served by the given
+// provider for the given model. A non-zero ProviderBinding.ContextWindow
+// overrides the model-level value; otherwise the model-level ContextWindow
+// applies. Returns DefaultContextWindow for an unknown model.
+func ContextWindowForBinding(modelID, provider string) int {
+	m, ok := ByID(modelID)
+	if !ok {
+		return DefaultContextWindow
+	}
+	cw := m.ContextWindow
+	if cw <= 0 {
+		cw = DefaultContextWindow
+	}
+	for _, b := range m.Providers {
+		if b.Provider == provider && b.ContextWindow > 0 {
+			return b.ContextWindow
+		}
+	}
+	return cw
+}
+
 // ToolUseLowSet returns model IDs with ToolUseLow quality. The cluster scorer
 // excludes these when req.HasTools, falling back to the unfiltered pool if
 // that would empty the eligible set.


### PR DESCRIPTION
## Problem

Session `9424eef5` hard-400'd on `deepseek/deepseek-v4-pro-0813` dispatched to Together. The router's pre-filter correctly estimated the request at 546K tokens (needed 610K with output reserve) but the catalog's model-level `ContextWindow: 1_048_576` let the model survive — only to hit Together's actual **512K** served window:

> This model's maximum context length is 512000 tokens, but the request requires 512356 tokens (448356 input including image/vision expansion + 64000 for the completion).

`failover_used: false` (context-overflow 400s aren't retried). The estimator worked; the **window was wrong.**

## Root cause

`ContextWindow` lives on `Model` (binding-agnostic), but the same model serves different windows on different providers. Together caps deepseek-v4-pro at 512K while Fireworks and OpenRouter serve the full 1M. The convention is "served window of primary binding" but there's no structural enforcement — the 0813 entry re-introduced 1M after a prior audit had corrected it.

**There's no per-provider context-window override anywhere in the catalog today.** This is the structural fix.

## Change

**Catalog** — `ProviderBinding.ContextWindow` field (zero = inherit model-level). New `ContextWindowForBinding(modelID, provider)` accessor. Together bindings on both `deepseek-v4-pro` and `deepseek-v4-pro-0813` → `512_000`.

**Proxy** — three-window-policy plumbing:

| Caller | Policy | Why |
|---|---|---|
| `excludeContextOverflowModels` (pre-filter) | **MIN** | Primary dispatches first; 512K primary must block even with 1M fallback |
| `maxEligibleContextWindow` (compaction) | **MAX** | Compaction decides when to SHRINK — a 1M fallback justifies holding off |
| Dispatch headers / pin re-eval / sibling fit | chosen provider | Provider already known; use its actual window |

- `contextWindowForRequest(modelID, provider...string)` — variadic, backward-compatible
- New `minContextWindowForModel` / `maxContextWindowForModel` helpers in proxy
- All header-emission sites (Anthropic, OAI, Gemini, usage-bypass, fallback) pass `decision.Provider`
- `sibling_failover.go`: resolve provider before fit check
- `safetyExcludedModels`: provider-aware (closes usage-bypass gap)
- `route_preview.go`: passes `enabledProviders`

**Tests** — `TestExcludeContextOverflowModels_MultiBindingMinWindow` validates all four combos. All existing tests pass with `nil` passthrough.

## Risk

Zero behavioral change unless a `ProviderBinding.ContextWindow` override exists. With the override, the only newly-excluded scenario is the fixed bug: Together-512K-primary deploys with requests between 512K–1M.

🤖 Generated with [Weave Router](https://router.workweave.ai)