### PR TITLE
feat: add Azure Entra BYOK authentication

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -23,6 +23,7 @@ import (
 	"workweave/router/internal/auth"
 	"workweave/router/internal/billing"
 	"workweave/router/internal/config"
+	"workweave/router/internal/entra"
 	"workweave/router/internal/feedback"
 	"workweave/router/internal/flags"
 	"workweave/router/internal/observability"
@@ -423,6 +424,7 @@ func main() {
 		WithClusterModelLists(repo.ClusterModelLists).
 		WithUserClusterModelLists(repo.UserClusterModelLists, userClusterCache).
 		WithWIFTokenSource(buildWIFTokenSource(logger)).
+		WithEntraTokenSource(buildEntraTokenSource(logger)).
 		WithFlagOverridesDisabled(flagOverridesDisabled)
 
 	// Fans out Pub/Sub invalidations to this replica's cache; the 5-min TTL
@@ -1275,6 +1277,14 @@ func buildClusterScorer(availableProviders map[string]struct{}) (router.Router, 
 	}
 
 	return multi, defaultEmbedderID, nil
+}
+
+// buildEntraTokenSource constructs the per-key Microsoft Entra client-credentials
+// source backing BYOK keys with auth_type=azure_entra. The source is lazy: a
+// deployment without Azure keys never contacts Microsoft Entra.
+func buildEntraTokenSource(logger *slog.Logger) auth.EntraTokenSource {
+	logger.Debug("Microsoft Entra client credentials token source initialized")
+	return entra.NewClientCredentialsSource(&http.Client{Timeout: 10 * time.Second}, time.Now)
 }
 
 // buildWIFTokenSource constructs the workload attestation source backing BYOK

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -1279,9 +1279,8 @@ func buildClusterScorer(availableProviders map[string]struct{}) (router.Router, 
 	return multi, defaultEmbedderID, nil
 }
 
-// buildEntraTokenSource constructs the per-key Microsoft Entra client-credentials
-// source backing BYOK keys with auth_type=azure_entra. The source is lazy: a
-// deployment without Azure keys never contacts Microsoft Entra.
+// buildEntraTokenSource returns the lazy Microsoft Entra client-credentials token source;
+// a deployment without Azure keys never contacts Microsoft Entra.
 func buildEntraTokenSource(logger *slog.Logger) auth.EntraTokenSource {
 	logger.Debug("Microsoft Entra client credentials token source initialized")
 	return entra.NewClientCredentialsSource(&http.Client{Timeout: 10 * time.Second}, time.Now)

--- a/db/migrations/0064_external-key-azure-entra-auth.down.sql
+++ b/db/migrations/0064_external-key-azure-entra-auth.down.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+DELETE FROM router.model_router_external_api_keys
+WHERE auth_type = 'azure_entra';
+
+ALTER TABLE router.model_router_external_api_keys
+  DROP CONSTRAINT model_router_external_api_keys_azure_entra_auth_check,
+  DROP CONSTRAINT model_router_external_api_keys_auth_type_check,
+  ADD CONSTRAINT model_router_external_api_keys_auth_type_check
+    CHECK (auth_type IN ('bearer', 'keypair_jwt', 'wif'));
+
+COMMENT ON COLUMN router.model_router_external_api_keys.auth_type IS 'bearer = send the stored secret as-is, keypair_jwt = the secret is an RSA private key the router signs short-lived JWTs with, wif = no stored secret and the router attests its own workload identity';
+COMMENT ON COLUMN router.model_router_external_api_keys.auth_account IS 'Account identifier the minted JWT is issued for; NULL unless auth_type is keypair_jwt';
+COMMENT ON COLUMN router.model_router_external_api_keys.auth_user IS 'User the minted JWT authenticates as; NULL unless auth_type is keypair_jwt';
+
+COMMIT;

--- a/db/migrations/0064_external-key-azure-entra-auth.up.sql
+++ b/db/migrations/0064_external-key-azure-entra-auth.up.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+ALTER TABLE router.model_router_external_api_keys
+  DROP CONSTRAINT model_router_external_api_keys_auth_type_check,
+  ADD CONSTRAINT model_router_external_api_keys_auth_type_check
+    CHECK (auth_type IN ('bearer', 'keypair_jwt', 'wif', 'azure_entra')),
+  ADD CONSTRAINT model_router_external_api_keys_azure_entra_auth_check
+    CHECK (auth_type <> 'azure_entra' OR (auth_account IS NOT NULL AND auth_user IS NOT NULL));
+
+COMMENT ON COLUMN router.model_router_external_api_keys.auth_type IS 'bearer = send the stored secret as-is, keypair_jwt = the secret is an RSA private key the router signs short-lived JWTs with, wif = no stored secret and the router attests its own workload identity, azure_entra = the secret is an Azure Entra client secret used to mint a short-lived bearer token';
+COMMENT ON COLUMN router.model_router_external_api_keys.auth_account IS 'Account identifier for keypair_jwt, or Microsoft Entra tenant ID for azure_entra';
+COMMENT ON COLUMN router.model_router_external_api_keys.auth_user IS 'User/principal for keypair_jwt, or Microsoft Entra client ID for azure_entra';
+
+COMMIT;

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -246,6 +246,58 @@ request depends on (`Authorization`, `x-api-key`, `Host`, `Content-Type`,
 `Content-Length`, `Accept`) is rejected with `400`. Omit both fields to forward
 nothing — identity only ever reaches the endpoint configured to receive it.
 
+
+### Microsoft Entra client credentials
+
+A tenant that uses Microsoft Foundry or Azure OpenAI can give the router an
+Entra application instead of a long-lived inference token. The stored secret is
+the application's client secret; the router exchanges it for a short-lived
+bearer token at the tenant's Microsoft identity endpoint and refreshes it before
+expiry. The secret is never sent to the inference endpoint.
+
+Use `azure_entra` only with `anthropic_gateway` (Foundry Claude) or
+`openai_gateway` (Azure OpenAI v1). The `auth_account` is the Entra tenant ID
+and `auth_user` is the application/client ID. The endpoint URL must be the
+provider's base URL; the router appends `/v1/messages` or `/chat/completions`.
+Azure deployment names belong in `model_aliases`:
+
+```bash
+# Foundry Claude: https://<resource>.services.ai.azure.com/anthropic/v1/messages
+curl -sS -b jar -X POST https://<router>/admin/v1/provider-keys \
+  -H 'content-type: application/json' \
+  -d '{"provider":"anthropic_gateway","auth_type":"azure_entra",
+       "key":"<entra-client-secret>",
+       "auth_account":"<tenant-id>",
+       "auth_user":"<client-id>",
+       "base_url":"https://<resource>.services.ai.azure.com/anthropic",
+       "model_aliases":{"claude-opus-5":"<deployment-name>"}}'
+
+# Azure OpenAI v1: https://<resource>.openai.azure.com/openai/v1/chat/completions
+curl -sS -b jar -X POST https://<router>/admin/v1/provider-keys \
+  -H 'content-type: application/json' \
+  -d '{"provider":"openai_gateway","auth_type":"azure_entra",
+       "key":"<entra-client-secret>",
+       "auth_account":"<tenant-id>",
+       "auth_user":"<client-id>",
+       "base_url":"https://<resource>.openai.azure.com/openai/v1",
+       "model_aliases":{"gpt-5":"<deployment-name>"}}'
+```
+
+The application must have permission to call the Azure resource (for example,
+**Foundry User** for Foundry Claude or **Cognitive Services OpenAI User** for
+Azure OpenAI). The token scope is `https://ai.azure.com/.default`.
+
+The router runs on GCP Cloud Run, so Azure managed identity is not available to
+it. Use a service principal for this mode. Workload identity federation from a
+GCP service account is a separate deployment-wide mode and is not the same as a
+per-tenant Entra application credential.
+
+Azure OpenAI's older dated `/openai/deployments/...` route is not supported by
+this gateway configuration; use the v1 endpoint shape above. Azure-hosted
+Foundry Claude deployments have a narrower feature set than Anthropic-hosted
+deployments, including restrictions on server-side tools, MCP, structured
+outputs, Agent Skills, programmatic tool calling, and the Files API.
+
 In `selfhosted` mode BYOK is always active (it's the only credentialing path).
 In `managed` mode it is opt-in per installation: the control plane sets
 `byok_enabled` on the installation row, and until it does, the auth middleware

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -285,7 +285,9 @@ curl -sS -b jar -X POST https://<router>/admin/v1/provider-keys \
 
 The application must have permission to call the Azure resource (for example,
 **Foundry User** for Foundry Claude or **Cognitive Services OpenAI User** for
-Azure OpenAI). The token scope is `https://ai.azure.com/.default`.
+Azure OpenAI). The token scope follows the endpoint: `https://ai.azure.com/.default`
+for Foundry, and `https://cognitiveservices.azure.com/.default` for
+`*.openai.azure.com` resources.
 
 The router runs on GCP Cloud Run, so Azure managed identity is not available to
 it. Use a service principal for this mode. Workload identity federation from a

--- a/frontend/src/components/settings/ProviderKeysPanel.tsx
+++ b/frontend/src/components/settings/ProviderKeysPanel.tsx
@@ -302,15 +302,17 @@ export function ProviderKeysPanel() {
   const baseURLRequired = provider != null && PROVIDERS_REQUIRING_BASE_URL.includes(provider);
   // Mirrors the server's normalization: a slash-only value normalizes away to nothing.
   const baseURLMissing = baseURLRequired && baseURL.trim().replace(/\/+$/, "") === "";
-  // Key-pair and workload-identity auth are gateway-only credential shapes; the
+  // Key-pair, workload-identity, and Entra auth are gateway-only credential shapes; the
   // vendor providers authenticate with their own API keys.
   const authTypeOffered = baseURLRequired;
   const usingKeypair = authTypeOffered && authType === "keypair_jwt";
   const usingWIF = authTypeOffered && authType === "wif";
+  const usingEntra = authTypeOffered && authType === "azure_entra";
   const keypairIncomplete = usingKeypair && (authAccount.trim() === "" || authUser.trim() === "");
+  const entraIncomplete = usingEntra && (authAccount.trim() === "" || authUser.trim() === "");
   // A WIF key carries no secret, so an empty key field is the expected state.
   const keyMissing = !usingWIF && keyValue.trim() === "";
-  const saveDisabled = saving || keyMissing || baseURLMissing || keypairIncomplete;
+  const saveDisabled = saving || keyMissing || baseURLMissing || keypairIncomplete || entraIncomplete;
   // Pre-save discovery can only authenticate with a token sent as-is; derived
   // auth (key pair, WIF) needs the stored key, so those save first and fetch
   // from the saved entry.
@@ -397,7 +399,7 @@ export function ProviderKeysPanel() {
         name.trim() || undefined,
         baseURL.trim() || undefined,
         aliasMapFrom(aliasRows),
-        usingKeypair
+        usingKeypair || usingEntra
           ? { type: authType, account: authAccount.trim(), user: authUser.trim() }
           : { type: authTypeOffered ? authType : "bearer" },
       );
@@ -480,14 +482,14 @@ export function ProviderKeysPanel() {
                   </div>
                 ) : (
                   <Input
-                    label="API key"
+                    label={usingEntra ? "Client secret" : "API key"}
                     type="password"
                     name="provider-api-key"
                     autoComplete="new-password"
                     data-1p-ignore
                     data-lpignore="true"
                     data-form-type="other"
-                    placeholder="sk-..."
+                    placeholder={usingEntra ? "Azure Entra client secret" : "sk-..."}
                     value={keyValue}
                     onChange={e => setKeyValue(e.target.value)}
                     required
@@ -512,6 +514,7 @@ export function ProviderKeysPanel() {
                     <option value="bearer">Token (sent as-is)</option>
                     <option value="keypair_jwt">Key pair (router signs a short-lived token)</option>
                     <option value="wif">Workload identity (router attests its own identity)</option>
+                    <option value="azure_entra">Microsoft Entra (router mints a short-lived token)</option>
                   </select>
                   {usingWIF ? (
                     <Text className="text-2xs text-muted-foreground">
@@ -521,27 +524,33 @@ export function ProviderKeysPanel() {
                   ) : null}
                 </div>
               ) : null}
-              {usingKeypair ? (
+              {usingKeypair || usingEntra ? (
                 <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                   <Input
-                    label="Account identifier"
+                    label={usingEntra ? "Tenant ID" : "Account identifier"}
                     name="provider-auth-account"
                     autoComplete="off"
-                    placeholder="MYORG-MYACCOUNT"
+                    placeholder={usingEntra ? "00000000-0000-0000-0000-000000000000" : "MYORG-MYACCOUNT"}
                     value={authAccount}
                     onChange={e => setAuthAccount(e.target.value)}
                     required
                   />
                   <Input
-                    label="User"
+                    label={usingEntra ? "Client ID" : "User"}
                     name="provider-auth-user"
                     autoComplete="off"
-                    placeholder="SERVICE_USER"
+                    placeholder={usingEntra ? "00000000-0000-0000-0000-000000000000" : "SERVICE_USER"}
                     value={authUser}
                     onChange={e => setAuthUser(e.target.value)}
                     required
                   />
                 </div>
+              ) : null}
+              {usingEntra ? (
+                <Text className="text-2xs text-muted-foreground">
+                  The router exchanges the client secret for a short-lived Entra token and sends only
+                  that token to Azure.
+                </Text>
               ) : null}
               <Input
                 label={baseURLRequired ? "Endpoint URL" : "Endpoint URL (optional)"}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -111,7 +111,8 @@ export interface IssueAPIKeyResponse {
 
 // ProviderAuthType is how a BYOK key authenticates upstream. "wif" keys hold no
 // secret at all: the router presents its own workload attestation per request.
-export type ProviderAuthType = "bearer" | "keypair_jwt" | "wif";
+// "azure_entra" stores an Entra client secret and mints a short-lived token.
+export type ProviderAuthType = "bearer" | "keypair_jwt" | "wif" | "azure_entra";
 
 export interface ExternalKey {
   id: string;
@@ -125,10 +126,13 @@ export interface ExternalKey {
   // uses catalog names directly.
   model_aliases?: Record<string, string>;
   // "bearer" (send the stored secret), "keypair_jwt" (the secret is an RSA
-  // private key the router signs short-lived tokens with), or "wif" (no stored
-  // secret; the router attests its own workload identity); absent means bearer.
+  // private key the router signs short-lived tokens with), "wif" (no stored
+  // secret; the router attests its own workload identity), or "azure_entra"
+  // (the secret is an Entra client secret used to mint a short-lived token);
+  // absent means bearer.
   auth_type?: ProviderAuthType;
-  // Principal a minted token is issued for; present only with keypair_jwt.
+  // Principal a minted token is issued for; present only with keypair_jwt or
+  // azure_entra. For azure_entra these are the tenant ID and client ID.
   auth_account?: string;
   auth_user?: string;
   last_used_at: string | null;

--- a/internal/api/admin/keys.go
+++ b/internal/api/admin/keys.go
@@ -291,7 +291,8 @@ func UpsertExternalKeyHandler(authSvc *auth.Service, models DeployedModelsSource
 		})
 		if err != nil {
 			if errors.Is(err, auth.ErrUnknownModel) || errors.Is(err, auth.ErrInvalidModelAlias) ||
-				errors.Is(err, auth.ErrInvalidIdentityHeader) || errors.Is(err, auth.ErrInvalidKeypairAuth) {
+				errors.Is(err, auth.ErrInvalidIdentityHeader) || errors.Is(err, auth.ErrInvalidKeypairAuth) ||
+				errors.Is(err, auth.ErrInvalidEntraAuth) {
 				c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 				return
 			}

--- a/internal/auth/entra.go
+++ b/internal/auth/entra.go
@@ -1,0 +1,18 @@
+package auth
+
+import (
+	"context"
+	"errors"
+)
+
+// EntraScope is the Microsoft Entra scope used by Azure AI inference endpoints.
+const EntraScope = "https://ai.azure.com/.default"
+
+// ErrEntraUnavailable is returned when an Azure Entra token cannot be obtained.
+var ErrEntraUnavailable = errors.New("auth: Microsoft Entra token is unavailable")
+
+// EntraTokenSource mints a short-lived Microsoft Entra token for a BYOK key.
+// The key carries the tenant ID, client ID, and encrypted client secret.
+type EntraTokenSource interface {
+	Token(context.Context, *ExternalAPIKey) ([]byte, error)
+}

--- a/internal/auth/entra.go
+++ b/internal/auth/entra.go
@@ -3,10 +3,32 @@ package auth
 import (
 	"context"
 	"errors"
+	"net/url"
+	"strings"
 )
 
-// EntraScope is the Microsoft Entra scope used by Azure AI inference endpoints.
+// EntraScope is the Microsoft Entra scope used by Foundry inference endpoints.
 const EntraScope = "https://ai.azure.com/.default"
+
+// EntraScopeCognitiveServices is the scope classic Azure OpenAI resources expect;
+// a token minted with EntraScope is rejected with 401 on *.openai.azure.com.
+const EntraScopeCognitiveServices = "https://cognitiveservices.azure.com/.default"
+
+// azureOpenAIHostSuffix identifies a classic Azure OpenAI resource endpoint.
+const azureOpenAIHostSuffix = ".openai.azure.com"
+
+// EntraScopeForBaseURL returns the token scope a key's endpoint accepts.
+func EntraScopeForBaseURL(baseURL string) string {
+	parsed, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil {
+		return EntraScope
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if strings.HasSuffix(host, azureOpenAIHostSuffix) {
+		return EntraScopeCognitiveServices
+	}
+	return EntraScope
+}
 
 // ErrEntraUnavailable is returned when an Azure Entra token cannot be obtained.
 var ErrEntraUnavailable = errors.New("auth: Microsoft Entra token is unavailable")

--- a/internal/auth/entra_test.go
+++ b/internal/auth/entra_test.go
@@ -1,0 +1,44 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/auth"
+)
+
+func TestNormalizeAuthTypeAzureEntraPreservesPrincipalValues(t *testing.T) {
+	tenantID := "  12345678-1234-1234-1234-123456789abc  "
+	clientID := "  ABCDEFAB-1234-1234-1234-ABCDEFABCDEF  "
+
+	authType, gotTenantID, gotClientID, err := auth.NormalizeAuthType(
+		auth.AuthTypeAzureEntra,
+		&tenantID,
+		&clientID,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, auth.AuthTypeAzureEntra, authType)
+	assert.Equal(t, "12345678-1234-1234-1234-123456789abc", *gotTenantID)
+	assert.Equal(t, "ABCDEFAB-1234-1234-1234-ABCDEFABCDEF", *gotClientID)
+}
+
+func TestNormalizeAuthTypeAzureEntraRequiresTenantAndClient(t *testing.T) {
+	value := "value"
+	for _, tc := range []struct {
+		name          string
+		account, user *string
+	}{
+		{name: "missing both"},
+		{name: "missing tenant", user: &value},
+		{name: "missing client", account: &value},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, _, err := auth.NormalizeAuthType(auth.AuthTypeAzureEntra, tc.account, tc.user)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, auth.ErrInvalidEntraAuth)
+		})
+	}
+}

--- a/internal/auth/entra_test.go
+++ b/internal/auth/entra_test.go
@@ -25,6 +25,20 @@ func TestNormalizeAuthTypeAzureEntraPreservesPrincipalValues(t *testing.T) {
 	assert.Equal(t, "ABCDEFAB-1234-1234-1234-ABCDEFABCDEF", *gotClientID)
 }
 
+func TestEntraScopeForBaseURL(t *testing.T) {
+	for _, tc := range []struct {
+		name, baseURL, want string
+	}{
+		{name: "empty base URL", want: auth.EntraScope},
+		{name: "foundry", baseURL: "https://resource.services.ai.azure.com/anthropic", want: auth.EntraScope},
+		{name: "azure openai", baseURL: " https://resource.OpenAI.Azure.com/openai/v1 ", want: auth.EntraScopeCognitiveServices},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, auth.EntraScopeForBaseURL(tc.baseURL))
+		})
+	}
+}
+
 func TestNormalizeAuthTypeAzureEntraRequiresTenantAndClient(t *testing.T) {
 	value := "value"
 	for _, tc := range []struct {

--- a/internal/auth/entra_verify_test.go
+++ b/internal/auth/entra_verify_test.go
@@ -1,0 +1,90 @@
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/auth"
+)
+
+type stubEntraSource struct {
+	credential []byte
+	err        error
+	calls      int
+}
+
+func (s *stubEntraSource) Token(ctx context.Context, key *auth.ExternalAPIKey) ([]byte, error) {
+	s.calls++
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return s.credential, s.err
+}
+
+func azureEntraKeyFor(installationID string) *auth.ExternalAPIKey {
+	return &auth.ExternalAPIKey{
+		ID:             "ext-key-entra",
+		InstallationID: installationID,
+		Provider:       "anthropic_gateway",
+		KeyFingerprint: "fp-entra",
+		AuthType:       auth.AuthTypeAzureEntra,
+		AuthAccount:    "tenant-id",
+		AuthUser:       "client-id",
+		Plaintext:      []byte("client-secret"),
+	}
+}
+
+func entraVerifyFixture(t *testing.T, rawToken string, src auth.EntraTokenSource) *auth.Service {
+	t.Helper()
+	install := &auth.Installation{ID: "install_entra", ExternalID: "org_entra", Name: "entra-tenant"}
+	apiKey := &auth.APIKey{
+		ID:             "key_entra",
+		InstallationID: install.ID,
+		ExternalID:     install.ExternalID,
+		KeyHash:        auth.HashAPIKeySHA256(rawToken),
+	}
+	external := &fakeExternalAPIKeyRepo{keys: []*auth.ExternalAPIKey{azureEntraKeyFor(install.ID)}}
+	return makeServiceWithExternalKeys(t, external, fakeKeyRow{apiKey: apiKey, installation: install}).
+		WithEntraTokenSource(src)
+}
+
+func TestService_VerifyAPIKeyAttachesEntraToken(t *testing.T) {
+	src := &stubEntraSource{credential: []byte("entra-access-token")}
+	svc := entraVerifyFixture(t, "rk_entra_attest_test", src)
+
+	_, _, externalKeys, _, err := svc.VerifyAPIKey(context.Background(), "rk_entra_attest_test")
+
+	require.NoError(t, err)
+	require.Len(t, externalKeys, 1)
+	assert.Equal(t, "entra-access-token", string(externalKeys[0].Plaintext))
+	assert.Equal(t, 1, src.calls)
+}
+
+func TestService_VerifyAPIKeyDropsEntraKeyWhenTokenFails(t *testing.T) {
+	svc := entraVerifyFixture(t, "rk_entra_broken_test", &stubEntraSource{err: errors.New("token endpoint unavailable")})
+
+	_, _, externalKeys, _, err := svc.VerifyAPIKey(context.Background(), "rk_entra_broken_test")
+
+	require.NoError(t, err)
+	assert.Empty(t, externalKeys, "a failed token exchange must not send the client secret upstream")
+}
+
+func TestService_UpsertExternalAPIKeyRejectsEntraForVendorProvider(t *testing.T) {
+	tenantID, clientID, baseURL := "tenant-id", "client-id", "https://example.com/anthropic"
+	svc := makeServiceWithExternalKeys(t, &fakeExternalAPIKeyRepo{})
+
+	_, err := svc.UpsertExternalAPIKey(context.Background(), "install_entra", auth.UpsertExternalAPIKeyParams{
+		Provider:    "anthropic",
+		RawKey:      "client-secret",
+		BaseURL:     &baseURL,
+		AuthType:    auth.AuthTypeAzureEntra,
+		AuthAccount: &tenantID,
+		AuthUser:    &clientID,
+	})
+
+	require.ErrorIs(t, err, auth.ErrInvalidEntraAuth)
+}

--- a/internal/auth/external_api_key.go
+++ b/internal/auth/external_api_key.go
@@ -27,9 +27,8 @@ type ExternalAPIKey struct {
 	IdentityHeaderFormat string
 	// AuthType is how Plaintext authenticates upstream; see AuthType* constants.
 	AuthType string
-	// AuthAccount and AuthUser identify the principal a minted JWT is issued
-	// for; empty unless AuthType is AuthTypeKeypairJWT or AuthTypeAzureEntra.
-	// Under AuthTypeWIF the principal comes from the attestation, so both stay empty.
+	// AuthAccount and AuthUser identify the upstream principal; empty unless
+	// AuthType is AuthTypeKeypairJWT or AuthTypeAzureEntra.
 	AuthAccount string
 	AuthUser    string
 	CreatedAt   time.Time
@@ -53,9 +52,8 @@ type CreateExternalAPIKeyParams struct {
 	IdentityHeader       *string
 	IdentityHeaderFormat *string
 	AuthType             string
-	// AuthAccount and AuthUser identify the principal a minted JWT is issued
-	// for; empty unless AuthType is AuthTypeKeypairJWT or AuthTypeAzureEntra.
-	// Under AuthTypeWIF the principal comes from the attestation, so both stay empty.
+	// AuthAccount and AuthUser identify the upstream principal; empty unless
+	// AuthType is AuthTypeKeypairJWT or AuthTypeAzureEntra.
 	AuthAccount *string
 	AuthUser    *string
 	CreatedBy   *string
@@ -67,9 +65,8 @@ type CreateExternalAPIKeyParams struct {
 const (
 	AuthTypeBearer     = "bearer"
 	AuthTypeKeypairJWT = "keypair_jwt"
-	// AuthTypeAzureEntra uses the stored client secret to mint a short-lived
-	// Microsoft Entra token. AuthAccount is the tenant ID and AuthUser is the
-	// client ID.
+	// AuthTypeAzureEntra exchanges the stored client secret for a short-lived Entra token;
+	// AuthAccount is the tenant ID, AuthUser is the client ID.
 	AuthTypeAzureEntra = "azure_entra"
 	AuthTypeWIF        = "wif"
 )

--- a/internal/auth/external_api_key.go
+++ b/internal/auth/external_api_key.go
@@ -28,8 +28,8 @@ type ExternalAPIKey struct {
 	// AuthType is how Plaintext authenticates upstream; see AuthType* constants.
 	AuthType string
 	// AuthAccount and AuthUser identify the principal a minted JWT is issued
-	// for; empty unless AuthType is AuthTypeKeypairJWT. Under AuthTypeWIF the
-	// principal comes from the attestation, so both stay empty.
+	// for; empty unless AuthType is AuthTypeKeypairJWT or AuthTypeAzureEntra.
+	// Under AuthTypeWIF the principal comes from the attestation, so both stay empty.
 	AuthAccount string
 	AuthUser    string
 	CreatedAt   time.Time
@@ -53,17 +53,24 @@ type CreateExternalAPIKeyParams struct {
 	IdentityHeader       *string
 	IdentityHeaderFormat *string
 	AuthType             string
-	// AuthAccount and AuthUser are required for AuthTypeKeypairJWT, nil otherwise.
+	// AuthAccount and AuthUser identify the principal a minted JWT is issued
+	// for; empty unless AuthType is AuthTypeKeypairJWT or AuthTypeAzureEntra.
+	// Under AuthTypeWIF the principal comes from the attestation, so both stay empty.
 	AuthAccount *string
 	AuthUser    *string
 	CreatedBy   *string
 }
 
 // AuthTypeBearer sends the secret verbatim; AuthTypeKeypairJWT signs a short-lived JWT with it;
-// AuthTypeWIF stores no secret and attests the router's own workload identity per request.
+// AuthTypeWIF stores no secret and attests the router's own workload identity per request;
+// AuthTypeAzureEntra exchanges the secret for a short-lived Microsoft Entra bearer token.
 const (
 	AuthTypeBearer     = "bearer"
 	AuthTypeKeypairJWT = "keypair_jwt"
+	// AuthTypeAzureEntra uses the stored client secret to mint a short-lived
+	// Microsoft Entra token. AuthAccount is the tenant ID and AuthUser is the
+	// client ID.
+	AuthTypeAzureEntra = "azure_entra"
 	AuthTypeWIF        = "wif"
 )
 
@@ -189,7 +196,8 @@ func NormalizeBaseURL(raw *string) (*string, error) {
 const maxKeypairFieldLength = 255
 
 // NormalizeAuthType validates authType with its account/user pair. Empty defaults to bearer;
-// keypair_jwt uppercases principal fields; wif accepts neither (the attestation names the principal).
+// keypair_jwt uppercases principal fields; azure_entra preserves the tenant and client IDs;
+// wif accepts neither because the attestation names the principal.
 func NormalizeAuthType(authType string, account, user *string) (string, *string, *string, error) {
 	normalized := strings.ToLower(strings.TrimSpace(authType))
 	// An account locator carries its region as dotted suffixes; the JWT claims
@@ -198,6 +206,17 @@ func NormalizeAuthType(authType string, account, user *string) (string, *string,
 	upperUser := strings.ToUpper(trimmedValue(user))
 	if normalized == "" {
 		normalized = AuthTypeBearer
+	}
+	if normalized == AuthTypeAzureEntra {
+		tenantID := strings.TrimSpace(trimmedValue(account))
+		clientID := strings.TrimSpace(trimmedValue(user))
+		if tenantID == "" || clientID == "" {
+			return "", nil, nil, fmt.Errorf("%w: %s needs both a tenant ID and a client ID", ErrInvalidEntraAuth, AuthTypeAzureEntra)
+		}
+		if len(tenantID) > maxKeypairFieldLength || len(clientID) > maxKeypairFieldLength {
+			return "", nil, nil, fmt.Errorf("%w: tenant ID and client ID are limited to %d characters", ErrInvalidEntraAuth, maxKeypairFieldLength)
+		}
+		return normalized, &tenantID, &clientID, nil
 	}
 	if normalized == AuthTypeBearer || normalized == AuthTypeWIF {
 		if upperAccount != "" || upperUser != "" {

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -38,6 +38,10 @@ var ErrInvalidIdentityHeader = errors.New("auth: invalid identity header")
 // principal, or private key is unusable.
 var ErrInvalidKeypairAuth = errors.New("auth: invalid keypair auth")
 
+// ErrInvalidEntraAuth is returned for an Azure Entra credential whose
+// principal or client secret is unusable.
+var ErrInvalidEntraAuth = errors.New("auth: invalid Microsoft Entra auth")
+
 type Clock func() time.Time
 
 // InstallationChangeNotifier fans out installation-change events to peer replicas.
@@ -70,6 +74,10 @@ type Service struct {
 	// wifTokens is nil unless the deployment runs with a workload identity;
 	// WIF keys are then dropped rather than sent without a credential.
 	wifTokens WIFTokenSource
+
+	// entraTokens is nil unless the deployment has an Entra token source;
+	// Azure Entra keys are then dropped rather than sent as client secrets.
+	entraTokens EntraTokenSource
 
 	// flagOverridesDisabled is the deployment-wide escape hatch
 	// (ROUTER_FLAG_OVERRIDES_DISABLED). When set, per-organization flag
@@ -121,6 +129,12 @@ func (s *Service) WithEncryptor(e Encryptor) *Service {
 // WithWIFTokenSource wires the attestation source backing AuthTypeWIF keys.
 func (s *Service) WithWIFTokenSource(src WIFTokenSource) *Service {
 	s.wifTokens = src
+	return s
+}
+
+// WithEntraTokenSource wires the source backing AuthTypeAzureEntra keys.
+func (s *Service) WithEntraTokenSource(src EntraTokenSource) *Service {
+	s.entraTokens = src
 	return s
 }
 
@@ -286,6 +300,7 @@ type UpsertExternalAPIKeyParams struct {
 	IdentityHeaderFormat *string
 	// AuthType selects how RawKey authenticates upstream; empty means AuthTypeBearer.
 	// AuthTypeKeypairJWT makes RawKey an RSA private key issued for AuthAccount/AuthUser.
+	// AuthTypeAzureEntra makes RawKey an Entra client secret for AuthAccount/AuthUser.
 	AuthType    string
 	AuthAccount *string
 	AuthUser    *string
@@ -319,6 +334,14 @@ func (s *Service) UpsertExternalAPIKey(ctx context.Context, installationID strin
 		// pasted secret here would be stored and never used.
 		if rawKey != "" {
 			return nil, fmt.Errorf("%w: %s takes no key material", ErrInvalidKeypairAuth, AuthTypeWIF)
+		}
+	}
+	if authType == AuthTypeAzureEntra {
+		if !providers.RequiresBaseURL(provider) {
+			return nil, fmt.Errorf("%w: %s does not accept Microsoft Entra credentials", ErrInvalidEntraAuth, provider)
+		}
+		if rawKey == "" {
+			return nil, fmt.Errorf("%w: %s needs a client secret", ErrInvalidEntraAuth, AuthTypeAzureEntra)
 		}
 	}
 	if authType == AuthTypeKeypairJWT {

--- a/internal/auth/upstream_secrets.go
+++ b/internal/auth/upstream_secrets.go
@@ -14,7 +14,7 @@ func (s *Service) resolveUpstreamSecrets(ctx context.Context, keys []*ExternalAP
 	}
 	resolved := make([]*ExternalAPIKey, 0, len(keys))
 	for _, key := range keys {
-		if key.AuthType != AuthTypeKeypairJWT && key.AuthType != AuthTypeWIF {
+		if key.AuthType != AuthTypeKeypairJWT && key.AuthType != AuthTypeWIF && key.AuthType != AuthTypeAzureEntra {
 			resolved = append(resolved, key)
 			continue
 		}
@@ -56,19 +56,26 @@ func (s *Service) ExternalAPIKeyWithCredential(ctx context.Context, installation
 // upstreamCredential derives the bearer value for a key whose stored secret is not itself
 // the credential.
 func (s *Service) upstreamCredential(ctx context.Context, key *ExternalAPIKey) ([]byte, error) {
-	if key.AuthType == AuthTypeWIF {
+	switch key.AuthType {
+	case AuthTypeWIF:
 		if s.wifTokens == nil {
 			return nil, ErrWIFUnavailable
 		}
 		return s.wifTokens.Attestation(ctx)
+	case AuthTypeAzureEntra:
+		if s.entraTokens == nil {
+			return nil, ErrEntraUnavailable
+		}
+		return s.entraTokens.Token(ctx, key)
+	default:
+		return s.keypairTokens.Bearer(key)
 	}
-	return s.keypairTokens.Bearer(key)
 }
 
 // anyDerivedAuth reports whether any key's credential has to be derived rather than sent as stored.
 func anyDerivedAuth(keys []*ExternalAPIKey) bool {
 	for _, key := range keys {
-		if key.AuthType == AuthTypeKeypairJWT || key.AuthType == AuthTypeWIF {
+		if key.AuthType == AuthTypeKeypairJWT || key.AuthType == AuthTypeWIF || key.AuthType == AuthTypeAzureEntra {
 			return true
 		}
 	}

--- a/internal/entra/client_credentials.go
+++ b/internal/entra/client_credentials.go
@@ -1,0 +1,165 @@
+// Package entra provides Microsoft Entra client-credentials token sources.
+package entra
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"golang.org/x/sync/singleflight"
+
+	"workweave/router/internal/auth"
+)
+
+const (
+	cacheSize       = 1024
+	refreshFraction = 0.8
+	maxErrorBody    = 4 * 1024
+)
+
+type cachedToken struct {
+	token     []byte
+	refreshAt time.Time
+}
+
+// ClientCredentialsSource obtains Microsoft Entra access tokens using an
+// external API key's tenant, client ID, and client secret.
+type ClientCredentialsSource struct {
+	httpClient *http.Client
+	now        auth.Clock
+
+	mu    sync.Mutex
+	cache *lru.Cache[string, cachedToken]
+	group singleflight.Group
+}
+
+// NewClientCredentialsSource constructs a source with the supplied HTTP client
+// and clock. A nil client uses http.DefaultClient; a nil clock uses time.Now.
+func NewClientCredentialsSource(httpClient *http.Client, now auth.Clock) *ClientCredentialsSource {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	if now == nil {
+		now = time.Now
+	}
+	cache, err := lru.New[string, cachedToken](cacheSize)
+	if err != nil {
+		panic("entra: invalid token cache size")
+	}
+	return &ClientCredentialsSource{
+		httpClient: httpClient,
+		now:        now,
+		cache:      cache,
+	}
+}
+
+// Token returns a cached or freshly minted Microsoft Entra access token for key.
+func (s *ClientCredentialsSource) Token(ctx context.Context, key *auth.ExternalAPIKey) ([]byte, error) {
+	if key == nil {
+		return nil, fmt.Errorf("%w: key is nil", auth.ErrEntraUnavailable)
+	}
+	if strings.TrimSpace(key.AuthAccount) == "" {
+		return nil, fmt.Errorf("%w: tenant ID is missing", auth.ErrEntraUnavailable)
+	}
+	if strings.TrimSpace(key.AuthUser) == "" {
+		return nil, fmt.Errorf("%w: client ID is missing", auth.ErrEntraUnavailable)
+	}
+	if len(key.Plaintext) == 0 {
+		return nil, fmt.Errorf("%w: client secret is missing", auth.ErrEntraUnavailable)
+	}
+
+	cacheKey := key.ID + "\x00" + key.KeyFingerprint
+	now := s.now()
+	s.mu.Lock()
+	cached, ok := s.cache.Get(cacheKey)
+	s.mu.Unlock()
+	if ok && now.Before(cached.refreshAt) {
+		return append([]byte(nil), cached.token...), nil
+	}
+
+	result := s.group.DoChan(cacheKey, func() (any, error) {
+		return s.mint(ctx, key, cacheKey)
+	})
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case response := <-result:
+		if response.Err != nil {
+			return nil, response.Err
+		}
+		token, ok := response.Val.([]byte)
+		if !ok {
+			return nil, fmt.Errorf("%w: token source returned an invalid value", auth.ErrEntraUnavailable)
+		}
+		return append([]byte(nil), token...), nil
+	}
+}
+
+func (s *ClientCredentialsSource) mint(ctx context.Context, key *auth.ExternalAPIKey, cacheKey string) ([]byte, error) {
+	now := s.now()
+	s.mu.Lock()
+	cached, ok := s.cache.Get(cacheKey)
+	s.mu.Unlock()
+	if ok && now.Before(cached.refreshAt) {
+		return append([]byte(nil), cached.token...), nil
+	}
+
+	tenant := strings.TrimSpace(key.AuthAccount)
+	clientID := strings.TrimSpace(key.AuthUser)
+	endpoint := "https://login.microsoftonline.com/" + url.PathEscape(tenant) + "/oauth2/v2.0/token"
+	form := url.Values{
+		"client_id":     {clientID},
+		"client_secret": {string(key.Plaintext)},
+		"scope":         {auth.EntraScope},
+		"grant_type":    {"client_credentials"},
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("%w: build token request: %v", auth.ErrEntraUnavailable, err)
+	}
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	response, err := s.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("%w: request token: %v", auth.ErrEntraUnavailable, err)
+	}
+	defer response.Body.Close()
+
+	body, readErr := io.ReadAll(io.LimitReader(response.Body, maxErrorBody))
+	if readErr != nil {
+		return nil, fmt.Errorf("%w: read token response: %v", auth.ErrEntraUnavailable, readErr)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("%w: token endpoint returned status %d", auth.ErrEntraUnavailable, response.StatusCode)
+	}
+
+	var tokenResponse struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int64  `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &tokenResponse); err != nil {
+		return nil, fmt.Errorf("%w: decode token response: %v", auth.ErrEntraUnavailable, err)
+	}
+	if tokenResponse.AccessToken == "" || tokenResponse.ExpiresIn <= 0 {
+		return nil, fmt.Errorf("%w: token response is missing access_token or expires_in", auth.ErrEntraUnavailable)
+	}
+
+	refreshAfter := time.Duration(float64(tokenResponse.ExpiresIn)*refreshFraction) * time.Second
+	if refreshAfter <= 0 {
+		return nil, fmt.Errorf("%w: token expiry is invalid (%s)", auth.ErrEntraUnavailable, strconv.FormatInt(tokenResponse.ExpiresIn, 10))
+	}
+	token := []byte(tokenResponse.AccessToken)
+	s.mu.Lock()
+	s.cache.Add(cacheKey, cachedToken{token: token, refreshAt: now.Add(refreshAfter)})
+	s.mu.Unlock()
+	return append([]byte(nil), token...), nil
+}
+
+var _ auth.EntraTokenSource = (*ClientCredentialsSource)(nil)

--- a/internal/entra/client_credentials.go
+++ b/internal/entra/client_credentials.go
@@ -23,6 +23,7 @@ const (
 	cacheSize       = 1024
 	refreshFraction = 0.8
 	maxErrorBody    = 4 * 1024
+	mintTimeout     = 30 * time.Second
 )
 
 type cachedToken struct {
@@ -85,8 +86,13 @@ func (s *ClientCredentialsSource) Token(ctx context.Context, key *auth.ExternalA
 		return append([]byte(nil), cached.token...), nil
 	}
 
+	// The shared mint runs under a detached context so a caller that cancels
+	// doesn't abort the flight for waiters whose own contexts are still live;
+	// each caller still stops waiting on its own ctx in the select below.
 	result := s.group.DoChan(cacheKey, func() (any, error) {
-		return s.mint(ctx, key, cacheKey)
+		mintCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), mintTimeout)
+		defer cancel()
+		return s.mint(mintCtx, key, cacheKey)
 	})
 	select {
 	case <-ctx.Done():
@@ -118,7 +124,7 @@ func (s *ClientCredentialsSource) mint(ctx context.Context, key *auth.ExternalAP
 	form := url.Values{
 		"client_id":     {clientID},
 		"client_secret": {string(key.Plaintext)},
-		"scope":         {auth.EntraScope},
+		"scope":         {auth.EntraScopeForBaseURL(key.BaseURL)},
 		"grant_type":    {"client_credentials"},
 	}
 	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))

--- a/internal/entra/client_credentials.go
+++ b/internal/entra/client_credentials.go
@@ -86,9 +86,8 @@ func (s *ClientCredentialsSource) Token(ctx context.Context, key *auth.ExternalA
 		return append([]byte(nil), cached.token...), nil
 	}
 
-	// The shared mint runs under a detached context so a caller that cancels
-	// doesn't abort the flight for waiters whose own contexts are still live;
-	// each caller still stops waiting on its own ctx in the select below.
+	// The shared mint runs under a detached context so a cancelling caller
+	// doesn't abort the flight for waiters whose own contexts are still live.
 	result := s.group.DoChan(cacheKey, func() (any, error) {
 		mintCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), mintTimeout)
 		defer cancel()

--- a/internal/entra/client_credentials_test.go
+++ b/internal/entra/client_credentials_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -111,6 +112,77 @@ func TestClientCredentialsSourceToken_RejectsInvalidResponse(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, auth.ErrEntraUnavailable)
 	assert.NotContains(t, err.Error(), "client-secret")
+}
+
+func TestClientCredentialsSourceToken_ScopesTokenToTheKeyEndpoint(t *testing.T) {
+	var scope string
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		values, err := url.ParseQuery(string(body))
+		require.NoError(t, err)
+		scope = values.Get("scope")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"access_token":"entra-token","expires_in":3600}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+	source := entra.NewClientCredentialsSource(client, time.Now)
+
+	key := entraKey()
+	key.BaseURL = "https://resource.openai.azure.com/openai/v1"
+	_, err := source.Token(context.Background(), key)
+	require.NoError(t, err)
+	assert.Equal(t, auth.EntraScopeCognitiveServices, scope)
+
+	key.KeyFingerprint = "fingerprint-foundry"
+	key.BaseURL = "https://resource.services.ai.azure.com/anthropic"
+	_, err = source.Token(context.Background(), key)
+	require.NoError(t, err)
+	assert.Equal(t, auth.EntraScope, scope)
+}
+
+func TestClientCredentialsSourceToken_ServesWaiterAfterLeaderCancels(t *testing.T) {
+	var once sync.Once
+	joined := make(chan struct{})
+	release := make(chan struct{})
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		once.Do(func() { close(joined) })
+		<-release
+		if err := req.Context().Err(); err != nil {
+			return nil, err
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"access_token":"entra-token","expires_in":3600}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+	source := entra.NewClientCredentialsSource(client, time.Now)
+	key := entraKey()
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	defer cancelLeader()
+	go func() {
+		_, _ = source.Token(leaderCtx, key)
+	}()
+	<-joined
+
+	waiter := make(chan error, 1)
+	tokens := make(chan []byte, 1)
+	go func() {
+		token, err := source.Token(context.Background(), key)
+		tokens <- token
+		waiter <- err
+	}()
+	// Give the waiter time to join the in-flight mint before the leader leaves.
+	time.Sleep(50 * time.Millisecond)
+	cancelLeader()
+	close(release)
+
+	require.NoError(t, <-waiter)
+	assert.Equal(t, []byte("entra-token"), <-tokens)
 }
 
 func TestClientCredentialsSourceToken_RequiresCredentialFields(t *testing.T) {

--- a/internal/entra/client_credentials_test.go
+++ b/internal/entra/client_credentials_test.go
@@ -1,0 +1,134 @@
+package entra_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/auth"
+	"workweave/router/internal/entra"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func entraKey() *auth.ExternalAPIKey {
+	return &auth.ExternalAPIKey{
+		ID:             "ekid_test",
+		KeyFingerprint: "fingerprint-a",
+		AuthAccount:    "tenant-id",
+		AuthUser:       "client-id",
+		Plaintext:      []byte("client-secret"),
+	}
+}
+
+func TestClientCredentialsSourceToken_MintsAndCachesUntilRefresh(t *testing.T) {
+	var calls int32
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodPost, req.Method)
+		assert.Equal(t, "/tenant-id/oauth2/v2.0/token", req.URL.Path)
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		values, err := url.ParseQuery(string(body))
+		require.NoError(t, err)
+		assert.Equal(t, "client-id", values.Get("client_id"))
+		assert.Equal(t, "client-secret", values.Get("client_secret"))
+		assert.Equal(t, auth.EntraScope, values.Get("scope"))
+		assert.Equal(t, "client_credentials", values.Get("grant_type"))
+		atomic.AddInt32(&calls, 1)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"access_token":"entra-token","expires_in":100}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+	current := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	source := entra.NewClientCredentialsSource(client, func() time.Time { return current })
+	key := entraKey()
+
+	got, err := source.Token(context.Background(), key)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("entra-token"), got)
+	got, err = source.Token(context.Background(), key)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("entra-token"), got)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+
+	current = current.Add(79 * time.Second)
+	_, err = source.Token(context.Background(), key)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "the token is cached until 80%% of expires_in")
+
+	current = current.Add(time.Second)
+	_, err = source.Token(context.Background(), key)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "the token refreshes at the configured refresh boundary")
+}
+
+func TestClientCredentialsSourceToken_InvalidatesOnFingerprintChange(t *testing.T) {
+	var calls int32
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		atomic.AddInt32(&calls, 1)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"access_token":"entra-token","expires_in":3600}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+	source := entra.NewClientCredentialsSource(client, time.Now)
+	key := entraKey()
+
+	_, err := source.Token(context.Background(), key)
+	require.NoError(t, err)
+	key.KeyFingerprint = "fingerprint-b"
+	_, err = source.Token(context.Background(), key)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls))
+}
+
+func TestClientCredentialsSourceToken_RejectsInvalidResponse(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       io.NopCloser(strings.NewReader(`{"error":"invalid_client"}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+	source := entra.NewClientCredentialsSource(client, time.Now)
+
+	_, err := source.Token(context.Background(), entraKey())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, auth.ErrEntraUnavailable)
+	assert.NotContains(t, err.Error(), "client-secret")
+}
+
+func TestClientCredentialsSourceToken_RequiresCredentialFields(t *testing.T) {
+	source := entra.NewClientCredentialsSource(nil, time.Now)
+	cases := []struct {
+		name string
+		key  *auth.ExternalAPIKey
+	}{
+		{name: "nil key"},
+		{name: "missing tenant", key: &auth.ExternalAPIKey{AuthUser: "client", Plaintext: []byte("secret")}},
+		{name: "missing client", key: &auth.ExternalAPIKey{AuthAccount: "tenant", Plaintext: []byte("secret")}},
+		{name: "missing secret", key: &auth.ExternalAPIKey{AuthAccount: "tenant", AuthUser: "client"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := source.Token(context.Background(), tc.key)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, auth.ErrEntraUnavailable)
+		})
+	}
+}

--- a/internal/proxy/wif_forwarding_test.go
+++ b/internal/proxy/wif_forwarding_test.go
@@ -41,7 +41,7 @@ func TestApplyWIFTokenType_OverridesClientSuppliedValue(t *testing.T) {
 }
 
 func TestApplyWIFTokenType_LeavesOtherAuthTypesAlone(t *testing.T) {
-	for _, authType := range []string{auth.AuthTypeBearer, auth.AuthTypeKeypairJWT, ""} {
+	for _, authType := range []string{auth.AuthTypeBearer, auth.AuthTypeKeypairJWT, auth.AuthTypeAzureEntra, ""} {
 		req := requestWithCredentials(t, &proxy.Credentials{APIKey: []byte("secret"), AuthType: authType})
 
 		proxy.ApplyWIFTokenType(req.Context(), req)

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -100,11 +100,11 @@ type RouterModelRouterExternalAPIKey struct {
 	IdentityHeaderName *string
 	// email = bare address, json = URL-encoded JSON property bag
 	IdentityHeaderFormat *string
-	// bearer = send the stored secret as-is, keypair_jwt = the secret is an RSA private key the router signs short-lived JWTs with, wif = no stored secret, the router attests its own workload identity
+	// bearer = send the stored secret as-is, keypair_jwt = the secret is an RSA private key the router signs short-lived JWTs with, wif = no stored secret and the router attests its own workload identity, azure_entra = the secret is an Azure Entra client secret used to mint a short-lived bearer token
 	AuthType string
-	// Account identifier the minted JWT is issued for; NULL unless auth_type is keypair_jwt
+	// Account identifier for keypair_jwt, or Microsoft Entra tenant ID for azure_entra
 	AuthAccount *string
-	// User the minted JWT authenticates as; NULL unless auth_type is keypair_jwt
+	// User/principal for keypair_jwt, or Microsoft Entra client ID for azure_entra
 	AuthUser *string
 	// Weave account that soft-deleted or replaced this key; NULL when the router deleted it internally or attribution predates the column
 	DeletedBy *string


### PR DESCRIPTION
Add per-installation Microsoft Entra client-credentials authentication for Foundry and Azure OpenAI v1 gateway endpoints.

Co-Authored-By: Weave Router <noreply@workweave.ai>