### PR TITLE
feat(hmm): Phase 3b — within-cluster effort hysteresis

### DIFF
--- a/internal/proxy/hysteresis.go
+++ b/internal/proxy/hysteresis.go
@@ -1,0 +1,53 @@
+package proxy
+
+import (
+	"strings"
+
+	"workweave/router/internal/router"
+)
+
+// effortHysteresisThreshold is the minimum WMI-score gap required for an
+// effort-only change on the same base model within the same cluster.
+// Below this, the incumbent is held to avoid cache-prefix invalidation
+// and thinking-block thrash from noise.
+const effortHysteresisThreshold = 1.0
+
+// applyEffortHysteresis decides whether to keep the incumbent effort or switch
+// to the challenger. Both are same-cluster arms the sidecar ranked within the
+// same complexity bucket, so their scores (wmi_low/wmi_medium/wmi_high/wmi_max)
+// are comparable.
+//
+// Returns true when hysteresis passed (switch is allowed or N/A).
+func applyEffortHysteresis(prev router.Decision, fresh router.Decision) bool {
+	if fresh.Metadata == nil || fresh.Metadata.ArmScores == nil {
+		return true
+	}
+	if fresh.Metadata.PolicyGroup == "" || prev.Metadata == nil || prev.Metadata.PolicyGroup == "" {
+		return true
+	}
+	if fresh.Metadata.PolicyGroup != prev.Metadata.PolicyGroup {
+		return true
+	}
+	incumbentID := prev.ServedIdentity()
+	if incumbentID == fresh.ServedIdentity() {
+		return true
+	}
+	incumbentBase, _ := splitModelEffort(incumbentID)
+	challengerBase, _ := splitModelEffort(fresh.ServedIdentity())
+	if incumbentBase == "" || incumbentBase != challengerBase {
+		return true
+	}
+	incumbentScore := fresh.Metadata.ArmScores[prev.ServedIdentity()]
+	challengerScore := fresh.Metadata.ArmScores[fresh.ServedIdentity()]
+	if incumbentScore == 0 && challengerScore == 0 {
+		return true
+	}
+	return challengerScore-incumbentScore >= effortHysteresisThreshold
+}
+
+func splitModelEffort(servedIdentity string) (string, string) {
+	if idx := strings.LastIndex(servedIdentity, ":"); idx > 0 {
+		return servedIdentity[:idx], servedIdentity[idx+1:]
+	}
+	return servedIdentity, ""
+}

--- a/internal/proxy/hysteresis.go
+++ b/internal/proxy/hysteresis.go
@@ -1,8 +1,6 @@
 package proxy
 
 import (
-	"strings"
-
 	"workweave/router/internal/router"
 )
 
@@ -10,122 +8,50 @@ import (
 // effort-only change on the same base model within the same cluster.
 const effortHysteresisThreshold = 1.0
 
-// incumbentEffortForHold returns the effort level the previous turn served,
-// adapting the bare "model" in LastServedModel (pre-effort pins) to "" so
-// the gap test below doesn't hold an old bare pin against a new effort arm.
-func incumbentEffortForHold(prevServedModel string) string {
-	if idx := strings.LastIndex(prevServedModel, ":"); idx > 0 {
-		return prevServedModel[idx+1:]
-	}
-	return ""
-}
+// effortHysteresisReason tags the planner reason of a held turn so a bake-off
+// can separate held turns from clean stays.
+const effortHysteresisReason = "effort_hysteresis"
 
-// challengerEffortForHold extracts the effort the fresh decision would serve.
-func challengerEffortForHold(decisionEffort string, selectedArmID string) string {
-	if decisionEffort != "" {
-		return decisionEffort
-	}
-	if idx := strings.LastIndex(selectedArmID, ":"); idx > 0 {
-		return selectedArmID[idx+1:]
-	}
-	return ""
-}
-
-// effortHysteresisHold decides whether to keep the incumbent effort.  The
-// guard fires when: the fresh pick is the same base model served last turn,
-// both turns carry an effort level, and the challenger's WMI gain is below
-// the threshold.
-//
-// Scores are keyed by roster arm ID ("anthropic/claude-opus-5:xhigh"), which
-// is what the sidecar reports.  The challenger's score comes from
-// freshMetadata.ArmScores (the current-turn sidecar response).  The
-// incumbent's score is found by searching the same map for a key matching
-// the base model + previous effort.
-//
-// Returns the effort to serve: challenger if switch is allowed, incumbent
-// if held.  Returns challenger unchanged when data is absent (pass-through).
-func effortHysteresisHold(
-	freshMetadata *router.RoutingMetadata,
-	prevServedModel string,
-	chosenEffort string,
-) string {
-	if freshMetadata == nil || freshMetadata.ArmScores == nil {
+// effortHysteresisHold returns the incumbent effort to keep serving, or "" to
+// let the challenger through. Both sides are looked up in the sidecar's
+// per-arm WMI map, which is keyed by effort-qualified roster arm ID
+// ("anthropic/claude-opus-5:xhigh") rather than by catalog serving identity.
+func effortHysteresisHold(fresh router.Decision, prevServedModel, chosenModel, chosenEffort string) string {
+	if fresh.Metadata == nil || len(fresh.Metadata.ArmScores) == 0 {
 		return ""
 	}
-	incumbentEffort := incumbentEffortForHold(prevServedModel)
-	if incumbentEffort == "" {
+	incumbentEffort, incumbentModel := stripEffortSuffix(prevServedModel)
+	if incumbentEffort == "" || chosenEffort == "" || incumbentEffort == chosenEffort {
 		return ""
 	}
-	challengerEffort := challengerEffortForHold(chosenEffort, freshMetadata.SelectedArmID)
-	if challengerEffort == "" || incumbentEffort == challengerEffort {
-		return challengerEffort
+	// Cross-model moves are the planner's call, and a stay can serve a model
+	// the fresh arm scores don't describe.
+	if chosenModel != incumbentModel || fresh.Model != incumbentModel {
+		return ""
 	}
-	if !sameBaseArmID(freshMetadata.SelectedArmID, prevServedModel) {
-		return challengerEffort
+	_, armBase := stripEffortSuffix(fresh.Metadata.SelectedRosterArmID)
+	if armBase == "" {
+		return ""
 	}
-	challengerScore := freshMetadata.ArmScores[freshMetadata.SelectedArmID]
-	if challengerScore == 0 {
-		return challengerEffort
+	challengerScore, ok := fresh.Metadata.ArmScores[armBase+":"+chosenEffort]
+	if !ok {
+		return ""
 	}
-	incumbentScore := findArmScore(freshMetadata.ArmScores, prevServedModel, incumbentEffort)
-	if incumbentScore == 0 {
-		return challengerEffort
+	incumbentScore, ok := fresh.Metadata.ArmScores[armBase+":"+incumbentEffort]
+	if !ok {
+		return ""
 	}
 	if challengerScore-incumbentScore >= effortHysteresisThreshold {
-		return challengerEffort
+		return ""
 	}
 	return incumbentEffort
 }
 
-// sameBaseArmID reports whether the two identities share a base model by
-// matching prefixes up to the last ":" in each.
-func sameBaseArmID(rosterArmID, catalogServedIdentity string) bool {
-	baseA, _, _ := splitArmID(rosterArmID)
-	baseB, _, _ := splitArmID(catalogServedIdentity)
-	return baseA != "" && baseB != "" && baseA == baseB
-}
-
-func splitArmID(id string) (base, provider, model string) {
-	if idx := len(id) - 1; idx > 0 {
-		for ; idx > 0; idx-- {
-			if id[idx] == ':' {
-				pref := strings.LastIndex(id[:idx], "/")
-				if pref > 0 {
-					return id[:idx], id[:pref], id[pref+1 : idx]
-				}
-				return id[:idx], "", id[:idx]
-			}
-		}
+// appendEffortHysteresisReason marks a planner reason as effort-held. The
+// planner's own verdict is preserved because it still explains the model.
+func appendEffortHysteresisReason(reason string) string {
+	if reason == "" {
+		return effortHysteresisReason
 	}
-	return id, "", ""
-}
-
-// findArmScore looks up the score for a model:effort combination in the
-// sidecar's score map.  Tries exact match first, then prefix match on the
-// bare model (e.g. "claude-opus-5:low" matches "anthropic/claude-opus-5:low").
-func findArmScore(scores map[string]float32, servedIdentity string, effort string) float32 {
-	exactKey := servedIdentity
-	if !strings.Contains(servedIdentity, "/") {
-		exactKey = strings.TrimPrefix(servedIdentity, "")
-	}
-	if s, ok := scores[exactKey]; ok && s != 0 {
-		return s
-	}
-	suffix := "/" + extractModel(servedIdentity) + ":" + effort
-	for key, s := range scores {
-		if strings.HasSuffix(key, suffix) && s != 0 {
-			return s
-		}
-	}
-	return 0
-}
-
-func extractModel(servedIdentity string) string {
-	if idx := strings.Index(servedIdentity, ":"); idx > 0 {
-		return servedIdentity[:idx]
-	}
-	if idx := strings.LastIndex(servedIdentity, "/"); idx > 0 {
-		return servedIdentity[idx+1:]
-	}
-	return servedIdentity
+	return reason + "+" + effortHysteresisReason
 }

--- a/internal/proxy/hysteresis.go
+++ b/internal/proxy/hysteresis.go
@@ -8,46 +8,124 @@ import (
 
 // effortHysteresisThreshold is the minimum WMI-score gap required for an
 // effort-only change on the same base model within the same cluster.
-// Below this, the incumbent is held to avoid cache-prefix invalidation
-// and thinking-block thrash from noise.
 const effortHysteresisThreshold = 1.0
 
-// applyEffortHysteresis decides whether to keep the incumbent effort or switch
-// to the challenger. Both are same-cluster arms the sidecar ranked within the
-// same complexity bucket, so their scores (wmi_low/wmi_medium/wmi_high/wmi_max)
-// are comparable.
-//
-// Returns true when hysteresis passed (switch is allowed or N/A).
-func applyEffortHysteresis(prev router.Decision, fresh router.Decision) bool {
-	if fresh.Metadata == nil || fresh.Metadata.ArmScores == nil {
-		return true
+// incumbentEffortForHold returns the effort level the previous turn served,
+// adapting the bare "model" in LastServedModel (pre-effort pins) to "" so
+// the gap test below doesn't hold an old bare pin against a new effort arm.
+func incumbentEffortForHold(prevServedModel string) string {
+	if idx := strings.LastIndex(prevServedModel, ":"); idx > 0 {
+		return prevServedModel[idx+1:]
 	}
-	if fresh.Metadata.PolicyGroup == "" || prev.Metadata == nil || prev.Metadata.PolicyGroup == "" {
-		return true
-	}
-	if fresh.Metadata.PolicyGroup != prev.Metadata.PolicyGroup {
-		return true
-	}
-	incumbentID := prev.ServedIdentity()
-	if incumbentID == fresh.ServedIdentity() {
-		return true
-	}
-	incumbentBase, _ := splitModelEffort(incumbentID)
-	challengerBase, _ := splitModelEffort(fresh.ServedIdentity())
-	if incumbentBase == "" || incumbentBase != challengerBase {
-		return true
-	}
-	incumbentScore := fresh.Metadata.ArmScores[prev.ServedIdentity()]
-	challengerScore := fresh.Metadata.ArmScores[fresh.ServedIdentity()]
-	if incumbentScore == 0 && challengerScore == 0 {
-		return true
-	}
-	return challengerScore-incumbentScore >= effortHysteresisThreshold
+	return ""
 }
 
-func splitModelEffort(servedIdentity string) (string, string) {
-	if idx := strings.LastIndex(servedIdentity, ":"); idx > 0 {
-		return servedIdentity[:idx], servedIdentity[idx+1:]
+// challengerEffortForHold extracts the effort the fresh decision would serve.
+func challengerEffortForHold(decisionEffort string, selectedArmID string) string {
+	if decisionEffort != "" {
+		return decisionEffort
 	}
-	return servedIdentity, ""
+	if idx := strings.LastIndex(selectedArmID, ":"); idx > 0 {
+		return selectedArmID[idx+1:]
+	}
+	return ""
+}
+
+// effortHysteresisHold decides whether to keep the incumbent effort.  The
+// guard fires when: the fresh pick is the same base model served last turn,
+// both turns carry an effort level, and the challenger's WMI gain is below
+// the threshold.
+//
+// Scores are keyed by roster arm ID ("anthropic/claude-opus-5:xhigh"), which
+// is what the sidecar reports.  The challenger's score comes from
+// freshMetadata.ArmScores (the current-turn sidecar response).  The
+// incumbent's score is found by searching the same map for a key matching
+// the base model + previous effort.
+//
+// Returns the effort to serve: challenger if switch is allowed, incumbent
+// if held.  Returns challenger unchanged when data is absent (pass-through).
+func effortHysteresisHold(
+	freshMetadata *router.RoutingMetadata,
+	prevServedModel string,
+	chosenEffort string,
+) string {
+	if freshMetadata == nil || freshMetadata.ArmScores == nil {
+		return ""
+	}
+	incumbentEffort := incumbentEffortForHold(prevServedModel)
+	if incumbentEffort == "" {
+		return ""
+	}
+	challengerEffort := challengerEffortForHold(chosenEffort, freshMetadata.SelectedArmID)
+	if challengerEffort == "" || incumbentEffort == challengerEffort {
+		return challengerEffort
+	}
+	if !sameBaseArmID(freshMetadata.SelectedArmID, prevServedModel) {
+		return challengerEffort
+	}
+	challengerScore := freshMetadata.ArmScores[freshMetadata.SelectedArmID]
+	if challengerScore == 0 {
+		return challengerEffort
+	}
+	incumbentScore := findArmScore(freshMetadata.ArmScores, prevServedModel, incumbentEffort)
+	if incumbentScore == 0 {
+		return challengerEffort
+	}
+	if challengerScore-incumbentScore >= effortHysteresisThreshold {
+		return challengerEffort
+	}
+	return incumbentEffort
+}
+
+// sameBaseArmID reports whether the two identities share a base model by
+// matching prefixes up to the last ":" in each.
+func sameBaseArmID(rosterArmID, catalogServedIdentity string) bool {
+	baseA, _, _ := splitArmID(rosterArmID)
+	baseB, _, _ := splitArmID(catalogServedIdentity)
+	return baseA != "" && baseB != "" && baseA == baseB
+}
+
+func splitArmID(id string) (base, provider, model string) {
+	if idx := len(id) - 1; idx > 0 {
+		for ; idx > 0; idx-- {
+			if id[idx] == ':' {
+				pref := strings.LastIndex(id[:idx], "/")
+				if pref > 0 {
+					return id[:idx], id[:pref], id[pref+1 : idx]
+				}
+				return id[:idx], "", id[:idx]
+			}
+		}
+	}
+	return id, "", ""
+}
+
+// findArmScore looks up the score for a model:effort combination in the
+// sidecar's score map.  Tries exact match first, then prefix match on the
+// bare model (e.g. "claude-opus-5:low" matches "anthropic/claude-opus-5:low").
+func findArmScore(scores map[string]float32, servedIdentity string, effort string) float32 {
+	exactKey := servedIdentity
+	if !strings.Contains(servedIdentity, "/") {
+		exactKey = strings.TrimPrefix(servedIdentity, "")
+	}
+	if s, ok := scores[exactKey]; ok && s != 0 {
+		return s
+	}
+	suffix := "/" + extractModel(servedIdentity) + ":" + effort
+	for key, s := range scores {
+		if strings.HasSuffix(key, suffix) && s != 0 {
+			return s
+		}
+	}
+	return 0
+}
+
+func extractModel(servedIdentity string) string {
+	if idx := strings.Index(servedIdentity, ":"); idx > 0 {
+		return servedIdentity[:idx]
+	}
+	if idx := strings.LastIndex(servedIdentity, "/"); idx > 0 {
+		return servedIdentity[idx+1:]
+	}
+	return servedIdentity
 }

--- a/internal/proxy/hysteresis.go
+++ b/internal/proxy/hysteresis.go
@@ -6,18 +6,12 @@ import (
 	"workweave/router/internal/router"
 )
 
-// effortHysteresisThreshold is the minimum WMI-score gap required for an
-// effort-only change on the same base model within the same cluster.
-// Below this, the incumbent is held to avoid cache-prefix invalidation
-// and thinking-block thrash from noise.
+// effortHysteresisThreshold is the minimum WMI-score gap to hold the incumbent
+// effort, avoiding cache-prefix invalidation and thinking-block thrash.
 const effortHysteresisThreshold = 1.0
 
-// applyEffortHysteresis decides whether to keep the incumbent effort or switch
-// to the challenger. Both are same-cluster arms the sidecar ranked within the
-// same complexity bucket, so their scores (wmi_low/wmi_medium/wmi_high/wmi_max)
-// are comparable.
-//
-// Returns true when hysteresis passed (switch is allowed or N/A).
+// applyEffortHysteresis returns true when the effort switch is allowed (or N/A).
+// Same-cluster arm scores are on a shared scale, so a gap below the threshold holds the incumbent.
 func applyEffortHysteresis(prev router.Decision, fresh router.Decision) bool {
 	if fresh.Metadata == nil || fresh.Metadata.ArmScores == nil {
 		return true

--- a/internal/proxy/hysteresis_internal_test.go
+++ b/internal/proxy/hysteresis_internal_test.go
@@ -1,0 +1,129 @@
+package proxy
+
+import (
+	"testing"
+
+	"workweave/router/internal/router"
+)
+
+func hysteresisDecision(model string, armScores map[string]float32) router.Decision {
+	return router.Decision{
+		Model: model,
+		Metadata: &router.RoutingMetadata{
+			SelectedRosterArmID: "anthropic/" + model + ":high",
+			ArmScores:           armScores,
+		},
+	}
+}
+
+func TestEffortHysteresisHoldsSmallGapOnSameModel(t *testing.T) {
+	fresh := hysteresisDecision("claude-opus-5", map[string]float32{
+		"anthropic/claude-opus-5:low":  4.0,
+		"anthropic/claude-opus-5:high": 4.5,
+	})
+
+	got := effortHysteresisHold(fresh, "claude-opus-5:low", "claude-opus-5", "high")
+
+	if got != "low" {
+		t.Fatalf("expected incumbent effort held, got %q", got)
+	}
+}
+
+func TestEffortHysteresisAllowsGapAboveThreshold(t *testing.T) {
+	fresh := hysteresisDecision("claude-opus-5", map[string]float32{
+		"anthropic/claude-opus-5:low":  4.0,
+		"anthropic/claude-opus-5:high": 6.0,
+	})
+
+	got := effortHysteresisHold(fresh, "claude-opus-5:low", "claude-opus-5", "high")
+
+	if got != "" {
+		t.Fatalf("expected switch allowed, got %q", got)
+	}
+}
+
+func TestEffortHysteresisAllowsCrossModelSwitch(t *testing.T) {
+	fresh := hysteresisDecision("claude-opus-5", map[string]float32{
+		"anthropic/claude-opus-5:low":  4.0,
+		"anthropic/claude-opus-5:high": 4.5,
+	})
+
+	got := effortHysteresisHold(fresh, "claude-fable-5:low", "claude-opus-5", "high")
+
+	if got != "" {
+		t.Fatalf("expected cross-model switch allowed, got %q", got)
+	}
+}
+
+func TestEffortHysteresisAllowsStayOnModelTheFreshArmDoesNotDescribe(t *testing.T) {
+	fresh := hysteresisDecision("claude-opus-5", map[string]float32{
+		"anthropic/claude-opus-5:low":  4.0,
+		"anthropic/claude-opus-5:high": 4.5,
+	})
+
+	got := effortHysteresisHold(fresh, "claude-fable-5:low", "claude-fable-5", "high")
+
+	if got != "" {
+		t.Fatalf("expected pass-through when the stay model differs from the scored arm, got %q", got)
+	}
+}
+
+func TestEffortHysteresisPassesThroughWithoutArmScores(t *testing.T) {
+	fresh := hysteresisDecision("claude-opus-5", nil)
+
+	got := effortHysteresisHold(fresh, "claude-opus-5:low", "claude-opus-5", "high")
+
+	if got != "" {
+		t.Fatalf("expected pass-through on a pre-B1 sidecar, got %q", got)
+	}
+}
+
+func TestEffortHysteresisPassesThroughOnBarePin(t *testing.T) {
+	fresh := hysteresisDecision("claude-opus-5", map[string]float32{
+		"anthropic/claude-opus-5:low":  4.0,
+		"anthropic/claude-opus-5:high": 4.5,
+	})
+
+	got := effortHysteresisHold(fresh, "claude-opus-5", "claude-opus-5", "high")
+
+	if got != "" {
+		t.Fatalf("expected pre-effort bare pin to pass through, got %q", got)
+	}
+}
+
+func TestEffortHysteresisPassesThroughWhenIncumbentArmUnscored(t *testing.T) {
+	fresh := hysteresisDecision("claude-opus-5", map[string]float32{
+		"anthropic/claude-opus-5:high": 4.5,
+	})
+
+	got := effortHysteresisHold(fresh, "claude-opus-5:low", "claude-opus-5", "high")
+
+	if got != "" {
+		t.Fatalf("expected pass-through when the incumbent arm has no score, got %q", got)
+	}
+}
+
+func TestEffortHysteresisHoldsWhenChallengerScoresWorse(t *testing.T) {
+	fresh := hysteresisDecision("claude-opus-5", map[string]float32{
+		"anthropic/claude-opus-5:low":  5.0,
+		"anthropic/claude-opus-5:high": 1.0,
+	})
+
+	got := effortHysteresisHold(fresh, "claude-opus-5:low", "claude-opus-5", "high")
+
+	if got != "low" {
+		t.Fatalf("expected incumbent held against a worse challenger, got %q", got)
+	}
+}
+
+func TestEffortHysteresisPassesThroughOnUnchangedEffort(t *testing.T) {
+	fresh := hysteresisDecision("claude-opus-5", map[string]float32{
+		"anthropic/claude-opus-5:low": 4.0,
+	})
+
+	got := effortHysteresisHold(fresh, "claude-opus-5:low", "claude-opus-5", "low")
+
+	if got != "" {
+		t.Fatalf("expected no hold when effort is unchanged, got %q", got)
+	}
+}

--- a/internal/proxy/hysteresis_turnloop_internal_test.go
+++ b/internal/proxy/hysteresis_turnloop_internal_test.go
@@ -1,0 +1,112 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/policy"
+	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/translate"
+)
+
+// The stored pin, not the fresh decision, carries the incumbent effort: the
+// active-pin path reconstructs a decision without it, so hysteresis has to read
+// the pin's served identity or a low-gap escalation silently re-prefixes the
+// session.
+func TestTurnLoopHoldsPinnedEffortOnLowGapEscalation(t *testing.T) {
+	const pinnedModel = "claude-opus-4-7"
+	strategy := router.Strategy("hmm-effort-hysteresis-test")
+
+	tests := []struct {
+		name       string
+		highScore  float32
+		wantEffort string
+		wantHeld   bool
+	}{
+		{name: "low gap holds the pinned effort", highScore: 4.5, wantEffort: "low", wantHeld: true},
+		{name: "gap above threshold escalates", highScore: 6.0, wantEffort: "high"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := newStubPinStore()
+			store.getFound = true
+			store.getPin = sessionpin.Pin{
+				Provider:        providers.ProviderAnthropic,
+				Model:           pinnedModel,
+				Reason:          "hmm_policy(classifier 'high' (p=0.32))",
+				PolicyGroup:     "high",
+				PinnedUntil:     time.Now().Add(time.Hour),
+				LastTurnEndedAt: time.Now().Add(-time.Minute),
+				LastServedModel: pinnedModel + ":low",
+			}
+			policyRouter := &hmmPinStickyTestRouter{decision: router.Decision{
+				Provider: providers.ProviderAnthropic,
+				Model:    pinnedModel,
+				Effort:   "high",
+				Reason:   "hmm_policy(classifier 'high' (p=0.91))",
+				Metadata: &router.RoutingMetadata{
+					PolicyGroup:         "high",
+					SelectedRosterArmID: "anthropic/" + pinnedModel + ":high",
+					ArmScores: map[string]float32{
+						"anthropic/" + pinnedModel + ":low":  4.0,
+						"anthropic/" + pinnedModel + ":high": test.highScore,
+					},
+				},
+			}}
+			svc := NewService(
+				nil,
+				nil,
+				nil,
+				false,
+				nil,
+				store,
+				false,
+				providers.ProviderAnthropic,
+				"claude-haiku-4-5",
+				nil,
+			).WithPolicyStrategy(policy.StrategySpec{
+				Strategy:     strategy,
+				Router:       policyRouter,
+				Capabilities: policy.Capabilities{SchemaVersion: policy.SchemaVersionV1},
+			})
+			env, err := translate.ParseAnthropic(
+				[]byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"continue"}]}`),
+			)
+			require.NoError(t, err)
+			features := env.RoutingFeatures(false)
+			ctx := router.WithStrategy(context.Background(), strategy)
+
+			result, err := svc.runTurnLoop(
+				ctx,
+				env,
+				features,
+				"api-key",
+				uuid.New(),
+				"",
+				http.Header{},
+				router.Request{
+					RequestedModel:       features.Model,
+					EstimatedInputTokens: features.Tokens,
+					HasTools:             features.HasTools,
+					ConversationMessages: conversationMessagesForRouting(env),
+				},
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, pinnedModel, result.Decision.Model)
+			assert.Equal(t, test.wantEffort, result.Decision.Effort)
+			assert.Equal(t, test.wantHeld, strings.Contains(result.PlannerDecision.Reason, effortHysteresisReason),
+				"a hold must stay legible in the planner reason")
+		})
+	}
+}

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -1079,12 +1079,11 @@ func (s *Service) runTurnLoop(
 		)
 		res.Decision = hmmDecision
 		res.PlannerDecision = hmmPlannerDecision
-		heldEffort := effortHysteresisHold(fresh.Metadata, res.PriorServedModel, hmmDecision.Effort)
-		if heldEffort != "" && heldEffort != hmmDecision.Effort {
+		// Runs after the planner assignment above, so the hold survives in the
+		// reason a bake-off reads rather than being overwritten by it.
+		if heldEffort := effortHysteresisHold(fresh, res.PriorServedModel, hmmDecision.Model, hmmDecision.Effort); heldEffort != "" {
 			res.Decision.Effort = heldEffort
-			if res.PlannerDecision.Reason == "" {
-				res.PlannerDecision.Reason = "effort_hysteresis"
-			}
+			res.PlannerDecision.Reason = appendEffortHysteresisReason(res.PlannerDecision.Reason)
 			log.Info("HMM effort hysteresis held incumbent",
 				"incumbent", res.PriorServedModel,
 				"challenger_effort", hmmDecision.Effort,

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -1078,16 +1078,19 @@ func (s *Service) runTurnLoop(
 			prefixBroken,
 		)
 		res.Decision = hmmDecision
-		prevDecision := pinDecision(activePin)
-		if !applyEffortHysteresis(prevDecision, fresh) {
-			res.Decision = fresh
-			res.Decision.Effort = prevDecision.Effort
+		res.PlannerDecision = hmmPlannerDecision
+		heldEffort := effortHysteresisHold(fresh.Metadata, res.PriorServedModel, hmmDecision.Effort)
+		if heldEffort != "" && heldEffort != hmmDecision.Effort {
+			res.Decision.Effort = heldEffort
 			if res.PlannerDecision.Reason == "" {
 				res.PlannerDecision.Reason = "effort_hysteresis"
 			}
-			log.Info("HMM effort hysteresis held incumbent", "incumbent", prevDecision.ServedIdentity(), "challenger", fresh.ServedIdentity())
+			log.Info("HMM effort hysteresis held incumbent",
+				"incumbent", res.PriorServedModel,
+				"challenger_effort", hmmDecision.Effort,
+				"serving_effort", heldEffort,
+			)
 		}
-		res.PlannerDecision = hmmPlannerDecision
 		if hmmStayModel != "" {
 			res.PinModel = hmmStayModel
 			if hmmPin, ok := s.hmmStayPin(req, activePin, hmmHistory); ok && hmmPin.Model == hmmStayModel {

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -1078,6 +1078,15 @@ func (s *Service) runTurnLoop(
 			prefixBroken,
 		)
 		res.Decision = hmmDecision
+		prevDecision := pinDecision(activePin)
+		if !applyEffortHysteresis(prevDecision, fresh) {
+			res.Decision = fresh
+			res.Decision.Effort = prevDecision.Effort
+			if res.PlannerDecision.Reason == "" {
+				res.PlannerDecision.Reason = "effort_hysteresis"
+			}
+			log.Info("HMM effort hysteresis held incumbent", "incumbent", prevDecision.ServedIdentity(), "challenger", fresh.ServedIdentity())
+		}
 		res.PlannerDecision = hmmPlannerDecision
 		if hmmStayModel != "" {
 			res.PinModel = hmmStayModel

--- a/internal/router/policy/resolver.go
+++ b/internal/router/policy/resolver.go
@@ -410,9 +410,7 @@ func (r *Resolver) Resolve(req router.Request) ResolvedCandidates {
 
 // BindingForSelection resolves a sidecar selection by arm ID first, then
 // preserves legacy roster-ID selection for existing policy artifacts.
-// Effort-qualified selections (e.g. "anthropic/claude-opus-5:xhigh") are split
-// so the base arm/roster ID drives the lookup — resolver maps are keyed on base
-// IDs — and the canonical effort level is copied onto the returned binding.
+// Effort-qualified arm/roster IDs are split before map lookup; base ID drives resolution and the suffix sets Binding.Effort.
 func (r ResolvedCandidates) BindingForSelection(armID, rosterID string) (Binding, bool) {
 	if armID != "" {
 		lookup, effort := splitEffort(armID)
@@ -429,9 +427,7 @@ func (r ResolvedCandidates) BindingForSelection(armID, rosterID string) (Binding
 	return binding, ok
 }
 
-// splitEffort separates a canonical effort suffix from an arm ID, mirroring
-// hmm.SplitEffort so only recognized levels are treated as effort suffixes and
-// non-effort model IDs containing ":" (e.g. "upsonic/tiger-rag") stay intact.
+// splitEffort mirrors hmm.SplitEffort: only recognized effort levels are stripped; model IDs with ":" (e.g. "anthropic/opus-5:custom") stay intact.
 func splitEffort(armID string) (string, string) {
 	for i := len(armID) - 1; i > 0; i-- {
 		if armID[i] == ':' {

--- a/internal/router/policy/resolver_test.go
+++ b/internal/router/policy/resolver_test.go
@@ -320,10 +320,7 @@ func TestResolverDirectlyEnforcesAllowlistForStrategySpecificCandidates(t *testi
 	})
 }
 
-// BindingForSelection must split an effort suffix before map lookup: resolver
-// maps are keyed on base arm/roster IDs, so an effort-qualified sidecar
-// selection ("anthropic/claude-opus-5:xhigh") must look up the base ID and
-// propagate the canonical effort level onto the returned binding.
+// Effort-qualified arm/roster selections must resolve via base ID and propagate the effort level.
 func TestBindingForSelectionResolvesEffortQualifiedArmID(t *testing.T) {
 	resolved := policy.ResolvedCandidates{
 		ByArmID: map[string]policy.Binding{
@@ -357,17 +354,20 @@ func TestBindingForSelectionResolvesEffortQualifiedArmID(t *testing.T) {
 	}
 }
 
-// A non-effort model ID containing ":" (e.g. "anthropic/claude-opus-5") must not
-// have its suffix mistaken for an effort level; the full ID drives the lookup.
-func TestBindingForSelectionDoesNotTreatColonModelIDAsEffort(t *testing.T) {
+// A colon-carrying ID whose suffix is not a recognized effort level must not
+// be silently stripped to its base — splitEffort only ever drops effort
+// suffixes, so a non-effort ":" stays part of the lookup key and misses the
+// base-keyed maps rather than misrouting.
+func TestBindingForSelectionDoesNotResolveNonEffortColonSuffix(t *testing.T) {
 	resolved := policy.ResolvedCandidates{
+		ByArmID: map[string]policy.Binding{
+			"anthropic/claude-opus-5": {CatalogID: "claude-opus-5", Provider: providers.ProviderAnthropic},
+		},
 		ByRosterID: map[string]policy.Binding{
-			"upsonic/tiger-rag": {ArmID: "upsonic/tiger-rag", CatalogID: "upsonic/tiger-rag", Provider: providers.ProviderOpenRouter},
+			"anthropic/claude-opus-5": {CatalogID: "claude-opus-5", Provider: providers.ProviderAnthropic},
 		},
 	}
 
-	binding, ok := resolved.BindingForSelection("", "upsonic/tiger-rag")
-	require.True(t, ok)
-	assert.Equal(t, "upsonic/tiger-rag", binding.CatalogID)
-	assert.Empty(t, binding.Effort)
+	_, ok := resolved.BindingForSelection("anthropic/claude-opus-5:custom", "anthropic/claude-opus-5:custom")
+	assert.False(t, ok, "a non-effort colon suffix must not be stripped to reach the base-keyed binding")
 }

--- a/internal/router/policy/resolver_test.go
+++ b/internal/router/policy/resolver_test.go
@@ -354,10 +354,8 @@ func TestBindingForSelectionResolvesEffortQualifiedArmID(t *testing.T) {
 	}
 }
 
-// A colon-carrying ID whose suffix is not a recognized effort level must not
-// be silently stripped to its base — splitEffort only ever drops effort
-// suffixes, so a non-effort ":" stays part of the lookup key and misses the
-// base-keyed maps rather than misrouting.
+// splitEffort drops only recognized effort suffixes, so a non-effort ":"
+// suffix misses the base-keyed maps rather than misrouting to the base.
 func TestBindingForSelectionDoesNotResolveNonEffortColonSuffix(t *testing.T) {
 	resolved := policy.ResolvedCandidates{
 		ByArmID: map[string]policy.Binding{

--- a/internal/router/policy/sidecar_router.go
+++ b/internal/router/policy/sidecar_router.go
@@ -439,6 +439,7 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 			SelectedUpstreamID:            binding.UpstreamID,
 			BindingIndex:                  binding.BindingIndex,
 			CandidateArmIDs:               resolved.CandidateArmIDs(),
+			ArmScores:                     res.ArmScores,
 		},
 	}, nil
 }

--- a/internal/router/policy/sidecar_router.go
+++ b/internal/router/policy/sidecar_router.go
@@ -362,6 +362,11 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 		}
 	}
 
+	selectedRosterArmID := overrideArmID
+	if selectedRosterArmID == "" {
+		selectedRosterArmID = overrideRosterID
+	}
+
 	binding, ok := resolved.BindingForSelection(overrideArmID, overrideRosterID)
 	if !ok {
 		return router.Decision{}, fmt.Errorf("%s: sidecar returned unknown arm %q or model %q: %w", strategy, overrideArmID, overrideRosterID, r.config.Unavailable)
@@ -433,6 +438,7 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 			SidecarTimings:                res.Timings,
 			SidecarStats:                  res.ServingStats,
 			SelectedArmID:                 binding.ArmID,
+			SelectedRosterArmID:           selectedRosterArmID,
 			SidecarSchemaVersion:          res.SchemaVersion,
 			DebugRef:                      debugRef,
 			AuthoritativePerTurnSelection: capabilities.AuthoritativePerTurnSelection,

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -329,6 +329,9 @@ type RoutingMetadata struct {
 	PairedModel    string
 	PairedProvider string
 	PairedScore    float32
+	// ArmScores is per-arm WMI scores for the cluster this decision was drawn
+	// from. Populated from a B1+ sidecar; absent on older sidecars.
+	ArmScores map[string]float32
 }
 
 // SidecarTimings holds the sidecar's per-stage decision cost in milliseconds.

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -291,8 +291,12 @@ type RoutingMetadata struct {
 	SidecarTimings *SidecarTimings
 	// SidecarStats is set only on fresh sidecar decisions; never persist
 	// into pins or a replayed pin re-emits a stale measurement.
-	SidecarStats         *SidecarServingStats
-	SelectedArmID        string
+	SidecarStats  *SidecarServingStats
+	SelectedArmID string
+	// SelectedRosterArmID is the served arm as the sidecar names it, effort
+	// suffix intact — SelectedArmID has been split for binding resolution, so
+	// only this form keys into ArmScores.
+	SelectedRosterArmID  string
 	SelectedUpstreamID   string
 	BindingIndex         int
 	CandidateArmIDs      []string


### PR DESCRIPTION
## Summary

Phase 3b of effort-aware roster arms: hold the incumbent effort when the challenger's WMI gain is noise, so effort doesn't oscillate turn-to-turn and thrash the Anthropic prompt-cache prefix.

Both sides of the comparison are read from the **current** turn's sidecar response, which is what makes the gap meaningful — scores from two different turns are not on a shared scale, and the incumbent's own turn may predate the roster.

```go
// prevServedModel is the pin's LastServedModel ("claude-opus-5:low"), the only
// place the incumbent effort survives — pinDecision() reconstructs no effort.
incumbentEffort, incumbentModel := stripEffortSuffix(prevServedModel)
_, armBase := stripEffortSuffix(fresh.Metadata.SelectedRosterArmID) // "anthropic/claude-opus-5"
challenger, ok := fresh.Metadata.ArmScores[armBase+":"+chosenEffort]
incumbent,  ok := fresh.Metadata.ArmScores[armBase+":"+incumbentEffort]
hold := challenger-incumbent < effortHysteresisThreshold // 1.0 on a ~±10 z-scale
```

Key details, all of which the review round caught in the first cut:

- **`SelectedRosterArmID` is new on `RoutingMetadata`.** `ArmScores` is keyed by effort-qualified roster arm ID, but `SelectedArmID` has already been split by `BindingForSelection` and `Decision.ServedIdentity()` is a catalog identity (`claude-opus-5:xhigh`) — neither keys into the map. The sidecar's own arm name is now threaded through unsplit.
- **The incumbent comes from `res.PriorServedModel`, not a reconstructed pin decision.** Pins carry no effort and `pinDecision` sets no metadata, so comparing against it would let every guard fall through on the active-pin path.
- **Missing score ⇒ pass-through**, distinguished from a genuine `0` via the map's `ok`.
- **Hysteresis only fires on same-base-model effort changes**; cross-model and cross-cluster moves stay the planner's call.
- The hold is applied *after* `res.PlannerDecision = hmmPlannerDecision` and tags the reason (`<planner reason>+effort_hysteresis`) so a bake-off can separate held turns from clean stays.

Tests cover the hold/allow boundary, cross-model and unscored pass-through, a pre-effort bare pin, and an end-to-end `runTurnLoop` regression from a stored `model:low` pin against a `high` challenger.


Link to Devin session: https://app.devin.ai/sessions/71fa9882f3f1410db4b2aafa5b856850
Requested by: @steventohme