### PR TITLE
fix(proxy): keep client streams byte-alive during silent reasoning

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -1407,11 +1407,9 @@ func feedbackLinkTTL() time.Duration {
 	return time.Duration(sec) * time.Second
 }
 
-// sseKeepaliveInterval resolves the client-facing silence budget before the
-// router injects an SSE `ping` (ROUTER_SSE_KEEPALIVE_INTERVAL_SECONDS). Default
-// 15s sits far below the 180s byte watchdog Claude Code applies to a
-// first-party stream. An explicit 0 disables keepalives, so it is parsed inline
-// rather than via parseEnvInt, which would reject 0.
+// sseKeepaliveInterval resolves ROUTER_SSE_KEEPALIVE_INTERVAL_SECONDS.
+// 0 is valid (kill switch), so it is parsed inline rather than via parseEnvInt,
+// which would reject 0. Default is 15s.
 func sseKeepaliveInterval() time.Duration {
 	const defaultSec = 15
 	raw := config.GetOr("ROUTER_SSE_KEEPALIVE_INTERVAL_SECONDS", "")

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -1407,9 +1407,8 @@ func feedbackLinkTTL() time.Duration {
 	return time.Duration(sec) * time.Second
 }
 
-// sseKeepaliveInterval resolves ROUTER_SSE_KEEPALIVE_INTERVAL_SECONDS.
-// 0 is valid (kill switch), so it is parsed inline rather than via parseEnvInt,
-// which would reject 0. Default is 15s.
+// sseKeepaliveInterval parses ROUTER_SSE_KEEPALIVE_INTERVAL_SECONDS.
+// Handled inline because 0 is a valid kill-switch value that parseEnvInt rejects.
 func sseKeepaliveInterval() time.Duration {
 	const defaultSec = 15
 	raw := config.GetOr("ROUTER_SSE_KEEPALIVE_INTERVAL_SECONDS", "")

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -579,6 +579,7 @@ func main() {
 	// Kill switch for degrading to a same-cluster candidate when the routed
 	// model's bindings are all exhausted by a transient upstream fault.
 	siblingFailover := config.GetOr("ROUTER_SIBLING_FAILOVER", "true") == "true"
+	sseKeepalive := sseKeepaliveInterval()
 	ccOrchToolsCrossVendor := config.GetOr("ROUTER_CC_ORCH_TOOLS_CROSSVENDOR", "true") == "true"
 	// Per-turn large-vs-small action-classifier swap. Off by default until the
 	// Layer-2 extrinsic validation clears it; enabling loads the compiled-in head.
@@ -868,6 +869,7 @@ func main() {
 		WithCyberRefusalRepin(cyberRefusalRepin).
 		WithCyberRefusalFallbackModel(cyberRefusalFallbackModel).
 		WithSiblingFailover(siblingFailover).
+		WithSSEKeepalive(sseKeepalive).
 		WithPrefixTrimFreeSwitch(prefixTrimFreeSwitch).
 		WithHMMUpgradeConfidenceThreshold(hmmUpgradeConfidence).
 		WithHMMSameTierPin(hmmSameTierPin).
@@ -1400,6 +1402,25 @@ func feedbackLinkTTL() time.Duration {
 	sec, err := strconv.Atoi(raw)
 	if err != nil || sec < 0 {
 		observability.Get().Warn("Invalid env var; using default", "key", "ROUTER_FEEDBACK_LINK_TTL_SEC", "value", raw, "default", defaultSec)
+		return defaultSec * time.Second
+	}
+	return time.Duration(sec) * time.Second
+}
+
+// sseKeepaliveInterval resolves the client-facing silence budget before the
+// router injects an SSE `ping` (ROUTER_SSE_KEEPALIVE_INTERVAL_SECONDS). Default
+// 15s sits far below the 180s byte watchdog Claude Code applies to a
+// first-party stream. An explicit 0 disables keepalives, so it is parsed inline
+// rather than via parseEnvInt, which would reject 0.
+func sseKeepaliveInterval() time.Duration {
+	const defaultSec = 15
+	raw := config.GetOr("ROUTER_SSE_KEEPALIVE_INTERVAL_SECONDS", "")
+	if raw == "" {
+		return defaultSec * time.Second
+	}
+	sec, err := strconv.Atoi(raw)
+	if err != nil || sec < 0 {
+		observability.Get().Warn("Invalid env var; using default", "key", "ROUTER_SSE_KEEPALIVE_INTERVAL_SECONDS", "value", raw, "default", defaultSec)
 		return defaultSec * time.Second
 	}
 	return time.Duration(sec) * time.Second

--- a/internal/proxy/AGENTS.md
+++ b/internal/proxy/AGENTS.md
@@ -108,6 +108,42 @@ Per-attempt body rebuild: each closure constructs `EmitOptions` with `TargetProv
 - Cancel/deadline classified as non-retryable: client disconnect or per-request budget elapse must not waste a second upstream call.
 - After dispatch, `actPricing` is re-resolved against the WINNING binding via `catalog.PriceFor(finalProvider, decision.Model)` so debits and OTel `cost.actual_*` reflect the actually-served provider's per-1M rate (the catalog's `PrimaryPriceFor` would otherwise always return the primary's).
 
+## Client-facing SSE keepalive
+
+Clients time a stream out on received BYTES, not on semantic events: Claude Code
+aborts a first-party stream (which includes any `ANTHROPIC_BASE_URL` override,
+so all routed traffic) after **180s** of byte silence. A long reasoning phase
+translates to zero client-facing frames, so a healthy turn reads as a dead
+connection — prod 2026-08-24, three `gpt-5.6-luna` turns that each spent their
+whole 64K output budget reasoning for 320-360s and were killed client-side at
+exactly 180s while the router went on to complete them successfully.
+
+None of the upstream watchdogs can cover this. They measure the *upstream* leg:
+byte-idle keeps getting reset by Responses bookkeeping frames, and the
+output-stall budget (240s) is longer than the client's 180s by design. The gap
+is the *client* leg, so `ProxyMessages` wraps the client writer in
+[`sse.KeepaliveWriter`](../sse/keepalive.go), which emits `anthropicPingFrame`
+after `ROUTER_SSE_KEEPALIVE_INTERVAL_SECONDS` (default 15s, 0 disables) of
+silence. This is what direct-to-Anthropic already gets for free — Anthropic's own
+API emits `ping` for exactly this reason (see `anthropic_footer.go`, which
+forwards them).
+
+**Invariants:**
+- **Innermost wrap.** The keepalive sits closest to the socket, below the
+  feedback footer, so it observes the bytes that actually reach the client
+  rather than what the proxy handed to the next translator.
+- **Arms on first byte, never before.** For a `preludeBuffer`-wrapped chain the
+  first byte through is the commit point, so a keepalive can never commit a
+  response the router still wants to retry on another binding.
+- **Record-boundary only.** A frame goes out only when the last write ended on a
+  blank line, so a keepalive can never land inside a partially written event.
+- **`Close()` before the handler returns** (deferred at the wrap site) and it
+  blocks on any in-flight frame, so no keepalive outlives the response.
+
+Only the Anthropic Messages surface is wrapped today — that is where the failure
+was observed. `KeepaliveWriter` takes the frame as a parameter, so adding the
+OpenAI/Gemini surfaces is a wiring change plus their own frame.
+
 ## `OnUpstreamMeta` callbacks
 
 Provider adapters call back into `proxy.OnUpstreamMeta` so streaming responses record usage/headers back to proxy without coupling provider packages to proxy internals. The catalog / planner stack depends on per-action token counts being recorded promptly — **don't add a provider that forgets to call the callback.**

--- a/internal/proxy/CLAUDE.md
+++ b/internal/proxy/CLAUDE.md
@@ -108,6 +108,42 @@ Per-attempt body rebuild: each closure constructs `EmitOptions` with `TargetProv
 - Cancel/deadline classified as non-retryable: client disconnect or per-request budget elapse must not waste a second upstream call.
 - After dispatch, `actPricing` is re-resolved against the WINNING binding via `catalog.PriceFor(finalProvider, decision.Model)` so debits and OTel `cost.actual_*` reflect the actually-served provider's per-1M rate (the catalog's `PrimaryPriceFor` would otherwise always return the primary's).
 
+## Client-facing SSE keepalive
+
+Clients time a stream out on received BYTES, not on semantic events: Claude Code
+aborts a first-party stream (which includes any `ANTHROPIC_BASE_URL` override,
+so all routed traffic) after **180s** of byte silence. A long reasoning phase
+translates to zero client-facing frames, so a healthy turn reads as a dead
+connection — prod 2026-08-24, three `gpt-5.6-luna` turns that each spent their
+whole 64K output budget reasoning for 320-360s and were killed client-side at
+exactly 180s while the router went on to complete them successfully.
+
+None of the upstream watchdogs can cover this. They measure the *upstream* leg:
+byte-idle keeps getting reset by Responses bookkeeping frames, and the
+output-stall budget (240s) is longer than the client's 180s by design. The gap
+is the *client* leg, so `ProxyMessages` wraps the client writer in
+[`sse.KeepaliveWriter`](../sse/keepalive.go), which emits `anthropicPingFrame`
+after `ROUTER_SSE_KEEPALIVE_INTERVAL_SECONDS` (default 15s, 0 disables) of
+silence. This is what direct-to-Anthropic already gets for free — Anthropic's own
+API emits `ping` for exactly this reason (see `anthropic_footer.go`, which
+forwards them).
+
+**Invariants:**
+- **Innermost wrap.** The keepalive sits closest to the socket, below the
+  feedback footer, so it observes the bytes that actually reach the client
+  rather than what the proxy handed to the next translator.
+- **Arms on first byte, never before.** For a `preludeBuffer`-wrapped chain the
+  first byte through is the commit point, so a keepalive can never commit a
+  response the router still wants to retry on another binding.
+- **Record-boundary only.** A frame goes out only when the last write ended on a
+  blank line, so a keepalive can never land inside a partially written event.
+- **`Close()` before the handler returns** (deferred at the wrap site) and it
+  blocks on any in-flight frame, so no keepalive outlives the response.
+
+Only the Anthropic Messages surface is wrapped today — that is where the failure
+was observed. `KeepaliveWriter` takes the frame as a parameter, so adding the
+OpenAI/Gemini surfaces is a wiring change plus their own frame.
+
 ## `OnUpstreamMeta` callbacks
 
 Provider adapters call back into `proxy.OnUpstreamMeta` so streaming responses record usage/headers back to proxy without coupling provider packages to proxy internals. The catalog / planner stack depends on per-action token counts being recorded promptly — **don't add a provider that forgets to call the callback.**

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -34,6 +34,7 @@ import (
 	"workweave/router/internal/router/rl"
 	"workweave/router/internal/router/sessionpin"
 	"workweave/router/internal/router/turntype"
+	"workweave/router/internal/sse"
 	"workweave/router/internal/timing"
 	"workweave/router/internal/translate"
 
@@ -167,6 +168,11 @@ type Service struct {
 	// for degrading to a same-cluster candidate when every binding of the
 	// routed model fails with a transient upstream fault.
 	siblingFailover bool
+	// sseKeepalive is how long a committed Anthropic stream may send the client
+	// nothing before a `ping` goes out (ROUTER_SSE_KEEPALIVE_INTERVAL_SECONDS,
+	// 0 disables). Guards against client-side byte watchdogs during a reasoning
+	// phase that produces no client-facing frames; see sse.KeepaliveWriter.
+	sseKeepalive time.Duration
 	// cyberRefusalFallbackModel is the model to re-pin to on a cyber refusal
 	// when the session pin carries no runner-up (PairedModel). Set from
 	// ROUTER_CYBER_REFUSAL_FALLBACK_MODEL; defaults to claude-sonnet-5.
@@ -1284,6 +1290,13 @@ func (s *Service) WithSiblingFailover(enabled bool) *Service {
 	return s
 }
 
+// WithSSEKeepalive sets the client-facing silence budget before a `ping` is
+// injected into a committed Anthropic stream. Non-positive disables it.
+func (s *Service) WithSSEKeepalive(interval time.Duration) *Service {
+	s.sseKeepalive = interval
+	return s
+}
+
 // WithCyberRefusalFallbackModel sets the re-pin target used when the session pin
 // carries no runner-up (ROUTER_CYBER_REFUSAL_FALLBACK_MODEL). Empty is ignored.
 func (s *Service) WithCyberRefusalFallbackModel(model string) *Service {
@@ -2382,6 +2395,12 @@ func (s *Service) maybeRepinOnRefusal(ctx context.Context, obs *refusalObserver,
 		"to_provider", fbProvider)
 }
 
+// anthropicPingFrame is the no-op heartbeat the Anthropic Messages stream
+// defines. Clients ignore it; its only job is to put bytes on the wire so a
+// client-side idle watchdog does not mistake a long reasoning phase for a dead
+// connection.
+var anthropicPingFrame = []byte(sseEvent("ping", `{"type":"ping"}`))
+
 func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.ResponseWriter, r *http.Request) error {
 	ctx, err := s.checkUserMonthlySpendLimit(ctx, r.Header, r.URL.Path)
 	if err != nil {
@@ -2954,8 +2973,17 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// cached/logged bodies. Transparent when streaming/feedback is off.
 	clientSink := w
 	if env.Stream() && !agentShadowMode {
+		// Innermost wrap (closest to the socket) so the keepalive observes the
+		// bytes that actually reach the client, and arms only once preludeBuffer
+		// commits — a ping before that would strand a response the router still
+		// wants to retry on another binding.
+		if s.sseKeepalive > 0 {
+			keepalive := sse.NewKeepaliveWriter(clientSink, anthropicPingFrame, s.sseKeepalive)
+			defer keepalive.Close()
+			clientSink = keepalive
+		}
 		if footer := s.feedbackFooter(ctx, ClientIdentityFrom(ctx).ClientApp, routeRes.TurnType); footer != "" {
-			clientSink = translate.NewAnthropicRoutingFooterWriter(w, footer)
+			clientSink = translate.NewAnthropicRoutingFooterWriter(clientSink, footer)
 		}
 	}
 	contentSink, contentCap := s.maybeCaptureResponse(ctx, clientSink)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2969,10 +2969,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// cached/logged bodies. Transparent when streaming/feedback is off.
 	clientSink := w
 	if env.Stream() && !agentShadowMode {
-		// Innermost wrap (closest to the socket) so the keepalive observes the
-		// bytes that actually reach the client, and arms only once preludeBuffer
-		// commits — a ping before that would strand a response the router still
-		// wants to retry on another binding.
+		// Innermost wrap: arms only once preludeBuffer commits, so a keepalive
+		// can never strand a response the router still wants to retry.
 		if s.sseKeepalive > 0 {
 			keepalive := sse.NewKeepaliveWriter(clientSink, anthropicPingFrame, s.sseKeepalive)
 			defer keepalive.Close()

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -168,10 +168,8 @@ type Service struct {
 	// for degrading to a same-cluster candidate when every binding of the
 	// routed model fails with a transient upstream fault.
 	siblingFailover bool
-	// sseKeepalive is how long a committed Anthropic stream may send the client
-	// nothing before a `ping` goes out (ROUTER_SSE_KEEPALIVE_INTERVAL_SECONDS,
-	// 0 disables). Guards against client-side byte watchdogs during a reasoning
-	// phase that produces no client-facing frames; see sse.KeepaliveWriter.
+	// sseKeepalive is the client-silence budget before a ping is injected
+	// (ROUTER_SSE_KEEPALIVE_INTERVAL_SECONDS; 0 disables). See sse.KeepaliveWriter.
 	sseKeepalive time.Duration
 	// cyberRefusalFallbackModel is the model to re-pin to on a cyber refusal
 	// when the session pin carries no runner-up (PairedModel). Set from

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2395,10 +2395,8 @@ func (s *Service) maybeRepinOnRefusal(ctx context.Context, obs *refusalObserver,
 		"to_provider", fbProvider)
 }
 
-// anthropicPingFrame is the no-op heartbeat the Anthropic Messages stream
-// defines. Clients ignore it; its only job is to put bytes on the wire so a
-// client-side idle watchdog does not mistake a long reasoning phase for a dead
-// connection.
+// anthropicPingFrame keeps a client-facing stream byte-alive during long
+// upstream reasoning phases that produce no translatable frames.
 var anthropicPingFrame = []byte(sseEvent("ping", `{"type":"ping"}`))
 
 func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.ResponseWriter, r *http.Request) error {

--- a/internal/proxy/sse_keepalive_integration_test.go
+++ b/internal/proxy/sse_keepalive_integration_test.go
@@ -1,0 +1,109 @@
+package proxy_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/providers/openaicompat"
+	"workweave/router/internal/proxy"
+	"workweave/router/internal/router"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProxyMessages_KeepaliveDuringUpstreamSilence is the end-to-end guard for
+// the prod 2026-08-24 failure: an upstream that commits a stream and then goes
+// quiet for minutes (a reasoning phase producing no client-facing frames) left
+// Claude Code with zero bytes and tripped its 180s byte watchdog, even though
+// the turn completed successfully upstream. The router must pad the gap.
+func TestProxyMessages_KeepaliveDuringUpstreamSilence(t *testing.T) {
+	const upstreamSilence = 250 * time.Millisecond
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		write := func(chunk string) {
+			_, _ = w.Write([]byte(chunk))
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+
+		write(`data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"deepseek/deepseek-v4-pro","choices":[{"index":0,"delta":{"role":"assistant","content":"thinking"},"finish_reason":null}]}` + "\n\n")
+		// The stall: committed, then nothing the translator can forward.
+		time.Sleep(upstreamSilence)
+		write(`data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"deepseek/deepseek-v4-pro","choices":[{"index":0,"delta":{"content":" done"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2}}` + "\n\n")
+		write("data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	svc := proxy.NewService(
+		&fakeRouter{decision: router.Decision{Provider: "fireworks", Model: "deepseek/deepseek-v4-pro"}},
+		map[string]providers.Client{"fireworks": openaicompat.NewClient("test-fw-key", upstream.URL)},
+		nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil,
+	).WithDeploymentKeyedProviders(map[string]struct{}{"fireworks": {}}).
+		WithSSEKeepalive(40 * time.Millisecond)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	body := []byte(`{"model":"deepseek/deepseek-v4-pro","stream":true,"messages":[{"role":"user","content":"hi"}]}`)
+
+	require.NoError(t, svc.ProxyMessages(context.Background(), body, rec, req))
+
+	got := rec.Body.String()
+	assert.GreaterOrEqual(t, strings.Count(got, "event: ping"), 2,
+		"a stalled-but-live stream must be padded with pings")
+
+	// The padding must not break the turn: real frames still bracket the stream,
+	// the answer survives, and no ping precedes message_start.
+	assert.Contains(t, got, "event: message_start")
+	assert.Contains(t, got, "event: message_stop")
+	assert.Contains(t, got, "thinking")
+	assert.Contains(t, got, " done")
+	assert.Less(t, strings.Index(got, "event: message_start"), strings.Index(got, "event: ping"),
+		"keepalives must never precede the stream envelope")
+}
+
+// The keepalive is a kill-switchable addition: with it off, the stream is
+// byte-for-byte what it was before, so an operator can always turn it back off.
+func TestProxyMessages_KeepaliveDisabledLeavesStreamUnpadded(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		write := func(chunk string) {
+			_, _ = w.Write([]byte(chunk))
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		write(`data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"deepseek/deepseek-v4-pro","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":null}]}` + "\n\n")
+		time.Sleep(150 * time.Millisecond)
+		write(`data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"deepseek/deepseek-v4-pro","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":1}}` + "\n\n")
+		write("data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	svc := proxy.NewService(
+		&fakeRouter{decision: router.Decision{Provider: "fireworks", Model: "deepseek/deepseek-v4-pro"}},
+		map[string]providers.Client{"fireworks": openaicompat.NewClient("test-fw-key", upstream.URL)},
+		nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil,
+	).WithDeploymentKeyedProviders(map[string]struct{}{"fireworks": {}}).
+		WithSSEKeepalive(0)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	body := []byte(`{"model":"deepseek/deepseek-v4-pro","stream":true,"messages":[{"role":"user","content":"hi"}]}`)
+
+	require.NoError(t, svc.ProxyMessages(context.Background(), body, rec, req))
+
+	assert.NotContains(t, rec.Body.String(), "event: ping", "keepalives must be off when the interval is 0")
+	assert.Contains(t, rec.Body.String(), "event: message_stop")
+}

--- a/internal/proxy/sse_keepalive_integration_test.go
+++ b/internal/proxy/sse_keepalive_integration_test.go
@@ -17,9 +17,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestProxyMessages_KeepaliveDuringUpstreamSilence verifies that a stream
-// committed upstream but silent during reasoning is padded with pings so the
-// client byte watchdog does not abort a healthy turn.
+// TestProxyMessages_KeepaliveDuringUpstreamSilence verifies a committed stream
+// silent during reasoning is padded so the client byte watchdog doesn't abort it.
 func TestProxyMessages_KeepaliveDuringUpstreamSilence(t *testing.T) {
 	const upstreamSilence = 250 * time.Millisecond
 

--- a/internal/proxy/sse_keepalive_integration_test.go
+++ b/internal/proxy/sse_keepalive_integration_test.go
@@ -17,11 +17,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestProxyMessages_KeepaliveDuringUpstreamSilence is the end-to-end guard for
-// the prod 2026-08-24 failure: an upstream that commits a stream and then goes
-// quiet for minutes (a reasoning phase producing no client-facing frames) left
-// Claude Code with zero bytes and tripped its 180s byte watchdog, even though
-// the turn completed successfully upstream. The router must pad the gap.
+// TestProxyMessages_KeepaliveDuringUpstreamSilence verifies that a stream
+// committed upstream but silent during reasoning is padded with pings so the
+// client byte watchdog does not abort a healthy turn.
 func TestProxyMessages_KeepaliveDuringUpstreamSilence(t *testing.T) {
 	const upstreamSilence = 250 * time.Millisecond
 

--- a/internal/sse/keepalive.go
+++ b/internal/sse/keepalive.go
@@ -11,10 +11,9 @@ import (
 // number of trailing bytes that must be carried across writes to recognize one.
 const maxRecordSepLen = 4
 
-// endsOnBlankLine reports whether b ends on a blank line — an SSE record
-// separator. Line terminators are CRLF or LF; a trailing lone CR is treated as
-// unterminated because it may be the first half of a CRLF still in flight, and
-// injecting between the two would split the record.
+// endsOnBlankLine reports whether b ends on an SSE record separator (blank
+// line). A trailing lone CR is treated as unterminated — it may be the first
+// half of a CRLF still in flight; injecting between the two would split the record.
 func endsOnBlankLine(b []byte) bool {
 	rest, ok := trimLineEnd(b)
 	if !ok {
@@ -53,8 +52,7 @@ type KeepaliveWriter struct {
 	tail  []byte
 	armed bool
 	// stopped halts emission (write error or Close); closed records that Close
-	// has run. Distinct because a write error must not make Close skip the
-	// channel close that reaps the goroutine.
+	// has run. Distinct: a write error must not let Close skip the goroutine reap.
 	stopped bool
 	closed  bool
 
@@ -106,9 +104,8 @@ func (k *KeepaliveWriter) Flush() {
 	}
 }
 
-// Close stops the keepalive and blocks until any in-flight frame has been
-// written, so a keepalive can never race a handler that has already returned.
-// Safe to call on an unarmed writer and safe to call more than once.
+// Close stops the keepalive, blocking until any in-flight frame is written.
+// Safe on an unarmed writer and idempotent.
 func (k *KeepaliveWriter) Close() {
 	k.mu.Lock()
 	if k.closed {

--- a/internal/sse/keepalive.go
+++ b/internal/sse/keepalive.go
@@ -46,9 +46,8 @@ type KeepaliveWriter struct {
 
 	mu   sync.Mutex
 	last time.Time
-	// tail is the last maxRecordSepLen bytes written to the client. A separator
-	// can straddle two writes, so the boundary test runs over this rather than
-	// over the latest write alone.
+	// tail holds the last maxRecordSepLen bytes so a record separator
+	// that straddles two writes is still detected.
 	tail  []byte
 	armed bool
 	// stopped halts emission (write error or Close); closed records that Close

--- a/internal/sse/keepalive.go
+++ b/internal/sse/keepalive.go
@@ -12,20 +12,13 @@ import (
 var recordSep = []byte("\n\n")
 
 // KeepaliveWriter injects a caller-supplied SSE frame whenever a committed
-// stream has sent the client nothing for interval.
+// stream has sent the client nothing for interval. Clients time out on bytes,
+// not semantic events; a long reasoning phase produces no translatable frames,
+// so the router must pad the gap itself.
 //
-// Clients time a stream out on received BYTES, not on semantic events: Claude
-// Code aborts a first-party stream after 180s of byte silence. A long upstream
-// reasoning phase translates to zero client-facing frames, so a healthy turn
-// that will complete reads as a dead connection — prod 2026-08-24, three
-// gpt-5.6-luna turns that each spent their whole 64K output budget reasoning for
-// 320-360s and were killed client-side at exactly 180s. Anthropic's own API
-// emits `ping` for this reason; translated streams had no equivalent.
-//
-// The timer arms on the first byte through the writer, which for a
-// preludeBuffer-wrapped chain is the commit point, so a keepalive can never
-// commit a response the router still wants to retry elsewhere. Frames go out
-// only at a record boundary, so one can never land inside a partial event.
+// Arms on first byte (the preludeBuffer commit point) so a keepalive can never
+// force a response that the router still wants to retry. Emits only at a record
+// boundary so it can never split an event.
 type KeepaliveWriter struct {
 	inner    http.ResponseWriter
 	flusher  http.Flusher
@@ -36,7 +29,11 @@ type KeepaliveWriter struct {
 	last       time.Time
 	atBoundary bool
 	armed      bool
-	stopped    bool
+	// stopped halts emission (write error or Close); closed records that Close
+	// has run. Distinct because a write error must not make Close skip the
+	// channel close that reaps the goroutine.
+	stopped bool
+	closed  bool
 
 	stop chan struct{}
 	done chan struct{}
@@ -93,11 +90,16 @@ func (k *KeepaliveWriter) Flush() {
 // Safe to call on an unarmed writer and safe to call more than once.
 func (k *KeepaliveWriter) Close() {
 	k.mu.Lock()
-	armed, alreadyStopped := k.armed, k.stopped
+	if k.closed {
+		k.mu.Unlock()
+		return
+	}
+	k.closed = true
 	k.stopped = true
+	armed := k.armed
 	k.mu.Unlock()
 
-	if !armed || alreadyStopped {
+	if !armed {
 		return
 	}
 	close(k.stop)
@@ -117,26 +119,33 @@ func (k *KeepaliveWriter) loop() {
 		case <-k.stop:
 			return
 		case <-tick.C:
-			k.emitIfSilent()
+			if !k.emitIfSilent() {
+				return
+			}
 		}
 	}
 }
 
-func (k *KeepaliveWriter) emitIfSilent() {
+// emitIfSilent reports whether the caller should keep ticking.
+func (k *KeepaliveWriter) emitIfSilent() bool {
 	k.mu.Lock()
 	defer k.mu.Unlock()
 
-	if k.stopped || !k.atBoundary || time.Since(k.last) < k.interval {
-		return
+	if k.stopped {
+		return false
+	}
+	if !k.atBoundary || time.Since(k.last) < k.interval {
+		return true
 	}
 	if _, err := k.inner.Write(k.frame); err != nil {
 		// A broken client connection is the handler's error to report; stop
 		// emitting rather than spinning on a dead socket.
 		k.stopped = true
-		return
+		return false
 	}
 	if k.flusher != nil {
 		k.flusher.Flush()
 	}
 	k.last = time.Now()
+	return true
 }

--- a/internal/sse/keepalive.go
+++ b/internal/sse/keepalive.go
@@ -7,9 +7,29 @@ import (
 	"time"
 )
 
-// recordSep terminates an SSE record. A keepalive is only safe to inject when
-// the last write landed on one.
-var recordSep = []byte("\n\n")
+// maxRecordSepLen is the longest SSE record separator ("\r\n\r\n"), and so the
+// number of trailing bytes that must be carried across writes to recognize one.
+const maxRecordSepLen = 4
+
+// endsOnBlankLine reports whether b ends on a blank line — an SSE record
+// separator. Line terminators are CRLF or LF; a trailing lone CR is treated as
+// unterminated because it may be the first half of a CRLF still in flight, and
+// injecting between the two would split the record.
+func endsOnBlankLine(b []byte) bool {
+	rest, ok := trimLineEnd(b)
+	if !ok {
+		return false
+	}
+	_, ok = trimLineEnd(rest)
+	return ok
+}
+
+func trimLineEnd(b []byte) ([]byte, bool) {
+	if !bytes.HasSuffix(b, []byte("\n")) {
+		return nil, false
+	}
+	return bytes.TrimSuffix(b[:len(b)-1], []byte("\r")), true
+}
 
 // KeepaliveWriter injects a caller-supplied SSE frame whenever a committed
 // stream has sent the client nothing for interval. Clients time out on bytes,
@@ -25,10 +45,13 @@ type KeepaliveWriter struct {
 	frame    []byte
 	interval time.Duration
 
-	mu         sync.Mutex
-	last       time.Time
-	atBoundary bool
-	armed      bool
+	mu   sync.Mutex
+	last time.Time
+	// tail is the last maxRecordSepLen bytes written to the client. A separator
+	// can straddle two writes, so the boundary test runs over this rather than
+	// over the latest write alone.
+	tail  []byte
+	armed bool
 	// stopped halts emission (write error or Close); closed records that Close
 	// has run. Distinct because a write error must not make Close skip the
 	// channel close that reaps the goroutine.
@@ -67,9 +90,7 @@ func (k *KeepaliveWriter) Write(p []byte) (n int, err error) {
 
 	n, err = k.inner.Write(p)
 	k.last = time.Now()
-	if n > 0 {
-		k.atBoundary = bytes.HasSuffix(p[:n], recordSep)
-	}
+	k.noteWritten(p[:n])
 	if !k.armed && !k.stopped && k.interval > 0 {
 		k.armed = true
 		go k.loop()
@@ -134,7 +155,7 @@ func (k *KeepaliveWriter) emitIfSilent() bool {
 	if k.stopped {
 		return false
 	}
-	if !k.atBoundary || time.Since(k.last) < k.interval {
+	if !endsOnBlankLine(k.tail) || time.Since(k.last) < k.interval {
 		return true
 	}
 	if _, err := k.inner.Write(k.frame); err != nil {
@@ -146,6 +167,20 @@ func (k *KeepaliveWriter) emitIfSilent() bool {
 	if k.flusher != nil {
 		k.flusher.Flush()
 	}
+	k.noteWritten(k.frame)
 	k.last = time.Now()
 	return true
+}
+
+// noteWritten keeps the trailing maxRecordSepLen bytes of the client-facing
+// stream, bounded regardless of how large p is.
+func (k *KeepaliveWriter) noteWritten(p []byte) {
+	if len(p) >= maxRecordSepLen {
+		k.tail = append(k.tail[:0], p[len(p)-maxRecordSepLen:]...)
+		return
+	}
+	k.tail = append(k.tail, p...)
+	if len(k.tail) > maxRecordSepLen {
+		k.tail = append(k.tail[:0], k.tail[len(k.tail)-maxRecordSepLen:]...)
+	}
 }

--- a/internal/sse/keepalive.go
+++ b/internal/sse/keepalive.go
@@ -1,0 +1,142 @@
+package sse
+
+import (
+	"bytes"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// recordSep terminates an SSE record. A keepalive is only safe to inject when
+// the last write landed on one.
+var recordSep = []byte("\n\n")
+
+// KeepaliveWriter injects a caller-supplied SSE frame whenever a committed
+// stream has sent the client nothing for interval.
+//
+// Clients time a stream out on received BYTES, not on semantic events: Claude
+// Code aborts a first-party stream after 180s of byte silence. A long upstream
+// reasoning phase translates to zero client-facing frames, so a healthy turn
+// that will complete reads as a dead connection — prod 2026-08-24, three
+// gpt-5.6-luna turns that each spent their whole 64K output budget reasoning for
+// 320-360s and were killed client-side at exactly 180s. Anthropic's own API
+// emits `ping` for this reason; translated streams had no equivalent.
+//
+// The timer arms on the first byte through the writer, which for a
+// preludeBuffer-wrapped chain is the commit point, so a keepalive can never
+// commit a response the router still wants to retry elsewhere. Frames go out
+// only at a record boundary, so one can never land inside a partial event.
+type KeepaliveWriter struct {
+	inner    http.ResponseWriter
+	flusher  http.Flusher
+	frame    []byte
+	interval time.Duration
+
+	mu         sync.Mutex
+	last       time.Time
+	atBoundary bool
+	armed      bool
+	stopped    bool
+
+	stop chan struct{}
+	done chan struct{}
+}
+
+// NewKeepaliveWriter wraps w so that frame is emitted after every interval of
+// client-facing silence. A non-positive interval yields a transparent writer.
+func NewKeepaliveWriter(w http.ResponseWriter, frame []byte, interval time.Duration) *KeepaliveWriter {
+	flusher, _ := w.(http.Flusher)
+	return &KeepaliveWriter{
+		inner:    w,
+		flusher:  flusher,
+		frame:    frame,
+		interval: interval,
+		stop:     make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+}
+
+func (k *KeepaliveWriter) Header() http.Header { return k.inner.Header() }
+
+func (k *KeepaliveWriter) WriteHeader(code int) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.inner.WriteHeader(code)
+}
+
+func (k *KeepaliveWriter) Write(p []byte) (n int, err error) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	n, err = k.inner.Write(p)
+	k.last = time.Now()
+	if n > 0 {
+		k.atBoundary = bytes.HasSuffix(p[:n], recordSep)
+	}
+	if !k.armed && !k.stopped && k.interval > 0 {
+		k.armed = true
+		go k.loop()
+	}
+	return n, err
+}
+
+func (k *KeepaliveWriter) Flush() {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if k.flusher != nil {
+		k.flusher.Flush()
+	}
+}
+
+// Close stops the keepalive and blocks until any in-flight frame has been
+// written, so a keepalive can never race a handler that has already returned.
+// Safe to call on an unarmed writer and safe to call more than once.
+func (k *KeepaliveWriter) Close() {
+	k.mu.Lock()
+	armed, alreadyStopped := k.armed, k.stopped
+	k.stopped = true
+	k.mu.Unlock()
+
+	if !armed || alreadyStopped {
+		return
+	}
+	close(k.stop)
+	<-k.done
+}
+
+func (k *KeepaliveWriter) loop() {
+	defer close(k.done)
+
+	// Tick at half the interval so a frame lands within interval of the last
+	// byte instead of up to twice as late.
+	tick := time.NewTicker(max(k.interval/2, time.Millisecond))
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-k.stop:
+			return
+		case <-tick.C:
+			k.emitIfSilent()
+		}
+	}
+}
+
+func (k *KeepaliveWriter) emitIfSilent() {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	if k.stopped || !k.atBoundary || time.Since(k.last) < k.interval {
+		return
+	}
+	if _, err := k.inner.Write(k.frame); err != nil {
+		// A broken client connection is the handler's error to report; stop
+		// emitting rather than spinning on a dead socket.
+		k.stopped = true
+		return
+	}
+	if k.flusher != nil {
+		k.flusher.Flush()
+	}
+	k.last = time.Now()
+}

--- a/internal/sse/keepalive_test.go
+++ b/internal/sse/keepalive_test.go
@@ -128,9 +128,8 @@ func TestKeepaliveWriter_NeverSplitsARecord(t *testing.T) {
 		"the record must be reassembled intact")
 }
 
-// SSE terminators are CRLF or LF and can straddle two writes. A boundary test
-// that only matched "\n\n" within a single write silently disabled keepalives
-// for both shapes — the exact stall this writer exists to prevent.
+// SSE terminators are CRLF or LF and can straddle two writes; both shapes
+// silently disabled keepalives when the boundary check only matched "\n\n".
 func TestKeepaliveWriter_RecognizesEveryRecordSeparator(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
@@ -216,9 +215,8 @@ func TestKeepaliveWriter_DisabledByNonPositiveInterval(t *testing.T) {
 	assert.Zero(t, pings(rec.body()), "interval <= 0 must disable keepalives")
 }
 
-// waitFor polls cond on the CALLING goroutine. testify's Eventually evaluates
-// its condition in a fresh goroutine, which perturbs the very count the
-// goroutine-leak test measures.
+// waitFor polls on the calling goroutine; testify.Eventually evaluates in a
+// fresh goroutine, which perturbs the goroutine count the leak test measures.
 func waitFor(cond func() bool) bool {
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {

--- a/internal/sse/keepalive_test.go
+++ b/internal/sse/keepalive_test.go
@@ -198,10 +198,8 @@ func waitFor(cond func() bool) bool {
 	return cond()
 }
 
-// A write error must reap the goroutine on its own. Close() short-circuits once
-// emission has already halted, so if the loop waited to be told to exit, every
-// client that disconnects mid-stream would leak a ticker for the process
-// lifetime.
+// A write error must reap the goroutine on its own; otherwise every client
+// disconnect leaks a ticker for the process lifetime.
 func TestKeepaliveWriter_WriteErrorReapsGoroutine(t *testing.T) {
 	baseline := runtime.NumGoroutine()
 	rec := newSyncRecorder()

--- a/internal/sse/keepalive_test.go
+++ b/internal/sse/keepalive_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"net/http"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -181,6 +182,41 @@ func TestKeepaliveWriter_DisabledByNonPositiveInterval(t *testing.T) {
 	time.Sleep(6 * testKeepalive)
 
 	assert.Zero(t, pings(rec.body()), "interval <= 0 must disable keepalives")
+}
+
+// waitFor polls cond on the CALLING goroutine. testify's Eventually evaluates
+// its condition in a fresh goroutine, which perturbs the very count the
+// goroutine-leak test measures.
+func waitFor(cond func() bool) bool {
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return cond()
+}
+
+// A write error must reap the goroutine on its own. Close() short-circuits once
+// emission has already halted, so if the loop waited to be told to exit, every
+// client that disconnects mid-stream would leak a ticker for the process
+// lifetime.
+func TestKeepaliveWriter_WriteErrorReapsGoroutine(t *testing.T) {
+	baseline := runtime.NumGoroutine()
+	rec := newSyncRecorder()
+	k := sse.NewKeepaliveWriter(rec, []byte(pingFrame), testKeepalive)
+	defer k.Close()
+
+	_, err := k.Write([]byte("event: message_start\ndata: {}\n\n"))
+	require.NoError(t, err)
+	require.True(t, waitFor(func() bool { return pings(rec.body()) >= 1 }))
+	require.Greater(t, runtime.NumGoroutine(), baseline, "loop must be running")
+
+	rec.setWriteErr(errors.New("connection reset"))
+
+	assert.True(t, waitFor(func() bool { return runtime.NumGoroutine() <= baseline }),
+		"the keepalive goroutine must exit on write error, not linger until Close")
 }
 
 // A dead client socket must not spin the keepalive goroutine forever.

--- a/internal/sse/keepalive_test.go
+++ b/internal/sse/keepalive_test.go
@@ -129,6 +129,39 @@ func TestKeepaliveWriter_NeverSplitsARecord(t *testing.T) {
 		"the record must be reassembled intact")
 }
 
+// SSE terminators are CRLF or LF and can straddle two writes. A boundary test
+// that only matched "\n\n" within a single write silently disabled keepalives
+// for both shapes — the exact stall this writer exists to prevent.
+func TestKeepaliveWriter_RecognizesEveryRecordSeparator(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		writes []string
+		want   bool
+	}{
+		{"lf", []string{"event: a\ndata: {}\n\n"}, true},
+		{"crlf", []string{"event: a\r\ndata: {}\r\n\r\n"}, true},
+		{"mixed", []string{"event: a\ndata: {}\n\r\n"}, true},
+		{"separator split across writes", []string{"event: a\ndata: {}\n", "\n"}, true},
+		{"record split mid-field", []string{"event: a\ndata: {", "}\n\n"}, true},
+		{"single terminator is not a blank line", []string{"data: {}\r\n"}, false},
+		{"trailing lone CR may be half a CRLF", []string{"data: {}\n\r"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := newSyncRecorder()
+			k := sse.NewKeepaliveWriter(rec, []byte(pingFrame), testKeepalive)
+			defer k.Close()
+
+			for _, w := range tc.writes {
+				_, err := k.Write([]byte(w))
+				require.NoError(t, err)
+			}
+
+			got := waitFor(func() bool { return pings(rec.body()) >= 1 })
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 // A stream that is actively delivering content needs no padding.
 func TestKeepaliveWriter_ActiveStreamNotPadded(t *testing.T) {
 	rec := newSyncRecorder()

--- a/internal/sse/keepalive_test.go
+++ b/internal/sse/keepalive_test.go
@@ -93,9 +93,8 @@ func TestKeepaliveWriter_EmitsAfterSilence(t *testing.T) {
 		"keepalives must not precede the real stream")
 }
 
-// The writer must stay dormant until the first byte reaches the client. Arming
-// earlier would let a keepalive commit a response the router still wants to
-// retry on another provider.
+// Arms on first byte so a keepalive cannot commit a response the router
+// still wants to retry on another provider.
 func TestKeepaliveWriter_SilentUntilFirstWrite(t *testing.T) {
 	rec := newSyncRecorder()
 	k := sse.NewKeepaliveWriter(rec, []byte(pingFrame), testKeepalive)

--- a/internal/sse/keepalive_test.go
+++ b/internal/sse/keepalive_test.go
@@ -1,0 +1,218 @@
+package sse_test
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"workweave/router/internal/sse"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	pingFrame     = "event: ping\ndata: {\"type\":\"ping\"}\n\n"
+	testKeepalive = 40 * time.Millisecond
+)
+
+// syncRecorder is a goroutine-safe http.ResponseWriter. httptest.ResponseRecorder
+// is not: the keepalive writes from its own goroutine while the test reads.
+type syncRecorder struct {
+	mu       sync.Mutex
+	buf      bytes.Buffer
+	hdr      http.Header
+	code     int
+	flushes  int
+	writeErr error
+}
+
+func newSyncRecorder() *syncRecorder { return &syncRecorder{hdr: make(http.Header)} }
+
+func (s *syncRecorder) Header() http.Header { return s.hdr }
+
+func (s *syncRecorder) WriteHeader(code int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.code = code
+}
+
+func (s *syncRecorder) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.writeErr != nil {
+		return 0, s.writeErr
+	}
+	return s.buf.Write(p)
+}
+
+func (s *syncRecorder) Flush() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.flushes++
+}
+
+func (s *syncRecorder) body() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+func (s *syncRecorder) flushCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.flushes
+}
+
+func (s *syncRecorder) setWriteErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.writeErr = err
+}
+
+func pings(body string) int { return strings.Count(body, pingFrame) }
+
+// A stream that goes quiet after a complete record must get keepalives, or the
+// client's byte watchdog kills a turn that is still healthy upstream.
+func TestKeepaliveWriter_EmitsAfterSilence(t *testing.T) {
+	rec := newSyncRecorder()
+	k := sse.NewKeepaliveWriter(rec, []byte(pingFrame), testKeepalive)
+	defer k.Close()
+
+	_, err := k.Write([]byte("event: message_start\ndata: {}\n\n"))
+	require.NoError(t, err)
+
+	assert.Eventually(t, func() bool { return pings(rec.body()) >= 2 },
+		2*time.Second, 5*time.Millisecond, "silent stream must keep receiving keepalives")
+	assert.True(t, strings.HasPrefix(rec.body(), "event: message_start\ndata: {}\n\n"),
+		"keepalives must not precede the real stream")
+}
+
+// The writer must stay dormant until the first byte reaches the client. Arming
+// earlier would let a keepalive commit a response the router still wants to
+// retry on another provider.
+func TestKeepaliveWriter_SilentUntilFirstWrite(t *testing.T) {
+	rec := newSyncRecorder()
+	k := sse.NewKeepaliveWriter(rec, []byte(pingFrame), testKeepalive)
+	defer k.Close()
+
+	k.WriteHeader(http.StatusOK)
+	time.Sleep(6 * testKeepalive)
+
+	assert.Empty(t, rec.body(), "unarmed writer must emit nothing")
+}
+
+// Injecting between the halves of a record would corrupt the event, so a write
+// that does not end on a record boundary must suppress keepalives until one does.
+func TestKeepaliveWriter_NeverSplitsARecord(t *testing.T) {
+	rec := newSyncRecorder()
+	k := sse.NewKeepaliveWriter(rec, []byte(pingFrame), testKeepalive)
+	defer k.Close()
+
+	_, err := k.Write([]byte("event: content_block_delta\ndata: {\"partial\":"))
+	require.NoError(t, err)
+	time.Sleep(6 * testKeepalive)
+	require.Zero(t, pings(rec.body()), "must not inject inside a partial record")
+
+	_, err = k.Write([]byte("true}\n\n"))
+	require.NoError(t, err)
+
+	assert.Eventually(t, func() bool { return pings(rec.body()) >= 1 },
+		2*time.Second, 5*time.Millisecond, "keepalives must resume once the record closes")
+	assert.True(t, strings.HasPrefix(rec.body(),
+		"event: content_block_delta\ndata: {\"partial\":true}\n\n"),
+		"the record must be reassembled intact")
+}
+
+// A stream that is actively delivering content needs no padding.
+func TestKeepaliveWriter_ActiveStreamNotPadded(t *testing.T) {
+	rec := newSyncRecorder()
+	k := sse.NewKeepaliveWriter(rec, []byte(pingFrame), 200*time.Millisecond)
+	defer k.Close()
+
+	for range 10 {
+		_, err := k.Write([]byte("event: content_block_delta\ndata: {}\n\n"))
+		require.NoError(t, err)
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	assert.Zero(t, pings(rec.body()), "an active stream must not be padded")
+}
+
+// Close must stop emission before the handler returns, or a keepalive could be
+// written after the response is finished.
+func TestKeepaliveWriter_CloseStopsEmission(t *testing.T) {
+	rec := newSyncRecorder()
+	k := sse.NewKeepaliveWriter(rec, []byte(pingFrame), testKeepalive)
+
+	_, err := k.Write([]byte("event: message_start\ndata: {}\n\n"))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return pings(rec.body()) >= 1 },
+		2*time.Second, 5*time.Millisecond)
+
+	k.Close()
+	settled := pings(rec.body())
+	time.Sleep(6 * testKeepalive)
+
+	assert.Equal(t, settled, pings(rec.body()), "no keepalive may follow Close")
+}
+
+func TestKeepaliveWriter_CloseIsIdempotentAndSafeUnarmed(t *testing.T) {
+	rec := newSyncRecorder()
+	k := sse.NewKeepaliveWriter(rec, []byte(pingFrame), testKeepalive)
+
+	assert.NotPanics(t, k.Close, "closing an unarmed writer must be safe")
+	assert.NotPanics(t, k.Close, "Close must be idempotent")
+	assert.Empty(t, rec.body())
+}
+
+// A non-positive interval is the kill switch: the writer stays transparent.
+func TestKeepaliveWriter_DisabledByNonPositiveInterval(t *testing.T) {
+	rec := newSyncRecorder()
+	k := sse.NewKeepaliveWriter(rec, []byte(pingFrame), 0)
+	defer k.Close()
+
+	_, err := k.Write([]byte("event: message_start\ndata: {}\n\n"))
+	require.NoError(t, err)
+	time.Sleep(6 * testKeepalive)
+
+	assert.Zero(t, pings(rec.body()), "interval <= 0 must disable keepalives")
+}
+
+// A dead client socket must not spin the keepalive goroutine forever.
+func TestKeepaliveWriter_StopsOnWriteError(t *testing.T) {
+	rec := newSyncRecorder()
+	k := sse.NewKeepaliveWriter(rec, []byte(pingFrame), testKeepalive)
+	defer k.Close()
+
+	_, err := k.Write([]byte("event: message_start\ndata: {}\n\n"))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return pings(rec.body()) >= 1 },
+		2*time.Second, 5*time.Millisecond)
+
+	rec.setWriteErr(errors.New("connection reset"))
+	time.Sleep(4 * testKeepalive)
+	rec.setWriteErr(nil)
+
+	settled := pings(rec.body())
+	time.Sleep(6 * testKeepalive)
+	assert.Equal(t, settled, pings(rec.body()), "keepalive must stop after a write error")
+}
+
+func TestKeepaliveWriter_PassesThroughHeaderStatusAndFlush(t *testing.T) {
+	rec := newSyncRecorder()
+	k := sse.NewKeepaliveWriter(rec, []byte(pingFrame), testKeepalive)
+	defer k.Close()
+
+	k.Header().Set("Content-Type", "text/event-stream")
+	k.WriteHeader(http.StatusOK)
+	k.Flush()
+
+	assert.Equal(t, "text/event-stream", rec.Header().Get("Content-Type"))
+	assert.Equal(t, http.StatusOK, rec.code)
+	assert.Equal(t, 1, rec.flushCount())
+}


### PR DESCRIPTION
## Problem

Clients time a stream out on received **bytes**, not on semantic events. Claude Code applies a byte-level stream idle watchdog that defaults to **180 s** for first-party streams, and an `ANTHROPIC_BASE_URL` override does not change that classification — so all routed traffic is subject to it. It is overridable client-side via `CLAUDE_STREAM_IDLE_TIMEOUT_MS` / `CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS`.

Three turns from one prod session on 2026-08-24:

| start (UTC) | latency | ttft | input | output | upstream |
|---|---|---|---|---|---|
| 00:13:42.807 | 357,659 ms | 1,763 ms | 309,240 | 64,000 | 0 (no error) |
| 00:28:30.024 | 324,172 ms | 1,786 ms | 371,127 | 64,000 | 0 |
| 00:35:21.790 | 322,209 ms | 1,864 ms | 380,173 | 64,000 | 0 |

Each `gpt-5.6-luna` turn spent its **entire 64K output budget reasoning** for 320–360 s on a 300–380K-token context. Reasoning emits no client-facing Anthropic frames, so Claude Code saw nothing after `message_start` and gave up at exactly `start + 180 s` (→ 00:16:42.8 and 00:31:30.0, matching the two reported failures). The router completed all three successfully and billed for them.

**No upstream watchdog covers this.** They measure the *upstream* leg: byte-idle (90 s) keeps getting reset by Responses bookkeeping frames the translator drops, and the output-stall budget (240 s) is deliberately longer than the client's 180 s. The gap is the *client* leg.

## Fix

Wrap the client writer in `sse.KeepaliveWriter`, emitting the Anthropic `ping` frame after `ROUTER_SSE_KEEPALIVE_INTERVAL_SECONDS` (default **15 s**, `0` disables) of client-facing silence. This is what direct-to-Anthropic already gets for free — Anthropic's own API emits `ping` for exactly this reason, and `anthropic_footer.go` already forwards them.

**Deliberately not lowering the output-stall budget below 180 s.** All three turns *succeeded*; aborting them would convert a recoverable stall into a hard failure.

### Invariants

- **Innermost wrap** — below the feedback footer, so it observes bytes that actually reach the client.
- **Arms on first byte, never before** — for a `preludeBuffer` chain that is the commit point, so a keepalive can never commit a response still eligible for retry on another binding.
- **Record-boundary only** — emits only when the last write ended on a blank line, so it can never split an event.
- **`Close()` before the handler returns**, blocking on any in-flight frame.

## Scope

Only the Anthropic Messages surface is wrapped — that is where the failure was observed. The frame is a parameter, so OpenAI/Gemini are a wiring change plus their own frame.

## Testing

`gofmt -l .`, `go vet ./...`, `go build ./...`, and the full `go test -count=1 ./...` all clean; `internal/sse` and `internal/proxy` also pass under `-race`.

- 9 unit tests in `internal/sse` covering arm-on-first-byte, record-boundary suppression, active-stream no-op, `Close()` semantics, the `0` kill switch, and write-error shutdown.
- 2 end-to-end `ProxyMessages` tests driving a real stub upstream that commits then stalls — one asserting the stream gets padded and stays well-formed, one asserting `interval = 0` leaves it byte-for-byte unpadded.

## Rollback

`ROUTER_SSE_KEEPALIVE_INTERVAL_SECONDS=0`.

🤖 Generated with [Weave Router](https://router.workweave.ai)
