### PR TITLE
fix(proxy): strip the provider prefix on Anthropic metadata passthrough

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2184,6 +2184,12 @@ func (s *Service) PassthroughToNamedProvider(ctx context.Context, providerName s
 		if canon, had, cerr := translate.CanonicalizeModelInBody(body); cerr == nil && had {
 			body = canon
 		}
+		// Same reason as the variant tag above: a provider-qualified id is
+		// valid at ingress and on the routing path, but the native Anthropic
+		// API 404s on it.
+		if bare, had, cerr := translate.StripProviderPrefixInBody(body, providerName); cerr == nil && had {
+			body = bare
+		}
 	}
 
 	var prep providers.PreparedRequest

--- a/internal/translate/model_variant.go
+++ b/internal/translate/model_variant.go
@@ -27,6 +27,43 @@ func CanonicalModel(model string) (canonical string, hadVariantTag bool) {
 	return model, false
 }
 
+// StripProviderPrefix removes a leading "<provider>/" qualifier from model and
+// reports whether one was present. Router ingress deliberately accepts
+// provider-qualified ids — eval harnesses and gateway clients send
+// "anthropic/claude-opus-4-8" — and the routing path resolves them, but the
+// native Anthropic API does not know them.
+func StripProviderPrefix(model, provider string) (stripped string, hadPrefix bool) {
+	prefix := provider + "/"
+	if provider != "" && strings.HasPrefix(model, prefix) {
+		return model[len(prefix):], true
+	}
+	return model, false
+}
+
+// StripProviderPrefixInBody rewrites the request body's top-level "model" field
+// to drop a leading "<provider>/" qualifier, reporting whether one was present.
+//
+// This exists for the metadata passthrough (count_tokens, model list), which
+// forwards the body to the native provider without a routing decision. A
+// provider-qualified id survives that hop and the upstream 404s: the
+// 2026-08-23 SWE-Interact runs, launched with
+// `--model anthropic/claude-opus-4-8`, produced 198 consecutive
+// `POST /v1/messages/count_tokens` 404s ("not_found_error: model:
+// anthropic/claude-opus-4-8"), leaving Claude Code unable to measure its own
+// context for the whole run. Routing, pins, and telemetry keep the qualified
+// id; only the outbound passthrough body is rewritten.
+func StripProviderPrefixInBody(body []byte, provider string) (out []byte, hadPrefix bool, err error) {
+	stripped, had := StripProviderPrefix(gjson.GetBytes(body, "model").String(), provider)
+	if !had {
+		return body, false, nil
+	}
+	out, err = sjson.SetBytes(body, "model", stripped)
+	if err != nil {
+		return body, true, err
+	}
+	return out, true, nil
+}
+
 // CanonicalizeModelInBody rewrites the request body's top-level "model" field
 // to its canonical form (stripping a Claude Code context-window variant tag)
 // and reports whether the tag was present. A body whose model carries no tag —

--- a/internal/translate/model_variant_test.go
+++ b/internal/translate/model_variant_test.go
@@ -61,3 +61,76 @@ func TestCanonicalizeModelInBody(t *testing.T) {
 		assert.Equal(t, body, out)
 	})
 }
+
+func TestStripProviderPrefix(t *testing.T) {
+	cases := []struct {
+		name     string
+		model    string
+		provider string
+		stripped string
+		had      bool
+	}{
+		{"anthropic qualified", "anthropic/claude-opus-4-8", "anthropic", "claude-opus-4-8", true},
+		{"already bare", "claude-opus-4-8", "anthropic", "claude-opus-4-8", false},
+		{"other provider left alone", "openai/gpt-5.6-luna", "anthropic", "openai/gpt-5.6-luna", false},
+		{"prefix not at start", "x-anthropic/claude-opus-4-8", "anthropic", "x-anthropic/claude-opus-4-8", false},
+		{"empty provider is a no-op", "anthropic/claude-opus-4-8", "", "anthropic/claude-opus-4-8", false},
+		{"empty model", "", "anthropic", "", false},
+		{"only the first segment is dropped", "anthropic/vendor/model", "anthropic", "vendor/model", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, had := translate.StripProviderPrefix(tc.model, tc.provider)
+			assert.Equal(t, tc.stripped, got)
+			assert.Equal(t, tc.had, had)
+		})
+	}
+}
+
+func TestStripProviderPrefixInBody(t *testing.T) {
+	t.Run("rewrites a qualified id and preserves the rest of the body", func(t *testing.T) {
+		body := []byte(`{"model":"anthropic/claude-opus-4-8","messages":[{"role":"user","content":"hi"}]}`)
+
+		out, had, err := translate.StripProviderPrefixInBody(body, "anthropic")
+
+		require.NoError(t, err)
+		assert.True(t, had)
+		assert.Equal(t, "claude-opus-4-8", gjson.GetBytes(out, "model").String())
+		assert.Equal(t, "hi", gjson.GetBytes(out, "messages.0.content").String())
+	})
+
+	t.Run("leaves a bare id untouched", func(t *testing.T) {
+		body := []byte(`{"model":"claude-opus-4-8"}`)
+
+		out, had, err := translate.StripProviderPrefixInBody(body, "anthropic")
+
+		require.NoError(t, err)
+		assert.False(t, had)
+		assert.Equal(t, body, out)
+	})
+
+	t.Run("leaves a body with no model field untouched", func(t *testing.T) {
+		body := []byte(`{"messages":[]}`)
+
+		out, had, err := translate.StripProviderPrefixInBody(body, "anthropic")
+
+		require.NoError(t, err)
+		assert.False(t, had)
+		assert.Equal(t, body, out)
+	})
+
+	t.Run("composes with the variant tag as the passthrough does", func(t *testing.T) {
+		// Claude Code can send both at once: a qualified id carrying the 1M tag.
+		body := []byte(`{"model":"anthropic/claude-opus-4-8[1m]"}`)
+
+		canon, hadTag, err := translate.CanonicalizeModelInBody(body)
+		require.NoError(t, err)
+		require.True(t, hadTag)
+
+		out, hadPrefix, err := translate.StripProviderPrefixInBody(canon, "anthropic")
+		require.NoError(t, err)
+		require.True(t, hadPrefix)
+
+		assert.Equal(t, "claude-opus-4-8", gjson.GetBytes(out, "model").String())
+	})
+}


### PR DESCRIPTION
## Problem

`PassthroughToNamedProvider` forwards metadata requests (`count_tokens`, model list) to the native Anthropic API without a routing decision. It already strips Claude Code's `[1m]` context-window tag — with a comment explaining that a verbatim passthrough 404s — but it does **not** strip a `provider/` qualifier, which router ingress deliberately accepts and `/v1/messages` resolves fine.

The SWE-Interact bake-off harnesses launch with `--model anthropic/claude-opus-4-8`, so Claude Code puts that id on every `count_tokens` pre-flight. Staging logs for the 2026-08-23 run:

```
POST /v1/messages/count_tokens -> 404
{"type":"not_found_error","message":"model: anthropic/claude-opus-4-8"}
```

**198 of them**, from the run's first router call (23:58:54Z) to its last (02:19:13Z) — every count_tokens call the run made, and none outside it. Claude Code sizes its context with that endpoint, so auto-compaction ran blind for the entire evaluation. Plausibly a contributor to a session in that same run that degenerated into ~12.8k tool-call turns.

## Fix

Add `translate.StripProviderPrefix` / `StripProviderPrefixInBody` and apply them on the same normalization hop as the variant tag, for Anthropic passthrough only.

Routing, pins, and telemetry keep the qualified id — only the outbound passthrough body is rewritten. `/v1/messages` is untouched.

## Tests

- `TestStripProviderPrefix` — qualified/bare ids, a different provider's prefix, a prefix that isn't at the start, empty provider, empty model, and multi-segment ids (only the first segment is dropped).
- `TestStripProviderPrefixInBody` — rewrite preserves the rest of the body; bare id and model-less body are byte-identical no-ops; and one case composing the variant tag with the prefix (`anthropic/claude-opus-4-8[1m]` → `claude-opus-4-8`), which is the order the passthrough applies them in.

`go build ./...`, `go vet ./...`, `go test ./internal/translate/... ./internal/proxy/...` all pass.

🤖 Generated with [Weave Router](https://router.workweave.ai)