### PR TITLE
fix(proxy): treat a same-model effort change as a model switch

### DIFF
--- a/internal/proxy/effort_switch_identity_internal_test.go
+++ b/internal/proxy/effort_switch_identity_internal_test.go
@@ -1,0 +1,99 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/sessionpin"
+)
+
+// An effort change on the SAME model rewrites the Anthropic prompt-cache prefix
+// and invalidates thinking-block signatures exactly like a model change does,
+// so it has to register as a switch. Before serving identities were compared,
+// both turns produced Decision.Model == "claude-opus-5" and the switch went
+// undetected — carrying stale signed thinking blocks into a 400.
+func TestModelSwitched_EffortChangeOnSameModelCountsAsSwitch(t *testing.T) {
+	res := turnLoopResult{
+		PriorServedModel: "claude-opus-5:low",
+		Decision:         router.Decision{Model: "claude-opus-5", Effort: "xhigh"},
+	}
+
+	assert.True(t, res.modelSwitched(),
+		"low -> xhigh on the same model must count as a switch")
+}
+
+func TestModelSwitched_SameModelAndEffortIsNotASwitch(t *testing.T) {
+	res := turnLoopResult{
+		PriorServedModel: "claude-opus-5:xhigh",
+		Decision:         router.Decision{Model: "claude-opus-5", Effort: "xhigh"},
+	}
+
+	assert.False(t, res.modelSwitched(),
+		"an unchanged model+effort must not report a switch")
+}
+
+// Pins written before effort existed hold a bare model ID. Comparing that to a
+// new "model:effort" identity reports a switch, which is the conservative
+// direction (strip stale blocks, lose one cache prefix) rather than the unsafe
+// one.
+func TestModelSwitched_LegacyBarePinReportsSwitchAgainstEffortIdentity(t *testing.T) {
+	res := turnLoopResult{
+		PriorServedModel: "claude-opus-5",
+		Decision:         router.Decision{Model: "claude-opus-5", Effort: "high"},
+	}
+
+	assert.True(t, res.modelSwitched(),
+		"a legacy bare pin must fail safe toward stripping")
+}
+
+func TestModelSwitched_NoEffortEitherSideBehavesAsBefore(t *testing.T) {
+	same := turnLoopResult{
+		PriorServedModel: "claude-opus-5",
+		Decision:         router.Decision{Model: "claude-opus-5"},
+	}
+	changed := turnLoopResult{
+		PriorServedModel: "claude-opus-5",
+		Decision:         router.Decision{Model: "gpt-5.6-sol"},
+	}
+
+	assert.False(t, same.modelSwitched(), "effort-free no-op must not switch")
+	assert.True(t, changed.modelSwitched(), "effort-free model change must switch")
+}
+
+func TestServedIdentity_FoldsEffortAndOmitsWhenAbsent(t *testing.T) {
+	assert.Equal(t, "claude-opus-5:xhigh",
+		router.Decision{Model: "claude-opus-5", Effort: "xhigh"}.ServedIdentity())
+	assert.Equal(t, "claude-opus-5",
+		router.Decision{Model: "claude-opus-5"}.ServedIdentity())
+}
+
+// ExcludedModels / SafetyExcludedModels are keyed on bare catalog IDs, so the
+// loop-breaker must strip effort off the pin's serving identity. Leaving it on
+// would make the exclusion silently never match, disabling loop-breaking for
+// every effort-carrying turn.
+func TestMaxedOutServedModel_StripsEffortSoExclusionMatches(t *testing.T) {
+	pin := sessionpin.Pin{
+		LastServedModel:  "claude-opus-5:xhigh",
+		LastOutputTokens: prevTurnMaxedOutThreshold,
+	}
+
+	assert.Equal(t, "claude-opus-5", maxedOutServedModel(pin),
+		"exclusion keys are bare catalog IDs")
+}
+
+func TestMaxedOutServedModel_BareIdentityUnchanged(t *testing.T) {
+	pin := sessionpin.Pin{
+		LastServedModel:  "claude-opus-5",
+		LastOutputTokens: prevTurnMaxedOutThreshold,
+	}
+
+	assert.Equal(t, "claude-opus-5", maxedOutServedModel(pin))
+}
+
+func TestBaseModelOf(t *testing.T) {
+	assert.Equal(t, "claude-opus-5", baseModelOf("claude-opus-5:xhigh"))
+	assert.Equal(t, "claude-opus-5", baseModelOf("claude-opus-5"))
+	assert.Equal(t, "", baseModelOf(""))
+}

--- a/internal/proxy/effort_switch_identity_internal_test.go
+++ b/internal/proxy/effort_switch_identity_internal_test.go
@@ -9,11 +9,8 @@ import (
 	"workweave/router/internal/router/sessionpin"
 )
 
-// An effort change on the SAME model rewrites the Anthropic prompt-cache prefix
-// and invalidates thinking-block signatures exactly like a model change does,
-// so it has to register as a switch. Before serving identities were compared,
-// both turns produced Decision.Model == "claude-opus-5" and the switch went
-// undetected — carrying stale signed thinking blocks into a 400.
+// An effort change on the same model invalidates thinking-block signatures
+// and the prompt-cache prefix exactly like a model change, so it must count as a switch.
 func TestModelSwitched_EffortChangeOnSameModelCountsAsSwitch(t *testing.T) {
 	res := turnLoopResult{
 		PriorServedModel: "claude-opus-5:low",
@@ -34,10 +31,8 @@ func TestModelSwitched_SameModelAndEffortIsNotASwitch(t *testing.T) {
 		"an unchanged model+effort must not report a switch")
 }
 
-// Pins written before effort existed hold a bare model ID. Comparing that to a
-// new "model:effort" identity reports a switch, which is the conservative
-// direction (strip stale blocks, lose one cache prefix) rather than the unsafe
-// one.
+// A bare legacy pin compared against a "model:effort" identity reports a switch — the
+// conservative direction — rather than the unsafe one.
 func TestModelSwitched_LegacyBarePinReportsSwitchAgainstEffortIdentity(t *testing.T) {
 	res := turnLoopResult{
 		PriorServedModel: "claude-opus-5",
@@ -69,10 +64,8 @@ func TestServedIdentity_FoldsEffortAndOmitsWhenAbsent(t *testing.T) {
 		router.Decision{Model: "claude-opus-5"}.ServedIdentity())
 }
 
-// ExcludedModels / SafetyExcludedModels are keyed on bare catalog IDs, so the
-// loop-breaker must strip effort off the pin's serving identity. Leaving it on
-// would make the exclusion silently never match, disabling loop-breaking for
-// every effort-carrying turn.
+// ExcludedModels / SafetyExcludedModels are keyed on bare catalog IDs;
+// leaving effort on would silently disable loop-breaking for effort-carrying turns.
 func TestMaxedOutServedModel_StripsEffortSoExclusionMatches(t *testing.T) {
 	pin := sessionpin.Pin{
 		LastServedModel:  "claude-opus-5:xhigh",

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -300,7 +300,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 
 	// Persist last-turn usage to the pin row so the next turn's planner
 	// has cache-hit evidence. Off the request path; drops on saturation.
-	s.recordTurnUsage(routeRes, finalProvider, decision.Model, in, out, cacheCreation, cacheRead)
+	s.recordTurnUsage(routeRes, finalProvider, decision.ServedIdentity(), in, out, cacheCreation, cacheRead)
 
 	if proxyErr == nil {
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -503,7 +503,7 @@ func routingMarkerFor(res turnLoopResult) string {
 	// for this turn" / "best pick for this turn" repeating each turn would
 	// otherwise be visible even when nothing switched. Hard-pin carve-outs and
 	// first-turn (empty prior) cases still flow to the sidecar marker below.
-	if res.PriorServedModel == res.Decision.Model {
+	if res.PriorServedModel == res.Decision.ServedIdentity() {
 		return ""
 	}
 	// A sidecar-supplied marker is a genuine per-turn status line (e.g.
@@ -579,7 +579,7 @@ func baselineRoutingMarkerFor(res turnLoopResult, baselineModel string) string {
 	}
 	// A failover that lands back on the model already serving is a no-op repeat;
 	// only a genuine switch to a different model is worth surfacing.
-	if res.PriorServedModel == baselineModel {
+	if baseModelOf(res.PriorServedModel) == baselineModel {
 		return ""
 	}
 	return "✦ **Weave Router** → " + baselineModel + " · " + markerReasonBaseline + "\n\n"
@@ -588,7 +588,7 @@ func baselineRoutingMarkerFor(res turnLoopResult, baselineModel string) string {
 // siblingRoutingMarkerFor renders the routing badge for an in-turn same-cluster
 // failover, naming the candidate that actually serves.
 func siblingRoutingMarkerFor(res turnLoopResult, siblingModel string) string {
-	if res.SuggestionMode || siblingModel == "" || res.PriorServedModel == siblingModel {
+	if res.SuggestionMode || siblingModel == "" || baseModelOf(res.PriorServedModel) == siblingModel {
 		return ""
 	}
 	return "✦ **Weave Router** → " + siblingModel + " · " + markerReasonSibling + "\n\n"
@@ -3249,8 +3249,12 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		baselineOpts.Capabilities = router.Lookup(baselineModel)
 		// Recompute against the model that actually serves, not the cost-routed
 		// OSS id — otherwise PrepareAnthropic may leave stale signed thinking
-		// blocks the baseline model rejects (400).
-		baselineOpts.ModelSwitched = routeRes.PriorServedModel != baselineModel || routeRes.SessionEverSwitched
+		// blocks the baseline model rejects (400). Compare bare model IDs:
+		// baselineModel carries no effort, and any effort on the prior identity
+		// belonged to a different model, so the model comparison already
+		// subsumes it.
+		baselineOpts.ModelSwitched = baseModelOf(routeRes.PriorServedModel) != baselineModel ||
+			routeRes.SessionEverSwitched
 		if knobs := routingKnobsForRequest(ctx); knobs != nil && knobs.ForceEffort != "" {
 			baselineOpts.ForceEffort = knobs.ForceEffort
 			baselineOpts.ForceReasoningEffort = translate.ResolveForceEffort(baselineOpts.Capabilities, knobs.ForceEffort)
@@ -3542,7 +3546,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	otel.Flush(ctx)
 
 	if !agentShadowMode {
-		s.recordTurnUsage(routeRes, finalProvider, decision.Model, in, out, cacheCreation, cacheRead)
+		s.recordTurnUsage(routeRes, finalProvider, decision.ServedIdentity(), in, out, cacheCreation, cacheRead)
 	}
 
 	// Eval rows must not enter serving telemetry; they would corrupt offline policy analysis.
@@ -5530,7 +5534,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		emitCallLog()
 	}
 
-	s.recordTurnUsage(routeRes, finalProvider, decision.Model, in, out, cacheCreation, cacheRead)
+	s.recordTurnUsage(routeRes, finalProvider, decision.ServedIdentity(), in, out, cacheCreation, cacheRead)
 
 	if proxyErr == nil {
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -203,10 +203,8 @@ type turnLoopResult struct {
 // turn, so stale-signed blocks from an earlier cross-model excursion would
 // otherwise 400 with "Invalid signature in thinking block" on every later turn.
 func (r turnLoopResult) modelSwitched() bool {
-	// Compare serving identities, not bare model IDs: a same-model effort
-	// change (opus-5:low -> opus-5:xhigh) rewrites the Anthropic prompt-cache
-	// prefix and invalidates thinking-block signatures exactly like a model
-	// change does, so it has to count as a switch.
+	// Compare serving identities: a same-model effort change reshapes the
+	// prompt-cache prefix and invalidates thinking-block signatures.
 	transition := r.PriorServedModel != "" && r.PriorServedModel != r.Decision.ServedIdentity()
 	return transition || r.SessionEverSwitched || r.StripThinkingBlocks
 }
@@ -1451,12 +1449,9 @@ func maxedOutServedModel(pin sessionpin.Pin) string {
 	if model == "" {
 		model = pin.Model
 	}
-	// LastServedModel is a serving identity ("model:effort" once the policy
-	// selects effort), but ExcludedModels / SafetyExcludedModels are keyed on
-	// bare catalog IDs. Strip the effort so the exclusion actually matches;
-	// leaving it on would silently disable loop-breaking for effort-carrying
-	// turns. Exclusion stays model-level on purpose: a model that saturated the
-	// output ceiling is barred at every effort for this turn.
+	// ExcludedModels / SafetyExcludedModels key on bare catalog IDs; strip effort
+	// so the exclusion matches. Exclusion is model-level: saturate at any effort
+	// and the model is barred at every effort for this turn.
 	return baseModelOf(model)
 }
 

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -203,7 +203,11 @@ type turnLoopResult struct {
 // turn, so stale-signed blocks from an earlier cross-model excursion would
 // otherwise 400 with "Invalid signature in thinking block" on every later turn.
 func (r turnLoopResult) modelSwitched() bool {
-	transition := r.PriorServedModel != "" && r.PriorServedModel != r.Decision.Model
+	// Compare serving identities, not bare model IDs: a same-model effort
+	// change (opus-5:low -> opus-5:xhigh) rewrites the Anthropic prompt-cache
+	// prefix and invalidates thinking-block signatures exactly like a model
+	// change does, so it has to count as a switch.
+	transition := r.PriorServedModel != "" && r.PriorServedModel != r.Decision.ServedIdentity()
 	return transition || r.SessionEverSwitched || r.StripThinkingBlocks
 }
 
@@ -1447,7 +1451,22 @@ func maxedOutServedModel(pin sessionpin.Pin) string {
 	if model == "" {
 		model = pin.Model
 	}
-	return model
+	// LastServedModel is a serving identity ("model:effort" once the policy
+	// selects effort), but ExcludedModels / SafetyExcludedModels are keyed on
+	// bare catalog IDs. Strip the effort so the exclusion actually matches;
+	// leaving it on would silently disable loop-breaking for effort-carrying
+	// turns. Exclusion stays model-level on purpose: a model that saturated the
+	// output ceiling is barred at every effort for this turn.
+	return baseModelOf(model)
+}
+
+// baseModelOf strips a trailing ":effort" from a serving identity, returning the
+// bare catalog ID. Safe on inputs that carry no effort.
+func baseModelOf(servedIdentity string) string {
+	if idx := strings.LastIndex(servedIdentity, ":"); idx > 0 {
+		return servedIdentity[:idx]
+	}
+	return servedIdentity
 }
 
 // roleForTier maps a requested-model tier to its session-pin role. Each tier

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -238,9 +238,37 @@ const (
 type Decision struct {
 	Provider string
 	Model    string
-	Reason   string
+	// Effort is the canonical reasoning-effort level the policy selected for
+	// this turn ("low".."xhigh"), empty when the policy expressed no
+	// preference. Model stays a bare catalog ID so catalog.ByID lookups for
+	// pricing, context window, and capabilities keep working; effort travels
+	// alongside it and is applied by the emit path via EmitOptions.ForceEffort.
+	//
+	// Effort participates in serving identity: ServedIdentity() folds it into
+	// the string the session pin compares across turns, so an effort-only
+	// change is treated as a model switch (thinking-block signatures are only
+	// valid for the exact model+effort that produced them, and effort reshapes
+	// the Anthropic prompt-cache prefix).
+	Effort string
+	Reason string
 	// Nil for non-content-aware routers; nil-check before dereferencing.
 	Metadata *RoutingMetadata
+}
+
+// ServedIdentity returns the model identity to persist and compare across
+// turns: the bare model when no effort was selected, else "model:effort".
+//
+// This is the value session pins store as LastServedModel. Comparing identities
+// rather than bare model IDs is what makes an effort-only change register as a
+// switch. Pins written before effort existed hold a bare ID, so the first turn
+// after rollout compares "m" against "m:high" and reports a switch — the
+// conservative direction (strip stale thinking blocks, lose one cache prefix)
+// rather than the unsafe one.
+func (d Decision) ServedIdentity() string {
+	if d.Effort == "" {
+		return d.Model
+	}
+	return d.Model + ":" + d.Effort
 }
 
 // RoutingMetadata lets downstream components reuse the embedding and

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -238,17 +238,12 @@ const (
 type Decision struct {
 	Provider string
 	Model    string
-	// Effort is the canonical reasoning-effort level the policy selected for
-	// this turn ("low".."xhigh"), empty when the policy expressed no
-	// preference. Model stays a bare catalog ID so catalog.ByID lookups for
-	// pricing, context window, and capabilities keep working; effort travels
-	// alongside it and is applied by the emit path via EmitOptions.ForceEffort.
-	//
-	// Effort participates in serving identity: ServedIdentity() folds it into
-	// the string the session pin compares across turns, so an effort-only
-	// change is treated as a model switch (thinking-block signatures are only
-	// valid for the exact model+effort that produced them, and effort reshapes
-	// the Anthropic prompt-cache prefix).
+	// Effort is the canonical reasoning-effort level selected for this turn
+	// ("low".."xhigh"), empty when the policy expressed no preference. Model
+	// stays a bare catalog ID so catalog.ByID lookups keep working; effort is
+	// applied by the emit path via EmitOptions.ForceEffort. An effort-only
+	// change registers as a model switch via ServedIdentity() because it
+	// invalidates thinking-block signatures and the prompt-cache prefix.
 	Effort string
 	Reason string
 	// Nil for non-content-aware routers; nil-check before dereferencing.
@@ -257,13 +252,8 @@ type Decision struct {
 
 // ServedIdentity returns the model identity to persist and compare across
 // turns: the bare model when no effort was selected, else "model:effort".
-//
-// This is the value session pins store as LastServedModel. Comparing identities
-// rather than bare model IDs is what makes an effort-only change register as a
-// switch. Pins written before effort existed hold a bare ID, so the first turn
-// after rollout compares "m" against "m:high" and reports a switch — the
-// conservative direction (strip stale thinking blocks, lose one cache prefix)
-// rather than the unsafe one.
+// Pins written before effort existed hold a bare ID, so the first post-rollout
+// turn compares "m" against "m:high" and reports a switch — conservative, not unsafe.
 func (d Decision) ServedIdentity() string {
 	if d.Effort == "" {
 		return d.Model


### PR DESCRIPTION
## Summary

Thinking-block signatures are only valid for the exact model **and effort** that produced them, and Anthropic's `output_config.effort` reshapes the rendered prompt — so it also invalidates the prompt-cache prefix. Comparing bare model IDs across turns missed this entirely.

Today an `opus-5:low` → `opus-5:xhigh` change leaves `Decision.Model` equal on both turns, so `modelSwitched()` returns `false`, stale signed thinking blocks are carried over, and the upstream 400s with `Invalid signature in thinking block` — or silently serves against a dead cache prefix.

This adds `Decision.Effort` + `Decision.ServedIdentity()` and persists/compares the **serving identity** (`"model:effort"`, bare when no effort was selected) instead of the bare model. `modelSwitched()` and the `HasEverSwitched` latch then inherit the behavior with no further change.

`Decision.Model` stays a bare catalog ID, so every `catalog.ByID` lookup for pricing, context window, and capabilities keeps working.

## Two boundaries need the effort stripped back off

Both key on bare catalog IDs, so leaving the effort on would break them:

- **`maxedOutServedModel`** feeds `ExcludedModels`/`SafetyExcludedModels`. With the effort left on, the exclusion would never match — silently disabling **loop-breaking** for every effort-carrying turn, letting the router re-pin a model that just saturated the output ceiling. Exclusion stays model-level on purpose: saturate the ceiling at any effort and you're barred at every effort for that turn.
- **baseline/sibling routing markers and the baseline shadow `ModelSwitched`** compare against bare locals (`baselineModel`, `siblingModel`). Any effort on the prior identity belonged to a *different* model there, so the model comparison already subsumes it.

The main routing marker (`routingMarkerFor`) is the opposite case — it compares against the decision itself, so it uses the full identity. An effort change *is* worth surfacing.

## Backward compatibility

Pins written before effort existed hold a bare ID, so the first turn after rollout compares `"m"` against `"m:high"` and reports a switch — the conservative direction (strip blocks, lose one cache prefix), never the unsafe one.

## Blast radius: none yet

`Decision.Effort` has **no producer** — nothing sets it, so `ServedIdentity()` returns the bare model everywhere and behavior is byte-identical today. This deliberately lands the switch contract *ahead* of the effort-aware roster work, so effort can never be introduced without cache eviction already being correct.

## Testing

- `go build`, `go vet` clean
- **49/49 packages pass**
- 8 new tests in `internal/proxy/effort_switch_identity_internal_test.go`:
  - effort-only change on the same model counts as a switch
  - unchanged model+effort does not
  - legacy bare pin fails safe toward stripping
  - effort-free behavior unchanged (both the no-op and the genuine model change)
  - `ServedIdentity()` folds effort and omits it when absent
  - `maxedOutServedModel` strips effort so the exclusion still matches

🤖 Generated with [Weave Router](https://router.workweave.ai)