### PR TITLE
feat(timing): measure time-to-first-OUTPUT, not just time-to-first-byte

### DIFF
--- a/internal/providers/anthropic/client.go
+++ b/internal/providers/anthropic/client.go
@@ -295,7 +295,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 			outMark()
 			tpMark()
 		}
-		if arm.ArmOutputProgress(combined) {
+		if arm.ArmOutputProgress(timing.FirstOutputMark(ctx, combined)) {
 			defer outStop()
 			defer tpStop()
 		} else {

--- a/internal/providers/google/native_client.go
+++ b/internal/providers/google/native_client.go
@@ -151,7 +151,7 @@ func (c *NativeClient) Proxy(ctx context.Context, decision router.Decision, prep
 	// byte-idle-guarded only.
 	if arm, ok := w.(providers.OutputProgressArmer); ok {
 		outMark, outStop := httputil.StartIdleWatchdogCause(ctx, cancel, c.outputStallTimeout(), httputil.ErrUpstreamOutputStall)
-		if arm.ArmOutputProgress(outMark) {
+		if arm.ArmOutputProgress(timing.FirstOutputMark(ctx, outMark)) {
 			defer outStop()
 		} else {
 			outStop()

--- a/internal/providers/openai/client.go
+++ b/internal/providers/openai/client.go
@@ -316,7 +316,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	if prep.Endpoint == providers.EndpointResponses {
 		if arm, ok := w.(providers.OutputProgressArmer); ok {
 			outMark, outStop := httputil.StartIdleWatchdogCause(ctx, cancel, c.outputStallTimeout(), httputil.ErrUpstreamOutputStall)
-			if arm.ArmOutputProgress(outMark) {
+			if arm.ArmOutputProgress(timing.FirstOutputMark(ctx, outMark)) {
 				defer outStop()
 			} else {
 				outStop()

--- a/internal/providers/openaicompat/client.go
+++ b/internal/providers/openaicompat/client.go
@@ -265,7 +265,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 			outMark()
 			tpMark()
 		}
-		if arm.ArmOutputProgress(combined) {
+		if arm.ArmOutputProgress(timing.FirstOutputMark(ctx, combined)) {
 			defer outStop()
 			defer tpStop()
 		} else {

--- a/internal/proxy/first_output_span_test.go
+++ b/internal/proxy/first_output_span_test.go
@@ -1,0 +1,96 @@
+package proxy_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/providers/openaicompat"
+	"workweave/router/internal/proxy"
+	"workweave/router/internal/router"
+	"workweave/router/internal/timing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+func attrInt(sp *tracev1.Span, key string) (int64, bool) {
+	for _, kv := range sp.Attributes {
+		if kv.Key != key {
+			continue
+		}
+		if iv, ok := kv.Value.Value.(*commonv1.AnyValue_IntValue); ok {
+			return iv.IntValue, true
+		}
+	}
+	return 0, false
+}
+
+// TestUpstreamSpan_FirstOutputMs_ExceedsTTFTOnReasoningStall is the reason the
+// attribute exists. TTFB stops at the response envelope, so the prod
+// 2026-08-24 turns reported a healthy ~1.8s TTFT while their first renderable
+// token was minutes away — the failure was invisible on every dashboard.
+// latency.first_output_ms must measure the first OUTPUT-BEARING frame, so a
+// role-only keepalive followed by a stall must not satisfy it.
+func TestUpstreamSpan_FirstOutputMs_ExceedsTTFTOnReasoningStall(t *testing.T) {
+	const preOutputStall = 120 * time.Millisecond
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		write := func(chunk string) {
+			_, _ = w.Write([]byte(chunk))
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		// Byte-alive immediately, but role-only: nothing the client can render.
+		write(`data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"deepseek/deepseek-v4-pro","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}` + "\n\n")
+		time.Sleep(preOutputStall)
+		write(`data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"deepseek/deepseek-v4-pro","choices":[{"index":0,"delta":{"content":"finally"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":1}}` + "\n\n")
+		write("data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	collector := newSpanCollector(t)
+	emitter := newTestEmitter(t, collector.srv.URL)
+
+	svc := proxy.NewService(
+		&fakeRouter{decision: router.Decision{Provider: "fireworks", Model: "deepseek/deepseek-v4-pro"}},
+		map[string]providers.Client{"fireworks": openaicompat.NewClient("test-fw-key", upstream.URL)},
+		emitter, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil,
+	).WithDeploymentKeyedProviders(map[string]struct{}{"fireworks": {}})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	body := []byte(`{"model":"deepseek/deepseek-v4-pro","stream":true,"messages":[{"role":"user","content":"hi"}]}`)
+	// Middleware installs Timing on the request context in prod; without it
+	// there are no latency attributes at all.
+	ctx, _ := timing.WithTiming(context.Background())
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec, req.WithContext(ctx)))
+	require.NoError(t, emitter.Shutdown(context.Background()))
+
+	collector.mu.Lock()
+	spans := collector.byName["router.upstream"]
+	collector.mu.Unlock()
+	require.Len(t, spans, 1, "exactly one router.upstream span must be exported")
+	sp := spans[0]
+
+	firstByte, hasFirstByte := attrInt(sp, "latency.upstream_first_byte_ms")
+	firstOutput, hasFirstOutput := attrInt(sp, "latency.first_output_ms")
+	require.True(t, hasFirstByte, "the established first-byte attribute must stay present")
+	require.True(t, hasFirstOutput, "a turn that produced output must carry latency.first_output_ms")
+
+	assert.GreaterOrEqual(t, firstOutput, int64(preOutputStall/time.Millisecond),
+		"first output must be measured past the stall, not at the role-only frame")
+	assert.Greater(t, firstOutput, firstByte,
+		"the whole point: a byte-alive stream with no renderable content must not look healthy")
+}

--- a/internal/proxy/first_output_span_test.go
+++ b/internal/proxy/first_output_span_test.go
@@ -33,12 +33,8 @@ func attrInt(sp *tracev1.Span, key string) (int64, bool) {
 	return 0, false
 }
 
-// TestUpstreamSpan_FirstOutputMs_ExceedsTTFTOnReasoningStall is the reason the
-// attribute exists. TTFB stops at the response envelope, so the prod
-// 2026-08-24 turns reported a healthy ~1.8s TTFT while their first renderable
-// token was minutes away — the failure was invisible on every dashboard.
-// latency.first_output_ms must measure the first OUTPUT-BEARING frame, so a
-// role-only keepalive followed by a stall must not satisfy it.
+// TestUpstreamSpan_FirstOutputMs_ExceedsTTFTOnReasoningStall verifies that
+// a role-only keepalive does not satisfy first_output_ms.
 func TestUpstreamSpan_FirstOutputMs_ExceedsTTFTOnReasoningStall(t *testing.T) {
 	const preOutputStall = 120 * time.Millisecond
 

--- a/internal/proxy/observation.go
+++ b/internal/proxy/observation.go
@@ -43,10 +43,8 @@ type observationContext struct {
 	// TTFTMs is the upstream-request-to-first-byte delta in ms. Pointer because
 	// zero is a legitimate sub-millisecond measurement.
 	TTFTMs *int64
-	// FirstOutputMs is upstream-request to first OUTPUT-BEARING frame. TTFTMs
-	// stops at the response envelope, so a turn that reasons for minutes before
-	// emitting a renderable token still reports a healthy TTFT; this is the
-	// delta that exposes it.
+	// FirstOutputMs is upstream-request to first OUTPUT-BEARING frame;
+	// unlike TTFTMs, not satisfied by a reasoning-only envelope.
 	FirstOutputMs *int64
 	// CandidateScores is the pre-argmax score vector, JSON-marshaled for the
 	// jsonb column (nil if none). Off-policy substrate only — never read on the request path.

--- a/internal/proxy/observation.go
+++ b/internal/proxy/observation.go
@@ -43,6 +43,11 @@ type observationContext struct {
 	// TTFTMs is the upstream-request-to-first-byte delta in ms. Pointer because
 	// zero is a legitimate sub-millisecond measurement.
 	TTFTMs *int64
+	// FirstOutputMs is upstream-request to first OUTPUT-BEARING frame. TTFTMs
+	// stops at the response envelope, so a turn that reasons for minutes before
+	// emitting a renderable token still reports a healthy TTFT; this is the
+	// delta that exposes it.
+	FirstOutputMs *int64
 	// CandidateScores is the pre-argmax score vector, JSON-marshaled for the
 	// jsonb column (nil if none). Off-policy substrate only — never read on the request path.
 	CandidateScores []byte
@@ -162,6 +167,9 @@ func buildObservationContext(ctx context.Context, decision, fresh router.Decisio
 		if ms := t.Ms(&t.UpstreamRequestNanos, &t.UpstreamFirstByteNanos); ms > 0 {
 			obs.TTFTMs = &ms
 		}
+		if ms := t.Ms(&t.UpstreamRequestNanos, &t.UpstreamFirstOutputNanos); ms > 0 {
+			obs.FirstOutputMs = &ms
+		}
 	}
 	return obs
 }
@@ -219,5 +227,8 @@ func (o observationContext) applySpanAttrs(b *otel.AttrBuilder) {
 	}
 	if o.TTFTMs != nil {
 		b.Int64("latency.ttft_ms", *o.TTFTMs)
+	}
+	if o.FirstOutputMs != nil {
+		b.Int64("latency.first_output_ms", *o.FirstOutputMs)
 	}
 }

--- a/internal/timing/first_output_test.go
+++ b/internal/timing/first_output_test.go
@@ -12,9 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// The whole point of the field: a reasoning turn's first BYTE lands in
-// milliseconds (the response envelope) while its first renderable token can be
-// minutes out, so TTFB reports a healthy stream on a turn nobody can see.
+// First output must be later than first byte on a reasoning-stall stream.
 func TestFirstOutputMark_MeasuresOutputNotFirstByte(t *testing.T) {
 	ctx, tm := timing.WithTiming(context.Background())
 

--- a/internal/timing/first_output_test.go
+++ b/internal/timing/first_output_test.go
@@ -1,0 +1,79 @@
+package timing_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"workweave/router/internal/timing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The whole point of the field: a reasoning turn's first BYTE lands in
+// milliseconds (the response envelope) while its first renderable token can be
+// minutes out, so TTFB reports a healthy stream on a turn nobody can see.
+func TestFirstOutputMark_MeasuresOutputNotFirstByte(t *testing.T) {
+	ctx, tm := timing.WithTiming(context.Background())
+
+	tm.StampUpstreamRequest()
+	tm.StampUpstreamFirstByte()
+	time.Sleep(20 * time.Millisecond)
+	timing.FirstOutputMark(ctx, func() {})()
+
+	ttfb := tm.Ms(&tm.UpstreamRequestNanos, &tm.UpstreamFirstByteNanos)
+	firstOutput := tm.Ms(&tm.UpstreamRequestNanos, &tm.UpstreamFirstOutputNanos)
+
+	assert.Greater(t, firstOutput, ttfb,
+		"first output must be measured from the output frame, not the envelope")
+	assert.GreaterOrEqual(t, firstOutput, int64(20))
+}
+
+// The mark feeds the output-stall watchdog; stamping must not swallow it.
+func TestFirstOutputMark_StillCallsWrappedMark(t *testing.T) {
+	var calls atomic.Int64
+	ctx, _ := timing.WithTiming(context.Background())
+	mark := timing.FirstOutputMark(ctx, func() { calls.Add(1) })
+
+	mark()
+	mark()
+	mark()
+
+	assert.Equal(t, int64(3), calls.Load(), "every output frame must still reach the watchdog")
+}
+
+// Later frames must not move the timestamp — it is a first-output measurement.
+func TestFirstOutputMark_StampsOnlyOnce(t *testing.T) {
+	ctx, tm := timing.WithTiming(context.Background())
+	mark := timing.FirstOutputMark(ctx, func() {})
+
+	mark()
+	first := tm.UpstreamFirstOutputNanos.Load()
+	require.NotZero(t, first)
+	time.Sleep(5 * time.Millisecond)
+	mark()
+
+	assert.Equal(t, first, tm.UpstreamFirstOutputNanos.Load(), "only the first output frame counts")
+}
+
+// A stream that never produces output must leave the field unset rather than
+// reporting 0 ms, which would read as "instant" on a dashboard.
+func TestFirstOutputMark_UnsetWhenNoOutputEverArrives(t *testing.T) {
+	_, tm := timing.WithTiming(context.Background())
+	tm.StampUpstreamRequest()
+
+	assert.Zero(t, tm.Ms(&tm.UpstreamRequestNanos, &tm.UpstreamFirstOutputNanos),
+		"no output frame means no measurement")
+}
+
+// Providers build the mark from the request context, which has no Timing on
+// non-proxied paths.
+func TestFirstOutputMark_NilTimingIsSafe(t *testing.T) {
+	var calls int
+	mark := timing.FirstOutputMark(context.Background(), func() { calls++ })
+
+	assert.NotPanics(t, mark, "a context without Timing must not panic the watchdog mark")
+	assert.Equal(t, 1, calls)
+}

--- a/internal/timing/timing.go
+++ b/internal/timing/timing.go
@@ -21,10 +21,8 @@ type Timing struct {
 	UpstreamRequestNanos   atomic.Int64
 	UpstreamHeadersNanos   atomic.Int64
 	UpstreamFirstByteNanos atomic.Int64
-	// UpstreamFirstOutputNanos is the first OUTPUT-BEARING frame, which is not
-	// the first byte: a reasoning model emits envelope and reasoning frames for
-	// minutes before any content the client can render. TTFB therefore reports
-	// ~2s on a turn whose first visible token is 5 minutes out.
+	// UpstreamFirstOutputNanos is the first OUTPUT-BEARING frame: a reasoning
+	// model emits envelope/reasoning frames before any renderable content.
 	UpstreamFirstOutputNanos atomic.Int64
 	UpstreamEOFNanos         atomic.Int64
 }

--- a/internal/timing/timing.go
+++ b/internal/timing/timing.go
@@ -21,7 +21,12 @@ type Timing struct {
 	UpstreamRequestNanos   atomic.Int64
 	UpstreamHeadersNanos   atomic.Int64
 	UpstreamFirstByteNanos atomic.Int64
-	UpstreamEOFNanos       atomic.Int64
+	// UpstreamFirstOutputNanos is the first OUTPUT-BEARING frame, which is not
+	// the first byte: a reasoning model emits envelope and reasoning frames for
+	// minutes before any content the client can render. TTFB therefore reports
+	// ~2s on a turn whose first visible token is 5 minutes out.
+	UpstreamFirstOutputNanos atomic.Int64
+	UpstreamEOFNanos         atomic.Int64
 }
 
 // stampOnce stores time.Now().UnixNano() into field if it has not been stamped
@@ -63,6 +68,15 @@ func (t *Timing) StampUpstreamFirstByte() {
 		return
 	}
 	stampOnce(&t.UpstreamFirstByteNanos)
+}
+
+// StampUpstreamFirstOutput records the instant the first output-bearing frame
+// is translated (reasoning deltas and keepalives do not count).
+func (t *Timing) StampUpstreamFirstOutput() {
+	if t == nil {
+		return
+	}
+	stampOnce(&t.UpstreamFirstOutputNanos)
 }
 
 // StampUpstreamEOF records the instant the upstream response body reaches EOF.
@@ -112,4 +126,16 @@ func WithTiming(ctx context.Context) (context.Context, *Timing) {
 func TimingFrom(ctx context.Context) *Timing {
 	t, _ := ctx.Value(timingKey{}).(*Timing)
 	return t
+}
+
+// FirstOutputMark wraps an output-progress watchdog mark so the first
+// output-bearing frame also stamps UpstreamFirstOutputNanos. Only the
+// translator can tell an output frame from a reasoning/keepalive frame, so this
+// piggybacks on the mark it already feeds rather than re-deriving it.
+func FirstOutputMark(ctx context.Context, mark func()) func() {
+	t := TimingFrom(ctx)
+	return func() {
+		t.StampUpstreamFirstOutput()
+		mark()
+	}
 }


### PR DESCRIPTION
## Problem

`ttft_ms` stops at the **response envelope**. A reasoning model emits `response.created` within milliseconds, then can produce nothing renderable for minutes — so a turn nobody can see reports a perfectly healthy TTFT.

Prod 2026-08-24, the three `gpt-5.6-luna` turns from #1001:

| ttft_ms | total | first client-visible token |
|---|---|---|
| 1,763 | 357,659 ms | never (client aborted at 180 s) |
| 1,786 | 324,172 ms | never |
| 1,864 | 322,209 ms | never |

Nothing on any dashboard distinguished these from a fast turn. They were only found by reading raw telemetry rows — and that is the actual reason this class of failure ran for weeks.

## Fix

Stamp `UpstreamFirstOutputNanos` off the mark the output-stall watchdog **already** feeds. Only the translator can tell an output-bearing frame from a reasoning/keepalive frame, so that mark is the one place in the system where the distinction already exists; wrapping it is one call per provider adapter and no new plumbing.

Surfaced as **`latency.first_output_ms`** on the `router.upstream` span, next to the existing `latency.upstream_first_byte_ms`. A "first output over N seconds" alert becomes expressible.

Covers all four adapters that arm output progress: `openai`, `openaicompat`, `anthropic`, `google`.

## Deliberately out of scope

No Postgres column. Alerting lives in OTel/SigNoz, and a column costs a migration plus sqlc regeneration for something the spans already answer. Easy follow-up if we want it in the SQL dashboards.

## Testing

`gofmt -l .`, `go vet ./...`, and the full `go test -count=1 ./...` clean; new tests also pass under `-race` at `-count=3`.

- 5 unit tests in `internal/timing`: measures output rather than first byte, still forwards every mark to the watchdog, stamps first-writer-wins only, stays **unset** (not `0`) when no output ever arrives — `0` would read as "instant" on a dashboard — and is nil-`Timing` safe for non-proxied paths.
- 1 end-to-end span test driving a real `openaicompat` upstream that is byte-alive immediately with a role-only frame, stalls 120 ms, then emits content. Asserts `latency.first_output_ms ≥ 120` while `latency.upstream_first_byte_ms` stays at 0 — i.e. exactly the prod shape, with the two metrics disagreeing the way they should.

## Relationship to #1001

Independent — different files, no shared edits. #1001 stops the client from dying during these stalls; this one makes them visible.

🤖 Generated with [Weave Router](https://router.workweave.ai)