### PR TITLE
feat(pi-router): lsp code-intelligence tools with subagent broker and opt-in server installs

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -899,11 +899,14 @@ install_lsp_servers() {
   local langs="$1" lang
   local seen=" "
   for lang in $(printf '%s' "$langs" | tr ',' ' '); do
-    local id="" bin="" alt_bin="" toolchain="" fallback_dir=""
+    local id="" bin="" alt_bin="" toolchain="" fallback_dir="" gopath=""
     local cmd=""
     case "$(printf '%s' "$lang" | tr '[:upper:]' '[:lower:]')" in
       go|golang)
-        id="go"; bin="gopls"; toolchain="go"; fallback_dir="$HOME/go/bin"
+        id="go"; bin="gopls"; toolchain="go"
+        # go install honors $GOBIN, else <first GOPATH element>/bin (default ~/go/bin).
+        gopath="${GOPATH:-$HOME/go}"
+        fallback_dir="${GOBIN:-${gopath%%:*}/bin}"
         cmd="go install golang.org/x/tools/gopls@latest"
         ;;
       ts|typescript|js|javascript)
@@ -915,7 +918,9 @@ install_lsp_servers() {
         cmd="npm i -g pyright"
         ;;
       rs|rust)
-        id="rust"; bin="rust-analyzer"; toolchain="rustup"; fallback_dir="$HOME/.cargo/bin"
+        id="rust"; bin="rust-analyzer"; toolchain="rustup"
+        # rustup honors $CARGO_HOME (default ~/.cargo).
+        fallback_dir="${CARGO_HOME:-$HOME/.cargo}/bin"
         cmd="rustup component add rust-analyzer"
         ;;
       *)

--- a/install/install.sh
+++ b/install/install.sh
@@ -37,6 +37,8 @@
 #   npx @workweave/router --codex                          # skip the picker, target Codex
 #   npx @workweave/router --opencode                       # skip the picker, target opencode
 #   npx @workweave/router --pi                              # skip the picker, target pi
+#   npx @workweave/router --pi --lsp go,typescript          # also install language servers for pi's lsp tool
+#                                                             (go/typescript/python/rust; needs that language's toolchain)
 #   npx @workweave/router --scope project                  # commit-with-team install
 #   npx @workweave/router --dir /tmp/my-sandbox            # isolated throwaway install
 #   npx @workweave/router --local                          # local router on localhost:8080
@@ -125,6 +127,10 @@ disable_routing_alias="false"
 # `set -u` would not. --json switches the output to the raw API payload.
 models_args=""
 models_json="false"
+
+# --lsp <langs>: comma-separated languages whose language servers to install
+# for the pi extension's `lsp` tool (pi target only). Empty = don't install any.
+lsp_langs=""
 
 # --rotate-key forces the interactive key prompt even when a usable key is
 # already installed, so a rotated key can replace it.
@@ -884,6 +890,64 @@ write_pi_settings_config() {
   printf '%s\n' "$merged" >"$settings_file"
 }
 
+# Language-server installs for the pi extension's `lsp` tool (--lsp go,ts,...).
+# The alias -> server -> toolchain matrix mirrors LSP_SERVERS in
+# install/pi-router/src/lsp-servers.ts — keep the two in lockstep. Every
+# failure is a warn-and-continue: a missing toolchain must not fail the router
+# install, and the extension re-offers conversationally at session start.
+install_lsp_servers() {
+  local langs="$1" lang
+  local seen=" "
+  for lang in $(printf '%s' "$langs" | tr ',' ' '); do
+    local id="" bin="" alt_bin="" toolchain="" fallback_dir=""
+    local cmd=""
+    case "$(printf '%s' "$lang" | tr '[:upper:]' '[:lower:]')" in
+      go|golang)
+        id="go"; bin="gopls"; toolchain="go"; fallback_dir="$HOME/go/bin"
+        cmd="go install golang.org/x/tools/gopls@latest"
+        ;;
+      ts|typescript|js|javascript)
+        id="typescript"; bin="typescript-language-server"; toolchain="npm"
+        cmd="npm i -g typescript-language-server typescript"
+        ;;
+      py|python)
+        id="python"; bin="pyright-langserver"; alt_bin="basedpyright-langserver"; toolchain="npm"
+        cmd="npm i -g pyright"
+        ;;
+      rs|rust)
+        id="rust"; bin="rust-analyzer"; toolchain="rustup"; fallback_dir="$HOME/.cargo/bin"
+        cmd="rustup component add rust-analyzer"
+        ;;
+      *)
+        warn "--lsp: unknown language '$lang' (valid: go, typescript, python, rust). Skipping."
+        continue
+        ;;
+    esac
+    case "$seen" in *" $id "*) continue ;; esac
+    seen="$seen$id "
+
+    if command -v "$bin" >/dev/null 2>&1 \
+      || { [ -n "$alt_bin" ] && command -v "$alt_bin" >/dev/null 2>&1; } \
+      || { [ -n "$fallback_dir" ] && [ -x "$fallback_dir/$bin" ]; }; then
+      ok "$id language server already installed ($bin)"
+      continue
+    fi
+    if ! command -v "$toolchain" >/dev/null 2>&1; then
+      warn "--lsp $id: needs '$toolchain' on PATH (install command: $cmd). Skipping — re-run after installing the $toolchain toolchain."
+      continue
+    fi
+    # shellcheck disable=SC2086 — $cmd is a fixed argv from the case above, never user input.
+    if spin "Installing $id language server" $cmd; then
+      ok "$id language server installed ($cmd)"
+      if [ -n "$fallback_dir" ] && ! command -v "$bin" >/dev/null 2>&1; then
+        info "$bin landed in $fallback_dir (not on PATH). The pi lsp tool finds it there; other tools may need a PATH entry."
+      fi
+    else
+      warn "--lsp $id: '$cmd' failed. Run it manually, or ask pi to enable $id LSP support later."
+    fi
+  done
+}
+
 # resolve_user_name mirrors resolve_user_email but for display name. Priority:
 # WEAVE_USER_NAME env override → git config user.name → empty. We don't
 # prompt for name independently: if email prompting yielded nothing, name
@@ -997,6 +1061,10 @@ while [ $# -gt 0 ]; do
     --pi)
       target="pi"; target_explicit="true"; shift
       ;;
+    --lsp)
+      lsp_langs="${2:-}"; shift 2
+      [ -n "$lsp_langs" ] || { err "--lsp requires a comma-separated language list (go,typescript,python,rust)."; exit 2; }
+      ;;
     --claude)
       # No-op selector for symmetry with --codex / --opencode. Useful in
       # pipelines that want to skip the interactive picker without depending
@@ -1046,6 +1114,16 @@ while [ $# -gt 0 ]; do
       ;;
   esac
 done
+
+# --lsp is a pi-extension feature, so it implies the pi target; combining it
+# with another explicit target is a contradiction, not a preference.
+if [ -n "$lsp_langs" ]; then
+  if [ "$target_explicit" = "true" ] && [ "$target" != "pi" ]; then
+    err "--lsp only applies to the pi target (the lsp tool ships in the pi extension). Drop --lsp or use --pi."
+    exit 2
+  fi
+  target="pi"; target_explicit="true"
+fi
 
 if [ "$disable_routing_alias" = "true" ]; then
   if [ "$target_explicit" = "true" ] && [ "$target" != "codex" ]; then
@@ -2772,6 +2850,10 @@ if [ "$target" = "pi" ]; then
     if ! spin "Validating API key" validate_pi_key; then
       warn "Router rejected the API key (check it matches the dashboard at $base_url/ui/)."
     fi
+  fi
+
+  if [ -n "$lsp_langs" ]; then
+    install_lsp_servers "$lsp_langs"
   fi
 
   printf "\n"

--- a/install/npm/package.json
+++ b/install/npm/package.json
@@ -9,6 +9,9 @@
   "pi": {
     "extensions": [
       "./pi-router/src/index.ts"
+    ],
+    "skills": [
+      "./pi-router/skills"
     ]
   },
   "files": [

--- a/install/npm/scripts/copy-installer.js
+++ b/install/npm/scripts/copy-installer.js
@@ -62,11 +62,14 @@ const piSrc = path.join(installDir, "pi-router", "src");
 const piDst = path.join(root, "pi-router", "src");
 mkdirSync(path.dirname(piDst), { recursive: true });
 cpSync(piSrc, piDst, { recursive: true });
+// pi discovers these through package.json's "pi.skills" once the package is
+// installed — no installer involvement.
+cpSync(path.join(installDir, "pi-router", "skills"), path.join(root, "pi-router", "skills"), { recursive: true });
 // package.json marks the sources as ESM (type:module); README is docs.
 for (const f of ["package.json", "README.md"]) {
   copyFileSync(path.join(installDir, "pi-router", f), path.join(root, "pi-router", f));
 }
-console.log("Copied pi-router/ (extension).");
+console.log("Copied pi-router/ (extension + skills).");
 
 // Bundle the opencode Codex-subscription plugin the same way. install.sh
 // (--codex/--opencode) drops opencode-weave/src/index.ts into the user's

--- a/install/pi-router/README.md
+++ b/install/pi-router/README.md
@@ -11,6 +11,7 @@ Installed automatically by the Weave Router installer:
 ```bash
 WEAVE_ROUTER_KEY=rk_… npx --package @workweave/router -y -- weave-router --pi
 WEAVE_ROUTER_KEY=rk_… npx --package @workweave/router -y -- weave-router --pi --local  # local router
+WEAVE_ROUTER_KEY=rk_… npx --package @workweave/router -y -- weave-router --pi --lsp go,typescript  # + language servers for the lsp tool
 ```
 
 That writes `~/.pi/agent/models.json` (the `weave` provider), adds
@@ -43,6 +44,24 @@ from npm on next start and loads this extension via its `pi.extensions` field.
   natively. `dispatch` spawns child `pi` processes (read-only by default), runs
   them concurrently, and returns only each subagent's final answer — intermediate
   tool output stays in the child, so the main context stays small.
+- **`lsp` tool — code intelligence through a language server.** definition,
+  references, hover, documentSymbol, and diagnostics for Go, TypeScript/
+  JavaScript, Python, and Rust (gopls, typescript-language-server, pyright,
+  rust-analyzer). Servers are spawned lazily per workspace root, shut down
+  after idling, and shared with dispatch subagents through a parent-side local
+  socket — a fan-out reuses the parent's warm servers instead of cold-starting
+  its own. Disable with `WEAVE_PI_NO_LSP=1`.
+- **Opt-in language-server install — nothing installs silently.** Two ways in:
+  pass `--lsp go,typescript` to the installer, or let the assistant offer.
+  When the workspace contains a language whose server is missing, the
+  assistant offers once in conversation ("I can enable go LSP support if
+  you'd like — just say the word!"); a yes runs the install through the
+  `lsp_enable` tool (main process only — subagents can't trigger installs), a
+  "don't ask again" is persisted per language in `<agentDir>/.weave_lsp.json`
+  and respected across sessions. Installs need that language's toolchain
+  (`go`, `npm`, or `rustup`) on PATH; when the toolchain itself is missing,
+  the bundled `install-lsps` skill (`/skill:install-lsps`) walks the agent
+  through installing it — again only with explicit consent.
 - **Persistent route + savings display.** Shows
   `WEAVE ROUTER — <routed> ← <selected> · saved $X.XX` below pi's native footer
   data. Savings compare the selected and routed catalog prices against the same
@@ -70,9 +89,17 @@ from npm on next start and loads this extension via its `pi.extensions` field.
 | `WEAVE_ROUTING_ALPHA` / `…_SPEED_WEIGHT` / `…_OUTPUT_COST_RATIO` / `…_EXPECTED_OUTPUT_TOKENS` | role preset | Override individual routing knobs (main process only — children always use their role preset) |
 | `WEAVE_NO_SAFETY` | unset | `1` disables the catastrophic-bash gate |
 | `WEAVE_PI_AUTO_COMPACTION` | unset | `0` disables the routed tool-loop compaction safeguard |
+| `WEAVE_PI_NO_LSP` | unset | `1` disables the `lsp` tool, the server pool, and the subagent broker |
+| `WEAVE_PI_LSP_IDLE_MS` | `300000` | Idle window before an unused language server is shut down |
+| `WEAVE_PI_LSP_REQUEST_TIMEOUT_MS` | `15000` | Per-request budget once a server is warm |
+| `WEAVE_PI_LSP_WARMUP_TIMEOUT_MS` | `60000` | Budget for initialize + the first query (indexing) |
+| `WEAVE_PI_LSP_DIAGNOSTICS_WAIT_MS` | `3000` | How long `diagnostics` waits for a fresh publish |
+| `WEAVE_PI_LSP_MAX_SERVERS` | `4` | LRU cap on concurrently live language servers |
+| `WEAVE_PI_LSP_MAX_REFERENCES` | `100` | Cap on reported reference sites |
 
-Internal: `WEAVE_PI_SUBAGENT=1` and `WEAVE_PI_SUBAGENT_ID` are set by `dispatch`
-on child processes; don't set them yourself.
+Internal: `WEAVE_PI_SUBAGENT=1`, `WEAVE_PI_SUBAGENT_ID`, `WEAVE_PI_LSP_BROKER`,
+and `WEAVE_PI_LSP_BROKER_TOKEN` are set by `dispatch` on child processes; don't
+set them yourself.
 
 ## Billing
 

--- a/install/pi-router/README.md
+++ b/install/pi-router/README.md
@@ -50,7 +50,9 @@ from npm on next start and loads this extension via its `pi.extensions` field.
   rust-analyzer). Servers are spawned lazily per workspace root, shut down
   after idling, and shared with dispatch subagents through a parent-side local
   socket — a fan-out reuses the parent's warm servers instead of cold-starting
-  its own. Disable with `WEAVE_PI_NO_LSP=1`.
+  its own. A bundled `lsp-guide` skill (`/skill:lsp-guide`) carries the usage
+  recipes (per-operation cookbook, the locate-then-references flow, caveats).
+  Disable with `WEAVE_PI_NO_LSP=1`.
 - **Opt-in language-server install — nothing installs silently.** Two ways in:
   pass `--lsp go,typescript` to the installer, or let the assistant offer.
   When the workspace contains a language whose server is missing, the

--- a/install/pi-router/skills/install-lsps/SKILL.md
+++ b/install/pi-router/skills/install-lsps/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: install-lsps
+description: Install language servers (gopls, typescript-language-server, pyright, rust-analyzer) and their prerequisite toolchains (Go, Node/npm, rustup) so the lsp tool works. Use when the user asks to enable or install LSP / language-server support, when lsp_enable reports a missing toolchain, or when the lsp tool reports no language server is installed.
+---
+
+# Install LSPs
+
+Enable the `lsp` tool for a language by installing its language server — and,
+when the server install needs it, the underlying toolchain.
+
+## Rules
+
+- Everything here is consent-gated: only act on the user's explicit go-ahead,
+  and confirm each toolchain install separately — those are system-level
+  changes, not part of whatever task prompted this.
+- If the user declines, stop. If they ask not to be offered again, call
+  `lsp_enable` with `{"language": "<language>", "action": "dismiss"}`.
+- Prefer the `lsp_enable` tool over bash whenever the toolchain already
+  exists; reach for bash only for the prerequisites `lsp_enable` refuses to
+  install itself.
+
+## Per language
+
+Work the ladder for each language the user wants:
+
+1. **Check what is missing.** Server binaries: `gopls`,
+   `typescript-language-server`, `pyright-langserver` (or
+   `basedpyright-langserver`), `rust-analyzer` — also look in `~/go/bin` and
+   `~/.cargo/bin`, which the lsp tool searches even when they are off PATH.
+   Toolchains: `go`, `npm`, `rustup`.
+2. **Toolchain present** → call `lsp_enable` with
+   `{"language": "<go|typescript|python|rust>"}` and you are done; it runs the
+   right server install and verifies the binary resolves.
+3. **Toolchain missing** → show the user the command you intend to run, get
+   their confirmation, run it in bash, then return to step 2.
+4. **Verify** with a real `lsp` query (`documentSymbol` on an actual source
+   file). The first query per workspace can take up to a minute while the
+   server indexes; that is normal.
+
+## Toolchain installs (step 3 reference)
+
+Go (for gopls):
+
+```bash
+brew install go            # macOS
+sudo apt-get install -y golang-go   # Debian/Ubuntu; or dnf install golang
+```
+
+Or the official downloads at https://go.dev/dl for anything else.
+
+Node/npm (for typescript-language-server and pyright):
+
+```bash
+brew install node          # macOS
+sudo apt-get install -y nodejs npm  # Debian/Ubuntu
+```
+
+Or nvm (https://github.com/nvm-sh/nvm) when the user prefers per-user installs.
+
+rustup (for rust-analyzer):
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+This is the official rust installer; show the user the command before running
+it and follow its printed PATH instructions afterwards.
+
+## Notes
+
+- `go install` drops gopls in `~/go/bin` and rustup drops rust-analyzer in
+  `~/.cargo/bin`. The lsp tool finds both without PATH changes; other tools
+  may still want a PATH entry.
+- All of this can also happen at install time:
+  `npx @workweave/router --pi --lsp go,typescript,python,rust`.

--- a/install/pi-router/skills/lsp-guide/SKILL.md
+++ b/install/pi-router/skills/lsp-guide/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: lsp-guide
+description: Recipes for the lsp tool — resolving where a symbol is defined, every place it is used, type signatures and docs, file outlines, and compiler/type errors through a real language server (Go, TypeScript/JavaScript, Python, Rust). Use when navigating or explaining code by symbol, finding callers or usages, checking what broke after an edit, or deciding between lsp and text search.
+---
+
+# Using the lsp tool
+
+The `lsp` tool answers *semantic* questions through the language's own server:
+it resolves through imports, types, and aliases, where grep only matches text.
+Reach for it whenever the question is about a **symbol**; keep grep for plain
+strings, comments, and file types no server supports.
+
+## Operations
+
+| Operation | Answers | Needs |
+|---|---|---|
+| `definition` | where the symbol at a position is defined | `path`, `line`, `column` |
+| `references` | every place the symbol at a position is used | `path`, `line`, `column` |
+| `hover` | type signature + docs for the symbol at a position | `path`, `line`, `column` |
+| `documentSymbol` | the outline (types, functions, methods) of one file | `path` |
+| `diagnostics` | compiler/type errors and warnings for one file | `path` |
+
+Positions are 1-based, and `column` must point **at the identifier** (its first
+character works). All paths resolve against the working directory.
+
+## Recipes
+
+**"Where is X defined?"** — from any usage site of X:
+`{"operation": "definition", "path": "<file>", "line": <L>, "column": <C>}`.
+Don't know a usage site? Find one first (see next recipe's step 1).
+
+**"Everywhere X is used"** — two steps, always:
+
+1. Locate the declaration: `rg -n --column '\bX\b'` (the `--column` output is
+   exactly the coordinate the next call needs), or `documentSymbol` when you
+   already know the file.
+2. `{"operation": "references", "path": "<decl file>", "line": <L>, "column": <C>}`.
+
+A grep hit list is **not** a references answer: it includes comments and
+strings, misses aliased imports, and can't distinguish same-named symbols.
+Step 2 is what makes the answer authoritative.
+
+**"What is this / what's its signature?"** — `hover` at the symbol. Prefer it
+over reading the definition file when you only need the type or doc comment.
+
+**"What's in this file?"** — `documentSymbol` before reading a large file; jump
+straight to the line the outline gives you.
+
+**"Did my edit break anything here?"** — `diagnostics` on the file after
+editing. It reports the server's current analysis of the saved file.
+
+## Behavior worth knowing
+
+- **First query per workspace is slow** (the server indexes — up to a minute
+  in a big repo). Later queries on that workspace are fast; don't give up
+  after one timeout, retry once.
+- **References are capped** (default 100, header says how many exist).
+- **Unsupported file type or missing server** returns advice text, not an
+  error — fall back to grep for that file. A missing server can be installed
+  with the user's consent via `lsp_enable` (see the install-lsps skill for
+  toolchain prerequisites).
+- Works inside dispatch subagents too (they share the parent's warm servers),
+  so symbol lookups are safe to fan out.

--- a/install/pi-router/src/config.ts
+++ b/install/pi-router/src/config.ts
@@ -71,6 +71,11 @@ export function getKeyFilePath(): string {
 	return process.env.WEAVE_ROUTER_KEY_FILE?.trim() || path.join(getAgentDir(), ".weave_router_key");
 }
 
+/** Persisted LSP preferences (per-language "don't offer again" dismissals). */
+export function getLspPrefsPath(): string {
+	return path.join(getAgentDir(), ".weave_lsp.json");
+}
+
 interface WeaveProviderConfig {
 	baseUrl?: string;
 	apiKey?: string;
@@ -261,6 +266,23 @@ export const DISPATCH_CONCURRENCY = Math.max(1, numEnv("WEAVE_PI_DISPATCH_CONCUR
 export const MAX_SUBAGENTS = 8;
 export const SUBAGENT_TIMEOUT_MS = Math.max(1000, numEnv("WEAVE_PI_SUBAGENT_TIMEOUT_MS", 600000));
 export const DEFAULT_READONLY_TOOLS = ["read", "grep", "find", "ls"];
+
+// ---------- LSP tunables ----------
+
+/** Idle window before an unused language server is shut down. */
+export const LSP_IDLE_MS = Math.max(10_000, numEnv("WEAVE_PI_LSP_IDLE_MS", 300_000));
+export const LSP_REQUEST_TIMEOUT_MS = Math.max(1000, numEnv("WEAVE_PI_LSP_REQUEST_TIMEOUT_MS", 15_000));
+/** Budget for `initialize` and the first query, which race the server's initial indexing pass. */
+export const LSP_WARMUP_TIMEOUT_MS = Math.max(5000, numEnv("WEAVE_PI_LSP_WARMUP_TIMEOUT_MS", 60_000));
+export const LSP_DIAGNOSTICS_WAIT_MS = Math.max(500, numEnv("WEAVE_PI_LSP_DIAGNOSTICS_WAIT_MS", 3000));
+export const LSP_MAX_SERVERS = Math.max(1, numEnv("WEAVE_PI_LSP_MAX_SERVERS", 4));
+export const LSP_MAX_REFERENCES = Math.max(1, numEnv("WEAVE_PI_LSP_MAX_REFERENCES", 100));
+
+// Set by dispatch on children so a subagent reaches the parent's warm server
+// pool over a local socket instead of cold-starting its own gopls. Internal:
+// never set these yourself.
+export const LSP_BROKER_ENV = "WEAVE_PI_LSP_BROKER";
+export const LSP_BROKER_TOKEN_ENV = "WEAVE_PI_LSP_BROKER_TOKEN";
 
 // Tools that let a subagent mutate the filesystem or run arbitrary commands.
 // dispatch strips these from model-requested per-task `tools` (and downgrades

--- a/install/pi-router/src/dispatch.ts
+++ b/install/pi-router/src/dispatch.ts
@@ -25,6 +25,8 @@ import {
 	DEFAULT_READONLY_TOOLS,
 	DISPATCH_CONCURRENCY,
 	getRouterBaseUrl,
+	LSP_BROKER_ENV,
+	LSP_BROKER_TOKEN_ENV,
 	MAX_SUBAGENTS,
 	PROVIDER_NAME,
 	resolveIdentity,
@@ -33,6 +35,15 @@ import {
 	SUBAGENT_MODEL,
 	SUBAGENT_TIMEOUT_MS,
 } from "./config.js";
+
+/**
+ * The slice of the LSP subsystem dispatch depends on: hand me the env a child
+ * needs to reach a warm server pool. Declared here, by the consumer, so
+ * dispatch and lsp stay unaware of each other and index.ts does the wiring.
+ */
+export interface SubagentEnvProvider {
+	ensure(): Promise<Record<string, string>>;
+}
 
 const SIGKILL_GRACE_MS = 5000;
 
@@ -123,6 +134,7 @@ function runChild(
 	key: string,
 	signal: AbortSignal | undefined,
 	index: number,
+	lspEnv: Record<string, string> | undefined,
 ): Promise<ChildResult> {
 	const args = ["--print", "--mode", "json", "--no-session", "-e", selfPath, "--model", `${PROVIDER_NAME}/${SUBAGENT_MODEL}`];
 
@@ -147,12 +159,17 @@ function runChild(
 		tools = tools.map((t) => t.trim()).filter((t) => t !== "" && !DANGEROUS_SUBAGENT_TOOLS.has(t.toLowerCase()));
 		if (tools.length === 0) tools = DEFAULT_READONLY_TOOLS;
 	}
+	// All five lsp operations are read-only, so granting it does not widen the
+	// capability gate above. Only offered when the parent actually has a broker
+	// listening; otherwise the child's tool list is exactly what it is today.
+	if (tools && lspEnv && !tools.includes("lsp")) tools = [...tools, "lsp"];
 	if (tools) args.push("--tools", tools.join(","));
 	args.push(task.prompt);
 
 	const identity = resolveIdentity();
 	const env: NodeJS.ProcessEnv = {
 		...process.env,
+		...lspEnv,
 		WEAVE_PI_SUBAGENT: "1",
 		WEAVE_PI_SUBAGENT_ID: randomUUID(),
 		WEAVE_ROUTER_KEY: key,
@@ -165,6 +182,12 @@ function runChild(
 	delete env.WEAVE_ROUTING_SPEED_WEIGHT;
 	delete env.WEAVE_ROUTING_OUTPUT_COST_RATIO;
 	delete env.WEAVE_ROUTING_EXPECTED_OUTPUT_TOKENS;
+	// With no broker there must be no broker env at all, so a child never tries
+	// to dial a socket that isn't there.
+	if (!lspEnv) {
+		delete env[LSP_BROKER_ENV];
+		delete env[LSP_BROKER_TOKEN_ENV];
+	}
 	if (identity.email) env.WEAVE_USER_EMAIL = identity.email;
 	if (identity.name) env.WEAVE_USER_NAME = identity.name;
 
@@ -282,7 +305,7 @@ function lastStderrLine(stderr: string): string {
 	return lines.length > 0 ? lines[lines.length - 1] : "";
 }
 
-export function registerDispatch(pi: ExtensionAPI, selfPath: string): void {
+export function registerDispatch(pi: ExtensionAPI, selfPath: string, lspBroker?: SubagentEnvProvider): void {
 	pi.registerTool({
 		name: "dispatch",
 		label: "Dispatch",
@@ -308,9 +331,19 @@ export function registerDispatch(pi: ExtensionAPI, selfPath: string): void {
 				};
 			}
 
+			// Start the broker before fan-out so N children share the parent's warm
+			// language servers instead of each cold-starting its own. A broker that
+			// will not start is not fatal: children just run without the lsp tool.
+			let lspEnv: Record<string, string> | undefined;
+			try {
+				lspEnv = await lspBroker?.ensure();
+			} catch {
+				lspEnv = undefined;
+			}
+
 			const readOnly = params.readOnly ?? true;
 			const results = await mapWithConcurrencyLimit(params.tasks, DISPATCH_CONCURRENCY, (task, index) =>
-				runChild(selfPath, task, readOnly, ctx.cwd, key, signal, index),
+				runChild(selfPath, task, readOnly, ctx.cwd, key, signal, index, lspEnv),
 			);
 
 			const succeeded = results.filter((r) => r.exitCode === 0 && !r.error).length;

--- a/install/pi-router/src/index.ts
+++ b/install/pi-router/src/index.ts
@@ -12,6 +12,9 @@
  *   - compaction:   protect long tool loops, then compact routed context.
  *   - dispatch:     parallel, context-isolated subagents — top-level process
  *                   only (no grandchildren).
+ *   - lsp:          code intelligence (definition/references/hover/symbols/
+ *                   diagnostics) over lazily spawned language servers, shared
+ *                   with subagents through a parent-side broker socket.
  *
  * The same module loads in dispatched children via `-e <self>`; WEAVE_PI_SUBAGENT
  * flips the provider knobs and suppresses the dispatch tool so fan-out doesn't recurse.
@@ -23,6 +26,7 @@ import { isSubagent } from "./config.js";
 import { registerCompaction } from "./compaction.js";
 import { registerDispatch } from "./dispatch.js";
 import { registerForceModelCommands } from "./force-model.js";
+import { registerLsp } from "./lsp.js";
 import { registerMetadata } from "./metadata.js";
 import { registerRoutedModel } from "./routed-model.js";
 import { registerSafety } from "./safety.js";
@@ -44,8 +48,13 @@ export default function (pi: ExtensionAPI): void {
 
 	if (process.env.WEAVE_NO_SAFETY !== "1") registerSafety(pi);
 
+	// registerLsp picks its own role: the main process gets the pool-backed tool
+	// and returns the broker provider below; a child gets the broker-backed tool
+	// only when dispatch actually handed it a socket.
+	const lspBroker = process.env.WEAVE_PI_NO_LSP === "1" ? undefined : registerLsp(pi);
+
 	// Only the top-level process fans out. Children (WEAVE_PI_SUBAGENT=1) load
 	// this same extension but get no dispatch tool, so subagents can't spawn
 	// grandchildren.
-	if (!isSubagent()) registerDispatch(pi, SELF_PATH);
+	if (!isSubagent()) registerDispatch(pi, SELF_PATH, lspBroker);
 }

--- a/install/pi-router/src/lsp-broker.ts
+++ b/install/pi-router/src/lsp-broker.ts
@@ -1,0 +1,255 @@
+/**
+ * Subagent access to the parent's language servers.
+ *
+ * Dispatch children are the heaviest potential LSP users and the shortest-lived
+ * processes, so letting each spawn its own gopls would pay the indexing cost N
+ * times over and then throw the warm index away. Instead the parent exposes its
+ * pool over a local socket and children forward queries to it. The socket
+ * carries the same Content-Length framing as LSP stdio.
+ *
+ * The broker takes the orchestration core as a function, so it never reaches
+ * into the pool itself and is testable against a fake runner.
+ */
+
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import * as fs from "node:fs";
+import * as net from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createFrameParser, encodeFrame, type JsonRpcMessage, type LspOperationParams } from "./lsp-protocol.js";
+
+const HELLO = "broker/hello";
+const EXECUTE = "lsp/execute";
+const CANCEL = "$/cancel";
+const CONNECTION_LOST = "LSP broker connection lost";
+
+export type LspRunner = (params: LspOperationParams, cwd: string, signal?: AbortSignal) => Promise<string>;
+
+export interface LspBrokerHandle {
+	socketPath: string;
+	token: string;
+	close(): Promise<void>;
+	/** Synchronous socket removal for `process.on("exit")`, which cannot await `close()`. */
+	removeSocket(): void;
+}
+
+export interface BrokerDeps {
+	makeSocketPath?(): { socketPath: string; cleanup(): void };
+	makeToken?(): string;
+}
+
+function tokensMatch(expected: string, received: unknown): boolean {
+	if (typeof received !== "string" || received.length !== expected.length) return false;
+	return timingSafeEqual(Buffer.from(expected), Buffer.from(received));
+}
+
+function defaultSocketPath(): { socketPath: string; cleanup(): void } {
+	if (process.platform === "win32") {
+		// Named pipes live in the kernel namespace: nothing to create or unlink.
+		return { socketPath: `\\\\.\\pipe\\weave-pi-lsp-${process.pid}-${randomBytes(6).toString("hex")}`, cleanup: () => undefined };
+	}
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "weave-pi-lsp-"));
+	fs.chmodSync(dir, 0o700);
+	const socketPath = path.join(dir, "lsp.sock");
+	return {
+		socketPath,
+		cleanup: () => {
+			try {
+				fs.rmSync(dir, { recursive: true, force: true });
+			} catch {
+				/* best effort */
+			}
+		},
+	};
+}
+
+/**
+ * Listen for child connections. Started on demand (right before a fan-out), so
+ * a session that never dispatches never opens a socket.
+ */
+export async function startLspBroker(runner: LspRunner, deps: BrokerDeps = {}): Promise<LspBrokerHandle> {
+	const token = (deps.makeToken ?? (() => randomBytes(32).toString("hex")))();
+	const { socketPath, cleanup } = (deps.makeSocketPath ?? defaultSocketPath)();
+	const connections = new Set<net.Socket>();
+
+	const server = net.createServer((socket) => {
+		connections.add(socket);
+		socket.on("close", () => connections.delete(socket));
+		socket.on("error", () => socket.destroy());
+
+		let authenticated = false;
+		const inflight = new Map<number, AbortController>();
+		const reply = (message: JsonRpcMessage): void => {
+			if (!socket.destroyed) socket.write(encodeFrame(message));
+		};
+
+		const parser = createFrameParser(
+			(message) => {
+				if (!authenticated) {
+					// Children share the user's privileges, so the token is not a
+					// privilege boundary — it keeps unrelated local processes out.
+					if (message.method !== HELLO || !tokensMatch(token, (message.params as { token?: unknown } | undefined)?.token)) {
+						socket.destroy();
+						return;
+					}
+					authenticated = true;
+					return;
+				}
+
+				if (message.method === CANCEL) {
+					const id = (message.params as { id?: unknown } | undefined)?.id;
+					if (typeof id === "number") inflight.get(id)?.abort();
+					return;
+				}
+				if (message.method !== EXECUTE || typeof message.id !== "number") return;
+
+				const id = message.id;
+				const payload = message.params as { params?: LspOperationParams; cwd?: string } | undefined;
+				if (!payload?.params) {
+					reply({ id, error: { code: -32602, message: "missing lsp params" } });
+					return;
+				}
+				const controller = new AbortController();
+				inflight.set(id, controller);
+				runner(payload.params, payload.cwd || process.cwd(), controller.signal)
+					.then((text) => reply({ id, result: { text } }))
+					.catch((error: Error) => reply({ id, error: { code: -32000, message: error.message } }))
+					.finally(() => inflight.delete(id));
+			},
+			() => socket.destroy(),
+		);
+
+		socket.on("data", (chunk: Buffer) => parser.push(chunk));
+	});
+
+	await new Promise<void>((resolve, reject) => {
+		const onError = (error: Error): void => reject(error);
+		server.once("error", onError);
+		server.listen(socketPath, () => {
+			server.removeListener("error", onError);
+			resolve();
+		});
+	});
+	// The listener must never be the reason the parent process stays alive.
+	server.unref();
+
+	return {
+		socketPath,
+		token,
+		removeSocket: cleanup,
+		close(): Promise<void> {
+			for (const socket of connections) socket.destroy();
+			connections.clear();
+			return new Promise<void>((resolve) => {
+				server.close(() => {
+					cleanup();
+					resolve();
+				});
+			});
+		},
+	};
+}
+
+type ConnectFn = (socketPath: string) => net.Socket;
+
+interface BrokerPending {
+	resolve(text: string): void;
+	reject(error: Error): void;
+}
+
+/** The child half: one lazy connection, shared by every `lsp` call in that process. */
+export class LspBrokerClient {
+	private nextId = 1;
+	private readonly pending = new Map<number, BrokerPending>();
+	private connection?: Promise<net.Socket>;
+
+	constructor(
+		private readonly socketPath: string,
+		private readonly token: string,
+		private readonly timeoutMs: number,
+		private readonly connectFn: ConnectFn = (target) => net.connect(target),
+	) {}
+
+	async execute(params: LspOperationParams, cwd: string, signal?: AbortSignal): Promise<string> {
+		const socket = await this.connect();
+		const id = this.nextId++;
+
+		return new Promise<string>((resolve, reject) => {
+			let settled = false;
+			const cleanup = (): void => {
+				settled = true;
+				clearTimeout(timer);
+				signal?.removeEventListener("abort", onAbort);
+				this.pending.delete(id);
+			};
+			const onAbort = (): void => {
+				if (settled) return;
+				cleanup();
+				if (!socket.destroyed) socket.write(encodeFrame({ method: CANCEL, params: { id } }));
+				reject(new Error("aborted"));
+			};
+			const timer = setTimeout(() => {
+				if (settled) return;
+				cleanup();
+				if (!socket.destroyed) socket.write(encodeFrame({ method: CANCEL, params: { id } }));
+				reject(new Error("timed out waiting for the LSP broker"));
+			}, this.timeoutMs);
+
+			this.pending.set(id, {
+				resolve: (text) => {
+					if (settled) return;
+					cleanup();
+					resolve(text);
+				},
+				reject: (error) => {
+					if (settled) return;
+					cleanup();
+					reject(error);
+				},
+			});
+			signal?.addEventListener("abort", onAbort, { once: true });
+			socket.write(encodeFrame({ id, method: EXECUTE, params: { params, cwd } }));
+		});
+	}
+
+	close(): void {
+		const pending = this.connection;
+		this.connection = undefined;
+		void pending?.then((socket) => socket.destroy()).catch(() => undefined);
+	}
+
+	private connect(): Promise<net.Socket> {
+		if (this.connection) return this.connection;
+		this.connection = new Promise<net.Socket>((resolve, reject) => {
+			const socket = this.connectFn(this.socketPath);
+			const parser = createFrameParser(
+				(message) => {
+					if (typeof message.id !== "number") return;
+					const entry = this.pending.get(message.id);
+					if (!entry) return;
+					if (message.error) entry.reject(new Error(message.error.message));
+					else entry.resolve(((message.result as { text?: string } | undefined)?.text) ?? "");
+				},
+				() => socket.destroy(),
+			);
+
+			const fail = (error: Error): void => {
+				// Drop the cached connection so a later call can retry a live parent.
+				this.connection = undefined;
+				for (const entry of [...this.pending.values()]) entry.reject(error);
+				this.pending.clear();
+				reject(error);
+			};
+
+			socket.on("data", (chunk: Buffer) => parser.push(chunk));
+			socket.on("error", (error: Error) => fail(error));
+			socket.on("close", () => fail(new Error(CONNECTION_LOST)));
+			socket.on("connect", () => {
+				socket.write(encodeFrame({ method: HELLO, params: { token: this.token } }));
+				resolve(socket);
+			});
+			socket.unref?.();
+		});
+		return this.connection;
+	}
+}

--- a/install/pi-router/src/lsp-client.ts
+++ b/install/pi-router/src/lsp-client.ts
@@ -219,12 +219,13 @@ export class LspClient {
 		this.notify("initialized", {});
 	}
 
-	async ensureDocument(uri: string, text: string, languageId: string): Promise<void> {
+	/** Returns the sync action taken, so callers can tell a real didOpen/didChange from a no-op. */
+	async ensureDocument(uri: string, text: string, languageId: string): Promise<DocumentSyncPlan["action"]> {
 		// Tool executionMode is parallel and broker requests interleave with the
 		// main loop's, so version numbering is serialized on one chain.
 		const run = this.syncChain.then(() => {
 			const plan = planDocumentSync(this.documents.get(uri), text);
-			if (plan.action === "none") return;
+			if (plan.action === "none") return plan.action;
 			if (plan.action === "open") {
 				this.notify("textDocument/didOpen", { textDocument: { uri, languageId, version: plan.version, text } });
 			} else {
@@ -234,8 +235,12 @@ export class LspClient {
 				});
 			}
 			this.documents.set(uri, { version: plan.version, text });
+			return plan.action;
 		});
-		this.syncChain = run.catch(() => undefined);
+		this.syncChain = run.then(
+			() => undefined,
+			() => undefined,
+		);
 		return run;
 	}
 

--- a/install/pi-router/src/lsp-client.ts
+++ b/install/pi-router/src/lsp-client.ts
@@ -183,6 +183,11 @@ export class LspClient {
 		return this.closeInfo !== undefined || this.disposed;
 	}
 
+	/** True while any request or diagnostics wait is in flight — the pool must not idle-dispose a busy client. */
+	get busy(): boolean {
+		return this.pending.size > 0 || this.diagnosticsWaiters.length > 0;
+	}
+
 	/** Shared across callers and never cancelled by one of them leaving: a rejected handshake poisons the pool entry. */
 	initialize(): Promise<void> {
 		if (!this.initializePromise) this.initializePromise = this.performInitialize();

--- a/install/pi-router/src/lsp-client.ts
+++ b/install/pi-router/src/lsp-client.ts
@@ -1,0 +1,425 @@
+/**
+ * One language-server connection.
+ *
+ * The server is reached through an `LspTransport` rather than a ChildProcess so
+ * the protocol logic — handshake, document versioning, request correlation,
+ * diagnostics bookkeeping — is exercised in tests without spawning anything.
+ */
+
+import { spawn as nodeSpawn, type ChildProcess, type SpawnOptions } from "node:child_process";
+import * as path from "node:path";
+import { createFrameParser, encodeFrame, pathToUri, type JsonRpcMessage } from "./lsp-protocol.js";
+import type { LspDiagnostic } from "./lsp-format.js";
+
+const STDERR_RING_BYTES = 4096;
+const SHUTDOWN_BUDGET_MS = 1000;
+const SIGKILL_GRACE_MS = 5000;
+const METHOD_NOT_FOUND = -32601;
+
+export interface TransportClose {
+	code: number | null;
+	stderr: string;
+}
+
+export interface LspTransport {
+	send(data: Buffer): void;
+	onMessage(handler: (message: JsonRpcMessage) => void): void;
+	onClose(handler: (info: TransportClose) => void): void;
+	/** Graceful stop: SIGTERM, then SIGKILL if the peer has not exited. */
+	kill(): void;
+	/** Synchronous SIGKILL for process-exit paths that cannot await anything. */
+	killNow(): void;
+}
+
+export type SpawnFn = (command: string, args: string[], options: SpawnOptions) => ChildProcess;
+
+export function spawnTransport(command: string, args: string[], cwd: string, spawnFn: SpawnFn = nodeSpawn): LspTransport {
+	const child = spawnFn(command, args, { cwd, shell: false, detached: false, stdio: ["pipe", "pipe", "pipe"] });
+	const messageHandlers: Array<(message: JsonRpcMessage) => void> = [];
+	const closeHandlers: Array<(info: TransportClose) => void> = [];
+	let stderrTail = "";
+	let settled = false;
+
+	const appendStderr = (text: string): void => {
+		stderrTail = (stderrTail + text).slice(-STDERR_RING_BYTES);
+	};
+	const emitClose = (code: number | null): void => {
+		if (settled) return;
+		settled = true;
+		for (const handler of closeHandlers) handler({ code, stderr: stderrTail });
+	};
+
+	const parser = createFrameParser(
+		(message) => {
+			for (const handler of messageHandlers) handler(message);
+		},
+		(error) => {
+			appendStderr(`\n${error.message}`);
+			child.kill("SIGKILL");
+		},
+	);
+
+	child.stdout?.on("data", (chunk: Buffer) => parser.push(chunk));
+	// Server stderr is diagnostic noise (gopls indexing chatter); it feeds error
+	// messages only and is never streamed to the model.
+	child.stderr?.on("data", (chunk: Buffer) => appendStderr(chunk.toString("utf8")));
+	child.on("close", (code) => emitClose(code));
+	child.on("error", (error: Error) => {
+		appendStderr(error.message);
+		emitClose(null);
+	});
+
+	return {
+		send(data) {
+			try {
+				child.stdin?.write(data);
+			} catch {
+				/* peer gone — the close handler rejects everything pending */
+			}
+		},
+		onMessage(handler) {
+			messageHandlers.push(handler);
+		},
+		onClose(handler) {
+			closeHandlers.push(handler);
+		},
+		kill() {
+			child.kill("SIGTERM");
+			// `child.killed` flips the instant SIGTERM is *sent*, so escalate on
+			// whether the process actually exited.
+			const timer = setTimeout(() => {
+				if (!settled) child.kill("SIGKILL");
+			}, SIGKILL_GRACE_MS);
+			timer.unref?.();
+		},
+		killNow() {
+			try {
+				child.kill("SIGKILL");
+			} catch {
+				/* already gone */
+			}
+		},
+	};
+}
+
+export interface DocumentState {
+	version: number;
+	text: string;
+}
+
+export type DocumentSyncPlan = { action: "none" } | { action: "open" | "change"; version: number };
+
+/** didOpen at v1, didChange at v+1, nothing when the buffer is unchanged. */
+export function planDocumentSync(state: DocumentState | undefined, text: string): DocumentSyncPlan {
+	if (!state) return { action: "open", version: 1 };
+	if (state.text === text) return { action: "none" };
+	return { action: "change", version: state.version + 1 };
+}
+
+/** Reject when `signal` aborts, leaving `promise` running (a shared warmup must survive one caller leaving). */
+export function abortable<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+	if (!signal) return promise;
+	if (signal.aborted) return Promise.reject(new Error("aborted"));
+	return new Promise<T>((resolve, reject) => {
+		const onAbort = (): void => reject(new Error("aborted"));
+		signal.addEventListener("abort", onAbort, { once: true });
+		promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", onAbort));
+	});
+}
+
+function lastLine(text: string): string {
+	const lines = text
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean);
+	return lines.length > 0 ? lines[lines.length - 1] : "";
+}
+
+interface Pending {
+	resolve(value: unknown): void;
+	reject(error: Error): void;
+	settle(): void;
+}
+
+interface DiagnosticsEntry {
+	generation: number;
+	items: LspDiagnostic[];
+}
+
+interface DiagnosticsWaiter {
+	uri: string;
+	minGeneration: number;
+	deliver(items: LspDiagnostic[] | undefined): void;
+}
+
+export interface LspClientOptions {
+	requestTimeoutMs: number;
+	warmupTimeoutMs: number;
+}
+
+export class LspClient {
+	private nextId = 1;
+	private readonly pending = new Map<number, Pending>();
+	private readonly documents = new Map<string, DocumentState>();
+	private readonly diagnostics = new Map<string, DiagnosticsEntry>();
+	private diagnosticsWaiters: DiagnosticsWaiter[] = [];
+	private syncChain: Promise<void> = Promise.resolve();
+	private initializePromise?: Promise<void>;
+	private generation = 0;
+	private warmedUp = false;
+	private disposed = false;
+	private closeInfo?: TransportClose;
+
+	constructor(
+		readonly root: string,
+		private readonly transport: LspTransport,
+		private readonly options: LspClientOptions,
+	) {
+		transport.onMessage((message) => this.handleMessage(message));
+		transport.onClose((info) => this.handleClose(info));
+	}
+
+	get dead(): boolean {
+		return this.closeInfo !== undefined || this.disposed;
+	}
+
+	/** Shared across callers and never cancelled by one of them leaving: a rejected handshake poisons the pool entry. */
+	initialize(): Promise<void> {
+		if (!this.initializePromise) this.initializePromise = this.performInitialize();
+		return this.initializePromise;
+	}
+
+	private async performInitialize(): Promise<void> {
+		await this.request(
+			"initialize",
+			{
+				processId: process.pid,
+				rootUri: pathToUri(this.root),
+				rootPath: this.root,
+				workspaceFolders: [{ uri: pathToUri(this.root), name: path.basename(this.root) }],
+				capabilities: {
+					textDocument: {
+						synchronization: { didSave: false, dynamicRegistration: false },
+						definition: { linkSupport: true },
+						references: {},
+						hover: { contentFormat: ["markdown", "plaintext"] },
+						documentSymbol: { hierarchicalDocumentSymbolSupport: true },
+						publishDiagnostics: { relatedInformation: false },
+					},
+					workspace: { workspaceFolders: true },
+					// Declaring workDoneProgress routes indexing chatter into $/progress
+					// notifications we drop, instead of showMessage traffic. We
+					// deliberately do NOT declare workspace.configuration — but we still
+					// answer it if the server asks anyway (see handleServerRequest).
+					window: { workDoneProgress: true },
+				},
+			},
+			{ timeoutMs: this.options.warmupTimeoutMs },
+		);
+		this.notify("initialized", {});
+	}
+
+	async ensureDocument(uri: string, text: string, languageId: string): Promise<void> {
+		// Tool executionMode is parallel and broker requests interleave with the
+		// main loop's, so version numbering is serialized on one chain.
+		const run = this.syncChain.then(() => {
+			const plan = planDocumentSync(this.documents.get(uri), text);
+			if (plan.action === "none") return;
+			if (plan.action === "open") {
+				this.notify("textDocument/didOpen", { textDocument: { uri, languageId, version: plan.version, text } });
+			} else {
+				this.notify("textDocument/didChange", {
+					textDocument: { uri, version: plan.version },
+					contentChanges: [{ text }],
+				});
+			}
+			this.documents.set(uri, { version: plan.version, text });
+		});
+		this.syncChain = run.catch(() => undefined);
+		return run;
+	}
+
+	diagnosticsGeneration(): number {
+		return this.generation;
+	}
+
+	async waitForDiagnostics(
+		uri: string,
+		sinceGeneration: number,
+		timeoutMs: number,
+		signal?: AbortSignal,
+	): Promise<{ items: LspDiagnostic[]; fresh: boolean }> {
+		const current = this.diagnostics.get(uri);
+		if (current && current.generation > sinceGeneration) return { items: current.items, fresh: true };
+
+		const published = await new Promise<LspDiagnostic[] | undefined>((resolve) => {
+			let settled = false;
+			const waiter: DiagnosticsWaiter = {
+				uri,
+				minGeneration: sinceGeneration,
+				deliver: (items) => {
+					if (settled) return;
+					settled = true;
+					clearTimeout(timer);
+					signal?.removeEventListener("abort", onAbort);
+					this.diagnosticsWaiters = this.diagnosticsWaiters.filter((entry) => entry !== waiter);
+					resolve(items);
+				},
+			};
+			const onAbort = (): void => waiter.deliver(undefined);
+			const timer = setTimeout(() => waiter.deliver(undefined), timeoutMs);
+			signal?.addEventListener("abort", onAbort, { once: true });
+			this.diagnosticsWaiters.push(waiter);
+		});
+
+		if (published) return { items: published, fresh: true };
+		return { items: this.diagnostics.get(uri)?.items ?? [], fresh: false };
+	}
+
+	request(method: string, params: unknown, options: { signal?: AbortSignal; timeoutMs?: number } = {}): Promise<unknown> {
+		if (this.closeInfo) return Promise.reject(new Error(this.closeMessage()));
+		const id = this.nextId++;
+		// The first real request lands while the server is still indexing, so it
+		// inherits the warmup budget rather than the steady-state one.
+		const timeoutMs = options.timeoutMs ?? (this.warmedUp ? this.options.requestTimeoutMs : this.options.warmupTimeoutMs);
+
+		return new Promise<unknown>((resolve, reject) => {
+			let settled = false;
+			const cleanup = (): void => {
+				settled = true;
+				clearTimeout(timer);
+				options.signal?.removeEventListener("abort", onAbort);
+				this.pending.delete(id);
+			};
+			const entry: Pending = {
+				resolve: (value) => {
+					if (settled) return;
+					cleanup();
+					this.warmedUp = true;
+					resolve(value);
+				},
+				reject: (error) => {
+					if (settled) return;
+					cleanup();
+					reject(error);
+				},
+				settle: cleanup,
+			};
+			const onAbort = (): void => {
+				if (settled) return;
+				cleanup();
+				this.notify("$/cancelRequest", { id });
+				reject(new Error("aborted"));
+			};
+			const timer = setTimeout(() => {
+				if (settled) return;
+				cleanup();
+				// Keep the server alive: it is probably still indexing, and the next
+				// request against a warm index usually succeeds.
+				this.notify("$/cancelRequest", { id });
+				reject(new Error(`${method} timed out after ${Math.round(timeoutMs / 1000)}s (the language server may still be indexing — retry shortly)`));
+			}, timeoutMs);
+
+			options.signal?.addEventListener("abort", onAbort, { once: true });
+			this.pending.set(id, entry);
+			this.transport.send(encodeFrame({ jsonrpc: "2.0", id, method, params }));
+		});
+	}
+
+	notify(method: string, params: unknown): void {
+		if (this.closeInfo) return;
+		this.transport.send(encodeFrame({ jsonrpc: "2.0", method, params }));
+	}
+
+	async dispose(): Promise<void> {
+		if (this.disposed) return;
+		this.disposed = true;
+		try {
+			await this.request("shutdown", null, { timeoutMs: SHUTDOWN_BUDGET_MS });
+			this.notify("exit", undefined);
+		} catch {
+			/* an unresponsive server just gets killed */
+		}
+		this.transport.kill();
+	}
+
+	killNow(): void {
+		this.disposed = true;
+		this.transport.killNow();
+	}
+
+	private closeMessage(): string {
+		const detail = lastLine(this.closeInfo?.stderr ?? "");
+		const code = this.closeInfo?.code;
+		return `language server exited${code === null || code === undefined ? "" : ` (code ${code})`}${detail ? `: ${detail}` : ""}`;
+	}
+
+	private handleClose(info: TransportClose): void {
+		this.closeInfo = info;
+		const error = new Error(this.closeMessage());
+		for (const entry of [...this.pending.values()]) entry.reject(error);
+		this.pending.clear();
+		for (const waiter of [...this.diagnosticsWaiters]) waiter.deliver(undefined);
+	}
+
+	private handleMessage(message: JsonRpcMessage): void {
+		if (message.method !== undefined) {
+			if (message.id === undefined || message.id === null) this.handleNotification(message);
+			else this.handleServerRequest(message);
+			return;
+		}
+		if (typeof message.id !== "number") return;
+		const entry = this.pending.get(message.id);
+		if (!entry) return;
+		if (message.error) entry.reject(new Error(message.error.message || "language server error"));
+		else entry.resolve(message.result);
+	}
+
+	private handleNotification(message: JsonRpcMessage): void {
+		if (message.method !== "textDocument/publishDiagnostics") return;
+		const params = message.params as { uri?: string; diagnostics?: LspDiagnostic[] } | undefined;
+		if (!params?.uri) return;
+		this.generation += 1;
+		const entry: DiagnosticsEntry = { generation: this.generation, items: params.diagnostics ?? [] };
+		this.diagnostics.set(params.uri, entry);
+		for (const waiter of [...this.diagnosticsWaiters]) {
+			if (waiter.uri === params.uri && entry.generation > waiter.minGeneration) waiter.deliver(entry.items);
+		}
+	}
+
+	/**
+	 * Every server request gets an answer. A server left waiting on a reply it
+	 * asked for will stall the whole session, so unknown methods are refused
+	 * explicitly rather than ignored.
+	 */
+	private handleServerRequest(message: JsonRpcMessage): void {
+		const reply = (result: unknown): void =>
+			this.transport.send(encodeFrame({ jsonrpc: "2.0", id: message.id, result }));
+
+		switch (message.method) {
+			case "workspace/configuration": {
+				const items = (message.params as { items?: unknown[] } | undefined)?.items ?? [];
+				reply(items.map(() => null));
+				return;
+			}
+			case "client/registerCapability":
+			case "client/unregisterCapability":
+			case "window/workDoneProgress/create":
+			case "window/showMessageRequest":
+				reply(null);
+				return;
+			case "workspace/applyEdit":
+				// This subsystem is read-only; refusing is the honest answer.
+				reply({ applied: false });
+				return;
+			default:
+				this.transport.send(
+					encodeFrame({
+						jsonrpc: "2.0",
+						id: message.id,
+						error: { code: METHOD_NOT_FOUND, message: `unsupported request: ${message.method}` },
+					}),
+				);
+		}
+	}
+}

--- a/install/pi-router/src/lsp-format.ts
+++ b/install/pi-router/src/lsp-format.ts
@@ -1,0 +1,230 @@
+/**
+ * LSP result shapes to the text the model reads.
+ *
+ * Pure: the only filesystem touch (a source line for grep-style context) is an
+ * injected reader. Empty results are friendly text rather than errors, matching
+ * pi's own grep tool ("No matches found") — a model that reads "not found"
+ * moves on, a model that reads an error retries.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fromLspPosition, uriToPath, type LspPosition } from "./lsp-protocol.js";
+
+const MAX_LINE_CHARS = 500;
+const MAX_HOVER_CHARS = 8000;
+const MAX_SYMBOLS = 200;
+const MAX_DIAGNOSTICS = 50;
+
+export interface LspRange {
+	start: LspPosition;
+	end: LspPosition;
+}
+
+export interface LspLocation {
+	uri: string;
+	range: LspRange;
+}
+
+export interface LspLocationLink {
+	targetUri: string;
+	targetRange: LspRange;
+	targetSelectionRange?: LspRange;
+}
+
+export interface NormalizedLocation {
+	path: string;
+	line: number;
+	column: number;
+}
+
+export interface LspDiagnostic {
+	range: LspRange;
+	severity?: number;
+	code?: string | number;
+	source?: string;
+	message: string;
+}
+
+interface LspDocumentSymbol {
+	name: string;
+	kind: number;
+	detail?: string;
+	range?: LspRange;
+	selectionRange?: LspRange;
+	children?: LspDocumentSymbol[];
+}
+
+interface LspSymbolInformation {
+	name: string;
+	kind: number;
+	containerName?: string;
+	location: LspLocation;
+}
+
+/** LSP 3.17 SymbolKind, 1-based. */
+const SYMBOL_KINDS = [
+	"File", "Module", "Namespace", "Package", "Class", "Method", "Property", "Field", "Constructor",
+	"Enum", "Interface", "Function", "Variable", "Constant", "String", "Number", "Boolean", "Array",
+	"Object", "Key", "Null", "EnumMember", "Struct", "Event", "Operator", "TypeParameter",
+];
+
+const SEVERITY_NAMES = ["error", "warning", "info", "hint"];
+
+export type LineReader = (filePath: string, line: number) => string | undefined;
+
+/** Memoized per call: a references result routinely hits the same file dozens of times. */
+export function createLineReader(readFile: (p: string) => string = (p) => fs.readFileSync(p, "utf8")): LineReader {
+	const cache = new Map<string, string[] | undefined>();
+	return (filePath, line) => {
+		if (!cache.has(filePath)) {
+			try {
+				cache.set(filePath, readFile(filePath).split(/\r?\n/));
+			} catch {
+				cache.set(filePath, undefined);
+			}
+		}
+		return cache.get(filePath)?.[line - 1];
+	};
+}
+
+export function displayPath(target: string, cwd: string): string {
+	const relative = path.relative(cwd, target);
+	if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) return target;
+	return relative;
+}
+
+function truncateLine(text: string): string {
+	const trimmed = text.trim();
+	return trimmed.length > MAX_LINE_CHARS ? `${trimmed.slice(0, MAX_LINE_CHARS)}... [truncated]` : trimmed;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+/** `Location | Location[] | LocationLink[] | null` collapsed to one 1-based shape. */
+export function normalizeLocations(result: unknown): NormalizedLocation[] {
+	if (result === null || result === undefined) return [];
+	const items = Array.isArray(result) ? result : [result];
+	const out: NormalizedLocation[] = [];
+	for (const item of items) {
+		if (!isRecord(item)) continue;
+		// LocationLink points at targetSelectionRange (the name) rather than
+		// targetRange (the whole declaration body), which is what a reader wants.
+		const uri = typeof item.uri === "string" ? item.uri : typeof item.targetUri === "string" ? item.targetUri : undefined;
+		if (!uri) continue;
+		const range = (item.range ?? item.targetSelectionRange ?? item.targetRange) as LspRange | undefined;
+		const { line, column } = fromLspPosition(range?.start);
+		out.push({ path: uriToPath(uri), line, column });
+	}
+	return out;
+}
+
+export interface LocationListOptions {
+	cwd: string;
+	readLine: LineReader;
+	limit: number;
+	/** Plural noun for the header, e.g. "references". Omit for a bare list. */
+	label?: string;
+}
+
+export function formatLocations(locations: NormalizedLocation[], options: LocationListOptions): string {
+	const shown = locations.slice(0, Math.max(1, options.limit));
+	const lines = shown.map((location) => {
+		const source = options.readLine(location.path, location.line);
+		const suffix = source === undefined ? "" : ` ${truncateLine(source)}`;
+		return `${displayPath(location.path, options.cwd)}:${location.line}:${location.column}:${suffix}`;
+	});
+	if (!options.label) return lines.join("\n");
+	const header =
+		locations.length > shown.length
+			? `${locations.length} ${options.label} (showing first ${shown.length})`
+			: `${locations.length} ${options.label}`;
+	return [header, ...lines].join("\n");
+}
+
+export function formatHover(result: unknown): string {
+	if (!isRecord(result)) return "";
+	const rendered = renderHoverContents(result.contents).trim();
+	return rendered.length > MAX_HOVER_CHARS ? `${rendered.slice(0, MAX_HOVER_CHARS)}\n... [truncated]` : rendered;
+}
+
+function renderHoverContents(contents: unknown): string {
+	if (typeof contents === "string") return contents;
+	if (Array.isArray(contents)) return contents.map(renderHoverContents).filter(Boolean).join("\n\n");
+	if (!isRecord(contents)) return "";
+	// MarkupContent
+	if (typeof contents.value === "string" && typeof contents.kind === "string") return contents.value;
+	// MarkedString: {language, value}
+	if (typeof contents.value === "string") {
+		const language = typeof contents.language === "string" ? contents.language : "";
+		return `\`\`\`${language}\n${contents.value}\n\`\`\``;
+	}
+	return "";
+}
+
+function symbolKindName(kind: number): string {
+	return SYMBOL_KINDS[kind - 1] ?? "Symbol";
+}
+
+export function formatSymbols(result: unknown, cwd: string): string {
+	if (!Array.isArray(result) || result.length === 0) return "";
+	const lines: string[] = [];
+	let remaining = MAX_SYMBOLS;
+
+	const walk = (symbols: LspDocumentSymbol[], depth: number): void => {
+		for (const symbol of symbols) {
+			if (remaining <= 0) return;
+			remaining -= 1;
+			const { line } = fromLspPosition((symbol.selectionRange ?? symbol.range)?.start);
+			const detail = symbol.detail ? ` ${symbol.detail}` : "";
+			lines.push(`${"  ".repeat(depth)}${symbolKindName(symbol.kind)} ${symbol.name}${detail} :${line}`);
+			if (symbol.children?.length) walk(symbol.children, depth + 1);
+		}
+	};
+
+	const first = result[0] as Record<string, unknown>;
+	if (isRecord(first) && isRecord(first.location)) {
+		// Flat SymbolInformation[] — older servers, no hierarchy available.
+		for (const symbol of (result as LspSymbolInformation[]).slice(0, MAX_SYMBOLS)) {
+			const { line } = fromLspPosition(symbol.location?.range?.start);
+			const container = symbol.containerName ? ` (in ${symbol.containerName})` : "";
+			const file = displayPath(uriToPath(symbol.location?.uri ?? ""), cwd);
+			lines.push(`${symbolKindName(symbol.kind)} ${symbol.name}${container} ${file}:${line}`);
+		}
+	} else {
+		walk(result as LspDocumentSymbol[], 0);
+	}
+
+	const total = countSymbols(result as LspDocumentSymbol[]);
+	if (total > lines.length) lines.push(`... ${total - lines.length} more symbols`);
+	return lines.join("\n");
+}
+
+function countSymbols(symbols: LspDocumentSymbol[]): number {
+	let total = 0;
+	for (const symbol of symbols) {
+		total += 1 + (symbol.children ? countSymbols(symbol.children) : 0);
+	}
+	return total;
+}
+
+export function formatDiagnostics(diagnostics: LspDiagnostic[], filePath: string, cwd: string): string {
+	if (diagnostics.length === 0) return "";
+	const counts = [0, 0, 0, 0];
+	for (const diagnostic of diagnostics) counts[(diagnostic.severity ?? 1) - 1] += 1;
+	const summary = SEVERITY_NAMES.map((name, index) => (counts[index] > 0 ? `${counts[index]} ${name}${counts[index] === 1 ? "" : "s"}` : null))
+		.filter(Boolean)
+		.join(", ");
+
+	const file = displayPath(filePath, cwd);
+	const lines = diagnostics.slice(0, MAX_DIAGNOSTICS).map((diagnostic) => {
+		const { line, column } = fromLspPosition(diagnostic.range?.start);
+		const severity = SEVERITY_NAMES[(diagnostic.severity ?? 1) - 1] ?? "error";
+		const source = diagnostic.source ? ` [${diagnostic.source}]` : "";
+		return `${severity} ${file}:${line}:${column}: ${diagnostic.message.replace(/\s*\n\s*/g, " ")}${source}`;
+	});
+	if (diagnostics.length > lines.length) lines.push(`... ${diagnostics.length - lines.length} more`);
+	return [summary, ...lines].join("\n");
+}

--- a/install/pi-router/src/lsp-install.ts
+++ b/install/pi-router/src/lsp-install.ts
@@ -23,6 +23,7 @@ import {
 } from "./lsp-servers.js";
 
 const INSTALL_TIMEOUT_MS = 300_000;
+const INSTALL_KILL_GRACE_MS = 5000;
 const OUTPUT_TAIL_BYTES = 2048;
 const MAX_SCAN_ENTRIES = 50;
 const SKIPPED_SCAN_DIRS = new Set(["node_modules", "vendor", "dist", "build", "target"]);
@@ -117,6 +118,7 @@ export interface InstallDeps {
 	which?: WhichFn;
 	spawnFn?: SpawnFn;
 	timeoutMs?: number;
+	killGraceMs?: number;
 }
 
 /** Run the spec's install command. Only ever called with the user's explicit consent. */
@@ -137,30 +139,39 @@ export async function installServer(spec: LanguageServerSpec, deps: InstallDeps 
 	const [command, ...args] = spec.install.command;
 	const spawnFn = deps.spawnFn ?? nodeSpawn;
 	const timeoutMs = deps.timeoutMs ?? INSTALL_TIMEOUT_MS;
+	const killGraceMs = deps.killGraceMs ?? INSTALL_KILL_GRACE_MS;
 
-	const outcome = await new Promise<{ code: number | null; output: string }>((resolve) => {
+	const outcome = await new Promise<{ code: number | null; output: string; cancelled?: "aborted" | "timed out" }>((resolve) => {
 		const child = spawnFn(command, args, { shell: false, stdio: ["ignore", "pipe", "pipe"] });
 		let tail = "";
 		let settled = false;
+		let cancelled: "aborted" | "timed out" | undefined;
+		let killTimer: NodeJS.Timeout | undefined;
 		const settle = (code: number | null): void => {
 			if (settled) return;
 			settled = true;
 			clearTimeout(timer);
+			if (killTimer) clearTimeout(killTimer);
 			signal?.removeEventListener("abort", onAbort);
-			resolve({ code, output: tail });
+			resolve({ code, output: tail, cancelled });
 		};
 		const append = (chunk: Buffer): void => {
 			tail = (tail + chunk.toString("utf8")).slice(-OUTPUT_TAIL_BYTES);
 		};
-		const onAbort = (): void => {
+		// Cancellation must not settle before the child actually exits — an
+		// installer that shrugs off SIGTERM would keep mutating the system after
+		// we reported failure. Settle on close, escalating to SIGKILL if needed.
+		const cancel = (reason: "aborted" | "timed out"): void => {
+			if (settled || cancelled) return;
+			cancelled = reason;
 			child.kill("SIGTERM");
-			settle(null);
+			killTimer = setTimeout(() => {
+				if (!settled) child.kill("SIGKILL");
+			}, killGraceMs);
+			killTimer.unref?.();
 		};
-		const timer = setTimeout(() => {
-			append(Buffer.from(`\ntimed out after ${Math.round(timeoutMs / 1000)}s`));
-			child.kill("SIGTERM");
-			settle(null);
-		}, timeoutMs);
+		const onAbort = (): void => cancel("aborted");
+		const timer = setTimeout(() => cancel("timed out"), timeoutMs);
 		timer.unref?.();
 
 		child.stdout?.on("data", append);
@@ -182,6 +193,12 @@ export async function installServer(spec: LanguageServerSpec, deps: InstallDeps 
 			.map((line) => line.trim())
 			.filter(Boolean)
 			.pop() ?? "";
+	if (outcome.cancelled) {
+		return {
+			ok: false,
+			text: `Installing the ${spec.language} language server ${outcome.cancelled} (\`${commandText}\`); the installer process was stopped. The install may be partial — re-run \`${commandText}\` to complete it.`,
+		};
+	}
 	if (outcome.code !== 0) {
 		return {
 			ok: false,

--- a/install/pi-router/src/lsp-install.ts
+++ b/install/pi-router/src/lsp-install.ts
@@ -1,0 +1,198 @@
+/**
+ * Opt-in language-server provisioning.
+ *
+ * Nothing here runs uninvited: the assistant is told (via a system-prompt
+ * addendum) which detected languages lack a server, offers ONCE in
+ * conversation ("I can enable Go LSP support if you'd like — just say the
+ * word!"), and only a user "yes" relayed through the lsp_enable tool triggers
+ * an install. A "no, stop asking" is persisted per language and respected
+ * across sessions.
+ */
+
+import { spawn as nodeSpawn } from "node:child_process";
+import * as fs from "node:fs";
+import type { SpawnFn } from "./lsp-client.js";
+import {
+	defaultWhich,
+	detectMarkers,
+	installCommandText,
+	LSP_SERVERS,
+	resolveBinary,
+	type LanguageServerSpec,
+	type WhichFn,
+} from "./lsp-servers.js";
+
+const INSTALL_TIMEOUT_MS = 300_000;
+const OUTPUT_TAIL_BYTES = 2048;
+const MAX_SCAN_ENTRIES = 50;
+const SKIPPED_SCAN_DIRS = new Set(["node_modules", "vendor", "dist", "build", "target"]);
+
+export interface DetectDeps {
+	exists?(target: string): boolean;
+	readDir?(dir: string): string[];
+	isDir?(target: string): boolean;
+}
+
+/**
+ * Which registry languages are present in a workspace: positive markers at the
+ * root or one level down (enough for common monorepo layouts, cheap enough to
+ * run at session start).
+ */
+export function detectWorkspaceServers(cwd: string, deps: DetectDeps = {}): LanguageServerSpec[] {
+	const exists = deps.exists ?? fs.existsSync;
+	const isDir = deps.isDir ?? ((target: string) => {
+		try {
+			return fs.statSync(target).isDirectory();
+		} catch {
+			return false;
+		}
+	});
+	const readDir = deps.readDir ?? ((dir: string) => {
+		try {
+			return fs.readdirSync(dir);
+		} catch {
+			return [];
+		}
+	});
+
+	const roots = [cwd];
+	for (const entry of readDir(cwd).slice(0, MAX_SCAN_ENTRIES)) {
+		if (entry.startsWith(".") || SKIPPED_SCAN_DIRS.has(entry)) continue;
+		const child = `${cwd}/${entry}`;
+		if (isDir(child)) roots.push(child);
+	}
+
+	return LSP_SERVERS.filter((spec) =>
+		roots.some((root) => detectMarkers(spec).some((marker) => exists(`${root}/${marker}`))),
+	);
+}
+
+interface LspPrefs {
+	dismissed: string[];
+}
+
+/** Tolerant read: a missing or corrupt prefs file means "nothing dismissed", never an error. */
+export function loadDismissedLanguages(prefsPath: string, readFile: (p: string) => string = (p) => fs.readFileSync(p, "utf8")): Set<string> {
+	try {
+		const parsed = JSON.parse(readFile(prefsPath)) as Partial<LspPrefs>;
+		return new Set(Array.isArray(parsed.dismissed) ? parsed.dismissed.filter((entry) => typeof entry === "string") : []);
+	} catch {
+		return new Set();
+	}
+}
+
+export function saveDismissedLanguages(
+	prefsPath: string,
+	dismissed: Set<string>,
+	writeFile: (p: string, data: string) => void = (p, data) => fs.writeFileSync(p, data),
+): void {
+	writeFile(prefsPath, `${JSON.stringify({ dismissed: [...dismissed].sort() }, null, 2)}\n`);
+}
+
+/**
+ * The system-prompt addendum that turns detection into a conversational offer.
+ * Returns undefined when there is nothing to offer (nothing detected missing,
+ * or everything relevant was dismissed).
+ */
+export function buildLspOffer(missing: LanguageServerSpec[], dismissed: Set<string>): string | undefined {
+	const offerable = missing.filter((spec) => !dismissed.has(spec.language));
+	if (offerable.length === 0) return undefined;
+	const languages = offerable.map((spec) => spec.language).join(", ");
+	return [
+		"## Code intelligence (LSP)",
+		`This workspace contains ${languages} code, but the matching language server(s) are not installed, so the \`lsp\` tool cannot serve those files yet.`,
+		`At a natural moment, offer ONCE — briefly, in your own words (e.g. "I can enable ${offerable[0].language} LSP support if you'd like — just say the word!") — to enable it.`,
+		'If the user agrees, call lsp_enable with {"language": "<language>"} for each language they want.',
+		'If they decline or ask not to be asked again, call lsp_enable with {"language": "<language>", "action": "dismiss"} and drop the subject.',
+		"Never call lsp_enable without the user's explicit go-ahead, and do not repeat the offer in this session.",
+	].join("\n");
+}
+
+export interface InstallResult {
+	ok: boolean;
+	text: string;
+}
+
+export interface InstallDeps {
+	which?: WhichFn;
+	spawnFn?: SpawnFn;
+	timeoutMs?: number;
+}
+
+/** Run the spec's install command. Only ever called with the user's explicit consent. */
+export async function installServer(spec: LanguageServerSpec, deps: InstallDeps = {}, signal?: AbortSignal): Promise<InstallResult> {
+	const which = deps.which ?? defaultWhich;
+	const commandText = installCommandText(spec);
+
+	if (resolveBinary(spec, which)) {
+		return { ok: true, text: `The ${spec.language} language server is already installed — the lsp tool is ready for ${spec.language} files.` };
+	}
+	if (!which(spec.install.requires)) {
+		return {
+			ok: false,
+			text: `Cannot install the ${spec.language} language server: it needs \`${spec.install.requires}\` on PATH (the install command is \`${commandText}\`). The install-lsps skill covers installing the ${spec.install.requires} toolchain with the user's consent.`,
+		};
+	}
+
+	const [command, ...args] = spec.install.command;
+	const spawnFn = deps.spawnFn ?? nodeSpawn;
+	const timeoutMs = deps.timeoutMs ?? INSTALL_TIMEOUT_MS;
+
+	const outcome = await new Promise<{ code: number | null; output: string }>((resolve) => {
+		const child = spawnFn(command, args, { shell: false, stdio: ["ignore", "pipe", "pipe"] });
+		let tail = "";
+		let settled = false;
+		const settle = (code: number | null): void => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			signal?.removeEventListener("abort", onAbort);
+			resolve({ code, output: tail });
+		};
+		const append = (chunk: Buffer): void => {
+			tail = (tail + chunk.toString("utf8")).slice(-OUTPUT_TAIL_BYTES);
+		};
+		const onAbort = (): void => {
+			child.kill("SIGTERM");
+			settle(null);
+		};
+		const timer = setTimeout(() => {
+			append(Buffer.from(`\ntimed out after ${Math.round(timeoutMs / 1000)}s`));
+			child.kill("SIGTERM");
+			settle(null);
+		}, timeoutMs);
+		timer.unref?.();
+
+		child.stdout?.on("data", append);
+		child.stderr?.on("data", append);
+		child.on("close", (code) => settle(code));
+		child.on("error", (error: Error) => {
+			append(Buffer.from(error.message));
+			settle(null);
+		});
+		if (signal) {
+			if (signal.aborted) onAbort();
+			else signal.addEventListener("abort", onAbort, { once: true });
+		}
+	});
+
+	const lastOutputLine =
+		outcome.output
+			.split("\n")
+			.map((line) => line.trim())
+			.filter(Boolean)
+			.pop() ?? "";
+	if (outcome.code !== 0) {
+		return {
+			ok: false,
+			text: `Installing the ${spec.language} language server failed (\`${commandText}\`${outcome.code === null ? "" : `, exit ${outcome.code}`})${lastOutputLine ? `: ${lastOutputLine}` : ""}`,
+		};
+	}
+	if (!resolveBinary(spec, which)) {
+		return {
+			ok: false,
+			text: `\`${commandText}\` succeeded but its binary is still not resolvable — the install location is probably not on PATH. Ask the user to add it and restart pi.`,
+		};
+	}
+	return { ok: true, text: `Installed the ${spec.language} language server — the lsp tool now works for ${spec.language} files in this session.` };
+}

--- a/install/pi-router/src/lsp-protocol.ts
+++ b/install/pi-router/src/lsp-protocol.ts
@@ -1,0 +1,128 @@
+/**
+ * Content-Length framing and coordinate conversion.
+ *
+ * Both transports in this subsystem speak the same wire format: LSP servers
+ * over stdio, and the subagent broker over a local socket. Framing lives here
+ * so neither owns it.
+ */
+
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export interface JsonRpcMessage {
+	jsonrpc?: string;
+	id?: number | string | null;
+	method?: string;
+	params?: unknown;
+	result?: unknown;
+	error?: { code: number; message: string; data?: unknown };
+}
+
+const HEADER_SEPARATOR = "\r\n\r\n";
+
+/** Buffered-bytes ceiling. A peer that blows through it is malfunctioning; the owner kills it. */
+export const MAX_FRAME_BYTES = 16 * 1024 * 1024;
+
+export function encodeFrame(message: unknown): Buffer {
+	const body = Buffer.from(JSON.stringify(message), "utf8");
+	// Content-Length counts BYTES, not characters — a UTF-8 body with any
+	// non-ASCII content would otherwise desynchronize the peer's parser.
+	return Buffer.concat([Buffer.from(`Content-Length: ${body.length}${HEADER_SEPARATOR}`, "ascii"), body]);
+}
+
+export interface FrameParser {
+	push(chunk: Buffer): void;
+}
+
+/**
+ * Incremental parser: handles several frames per chunk, one frame split across
+ * chunks, and extra headers (`Content-Type`). A body that is not JSON costs
+ * that one message; `onOverflow` fires once and the parser then stays quiet so
+ * the owner can tear the peer down.
+ */
+export function createFrameParser(onMessage: (message: JsonRpcMessage) => void, onOverflow?: (error: Error) => void): FrameParser {
+	let buffer = Buffer.alloc(0);
+	let overflowed = false;
+
+	return {
+		push(chunk: Buffer): void {
+			if (overflowed) return;
+			buffer = buffer.length === 0 ? chunk : Buffer.concat([buffer, chunk]);
+			if (buffer.length > MAX_FRAME_BYTES) {
+				overflowed = true;
+				buffer = Buffer.alloc(0);
+				onOverflow?.(new Error(`framed message exceeded ${MAX_FRAME_BYTES} bytes`));
+				return;
+			}
+
+			while (true) {
+				const headerEnd = buffer.indexOf(HEADER_SEPARATOR);
+				if (headerEnd === -1) return;
+				const header = buffer.subarray(0, headerEnd).toString("ascii");
+				const match = /content-length:\s*(\d+)/i.exec(header);
+				if (!match) {
+					// No length means no way to find the next boundary; drop the header
+					// block and resynchronize on whatever follows it.
+					buffer = buffer.subarray(headerEnd + HEADER_SEPARATOR.length);
+					continue;
+				}
+				const bodyStart = headerEnd + HEADER_SEPARATOR.length;
+				const bodyLength = Number(match[1]);
+				if (buffer.length < bodyStart + bodyLength) return;
+				const body = buffer.subarray(bodyStart, bodyStart + bodyLength).toString("utf8");
+				buffer = buffer.subarray(bodyStart + bodyLength);
+				try {
+					onMessage(JSON.parse(body) as JsonRpcMessage);
+				} catch {
+					/* malformed body — skip this message, keep the stream */
+				}
+			}
+		},
+	};
+}
+
+export function pathToUri(filePath: string): string {
+	return pathToFileURL(filePath).toString();
+}
+
+export function uriToPath(uri: string): string {
+	if (!uri.startsWith("file:")) return uri;
+	try {
+		return fileURLToPath(uri);
+	} catch {
+		// Some servers emit non-canonical file URIs (unencoded spaces).
+		return decodeURIComponent(uri.replace(/^file:\/\//, ""));
+	}
+}
+
+/**
+ * The operation vocabulary. It lives beside the framing rather than with the pi
+ * tool because it is literally the broker's wire payload — keeping it here lets
+ * the broker stay below the tool adapter instead of importing back into it.
+ */
+export const LSP_OPERATIONS = ["definition", "references", "hover", "documentSymbol", "diagnostics"] as const;
+
+export type LspOperation = (typeof LSP_OPERATIONS)[number];
+
+/** Operations that resolve a point in a file, and so require line + column. */
+export const POSITION_OPERATIONS = new Set<LspOperation>(["definition", "references", "hover"]);
+
+export interface LspOperationParams {
+	operation: LspOperation;
+	path: string;
+	line?: number;
+	column?: number;
+}
+
+export interface LspPosition {
+	line: number;
+	character: number;
+}
+
+/** Model-facing 1-based line/column to the 0-based position LSP uses. */
+export function toLspPosition(line: number, column: number): LspPosition {
+	return { line: Math.max(0, Math.trunc(line) - 1), character: Math.max(0, Math.trunc(column) - 1) };
+}
+
+export function fromLspPosition(position: LspPosition | undefined): { line: number; column: number } {
+	return { line: (position?.line ?? 0) + 1, column: (position?.character ?? 0) + 1 };
+}

--- a/install/pi-router/src/lsp-servers.ts
+++ b/install/pi-router/src/lsp-servers.ts
@@ -34,10 +34,26 @@ export interface LanguageServerSpec {
 	install: ServerInstall;
 	/**
 	 * Where the install command drops its binary when that directory is not on
-	 * PATH ("~" expands to the home dir). Lets a just-installed server resolve
-	 * immediately instead of failing until the user edits their PATH.
+	 * PATH ("~" expands to the home dir). A function of the environment because
+	 * the toolchains honor overrides (GOBIN / GOPATH / CARGO_HOME) — hardcoding
+	 * the defaults would lose a successful install to a non-default location.
 	 */
-	fallbackDirs: string[];
+	fallbackDirs(env: NodeJS.ProcessEnv): string[];
+}
+
+/** `go install` target: $GOBIN, else <first GOPATH element>/bin, else ~/go/bin. */
+export function goBinDirs(env: NodeJS.ProcessEnv): string[] {
+	const dirs: string[] = [];
+	if (env.GOBIN?.trim()) dirs.push(env.GOBIN.trim());
+	const gopathFirst = env.GOPATH?.split(path.delimiter)[0]?.trim();
+	dirs.push(gopathFirst ? path.join(gopathFirst, "bin") : "~/go/bin");
+	return dirs;
+}
+
+/** rustup/cargo bin dir: $CARGO_HOME/bin, else ~/.cargo/bin. */
+export function cargoBinDirs(env: NodeJS.ProcessEnv): string[] {
+	const cargoHome = env.CARGO_HOME?.trim();
+	return [cargoHome ? path.join(cargoHome, "bin") : "~/.cargo/bin"];
 }
 
 export const LSP_SERVERS: LanguageServerSpec[] = [
@@ -48,7 +64,7 @@ export const LSP_SERVERS: LanguageServerSpec[] = [
 		binaries: [{ command: "gopls", args: ["serve"] }],
 		rootMarkers: ["go.work", "go.mod"],
 		install: { requires: "go", command: ["go", "install", "golang.org/x/tools/gopls@latest"] },
-		fallbackDirs: ["~/go/bin"],
+		fallbackDirs: goBinDirs,
 	},
 	{
 		id: "typescript",
@@ -66,7 +82,7 @@ export const LSP_SERVERS: LanguageServerSpec[] = [
 		binaries: [{ command: "typescript-language-server", args: ["--stdio"] }],
 		rootMarkers: ["tsconfig.json", "jsconfig.json", "package.json", ".git"],
 		install: { requires: "npm", command: ["npm", "i", "-g", "typescript-language-server", "typescript"] },
-		fallbackDirs: [],
+		fallbackDirs: () => [],
 	},
 	{
 		id: "pyright",
@@ -78,7 +94,7 @@ export const LSP_SERVERS: LanguageServerSpec[] = [
 		],
 		rootMarkers: ["pyrightconfig.json", "pyproject.toml", "setup.py", "requirements.txt", ".git"],
 		install: { requires: "npm", command: ["npm", "i", "-g", "pyright"] },
-		fallbackDirs: [],
+		fallbackDirs: () => [],
 	},
 	{
 		id: "rust-analyzer",
@@ -87,7 +103,7 @@ export const LSP_SERVERS: LanguageServerSpec[] = [
 		binaries: [{ command: "rust-analyzer", args: [] }],
 		rootMarkers: ["Cargo.toml"],
 		install: { requires: "rustup", command: ["rustup", "component", "add", "rust-analyzer"] },
-		fallbackDirs: ["~/.cargo/bin"],
+		fallbackDirs: cargoBinDirs,
 	},
 ];
 
@@ -167,11 +183,15 @@ function expandHome(dir: string): string {
 	return dir.startsWith("~/") ? path.join(os.homedir(), dir.slice(2)) : dir;
 }
 
-export function resolveBinary(spec: LanguageServerSpec, which: WhichFn = defaultWhich): ServerBinary | undefined {
+export function resolveBinary(
+	spec: LanguageServerSpec,
+	which: WhichFn = defaultWhich,
+	env: NodeJS.ProcessEnv = process.env,
+): ServerBinary | undefined {
 	for (const binary of spec.binaries) {
 		// Fallback candidates are absolute, which defaultWhich checks directly;
 		// routing them through `which` keeps a single injectable seam.
-		const candidates = [binary.command, ...spec.fallbackDirs.map((dir) => path.join(expandHome(dir), binary.command))];
+		const candidates = [binary.command, ...spec.fallbackDirs(env).map((dir) => path.join(expandHome(dir), binary.command))];
 		for (const candidate of candidates) {
 			const resolved = which(candidate);
 			if (resolved) return { command: resolved, args: binary.args };

--- a/install/pi-router/src/lsp-servers.ts
+++ b/install/pi-router/src/lsp-servers.ts
@@ -223,6 +223,8 @@ interface PoolEntry {
 	client: LspClient;
 	ready: Promise<LspClient>;
 	lastUsed: number;
+	/** False until initialize succeeds — pending entries are exempt from idle and LRU eviction. */
+	initialized: boolean;
 	idleTimer?: NodeJS.Timeout;
 }
 
@@ -269,7 +271,15 @@ export class LspServerPool {
 		let entry = this.entries.get(key);
 		if (!entry) {
 			const client = this.createClient(spec, binary, root, this.options);
-			const created: PoolEntry = { client, ready: client.initialize().then(() => client), lastUsed: this.now() };
+			const created: PoolEntry = { client, ready: Promise.resolve(client), lastUsed: this.now(), initialized: false };
+			created.ready = client.initialize().then(() => {
+				// Only now does the entry become evictable: an idle timer or LRU pass
+				// during the (up to warmup-length) handshake would dispose a client
+				// its original caller is still awaiting.
+				created.initialized = true;
+				if (this.entries.get(key) === created) this.armIdleTimer(key, created);
+				return client;
+			});
 			this.entries.set(key, created);
 			// A failed handshake must not stay cached as a poisoned promise.
 			created.ready.catch(() => {
@@ -280,7 +290,7 @@ export class LspServerPool {
 		}
 
 		entry.lastUsed = this.now();
-		this.armIdleTimer(key, entry);
+		if (entry.initialized) this.armIdleTimer(key, entry);
 		this.evictOverCap(key);
 		return abortable(entry.ready, signal);
 	}
@@ -317,6 +327,12 @@ export class LspServerPool {
 	private armIdleTimer(key: string, entry: PoolEntry): void {
 		if (entry.idleTimer) clearTimeout(entry.idleTimer);
 		entry.idleTimer = setTimeout(() => {
+			// A slow request (or diagnostics wait) can outlive a short idle window;
+			// "idle" means no in-flight work, not merely no recent acquire.
+			if (entry.client.busy && !entry.client.dead) {
+				this.armIdleTimer(key, entry);
+				return;
+			}
 			this.forget(key, entry);
 			void entry.client.dispose();
 		}, this.options.idleMs);
@@ -329,6 +345,9 @@ export class LspServerPool {
 			let oldestEntry: PoolEntry | undefined;
 			for (const [key, entry] of this.entries) {
 				if (key === keepKey) continue;
+				// Still initializing = someone is awaiting it. The cap is soft during
+				// warmup; the overflow is reclaimed on the next settled acquire.
+				if (!entry.initialized) continue;
 				if (!oldestEntry || entry.lastUsed < oldestEntry.lastUsed) {
 					oldestKey = key;
 					oldestEntry = entry;

--- a/install/pi-router/src/lsp-servers.ts
+++ b/install/pi-router/src/lsp-servers.ts
@@ -1,0 +1,322 @@
+/**
+ * Which language server serves which file, and the pool of live ones.
+ *
+ * The registry is a data table rather than a class hierarchy: adding a language
+ * is one row, and every behavioral difference between servers is already
+ * expressible as data (binary, root markers, install hint).
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { abortable, LspClient, spawnTransport, type LspClientOptions } from "./lsp-client.js";
+
+export interface ServerBinary {
+	command: string;
+	args: string[];
+}
+
+export interface ServerInstall {
+	/** Toolchain binary that must already exist for the install to be possible. */
+	requires: string;
+	command: string[];
+}
+
+export interface LanguageServerSpec {
+	id: string;
+	/** Model/user-facing language name ("go"), distinct from the server id ("gopls"). */
+	language: string;
+	/** Lowercased file extension (with dot) to LSP languageId. */
+	languages: Record<string, string>;
+	/** Tried in order; the first one on PATH wins. */
+	binaries: ServerBinary[];
+	rootMarkers: string[];
+	install: ServerInstall;
+	/**
+	 * Where the install command drops its binary when that directory is not on
+	 * PATH ("~" expands to the home dir). Lets a just-installed server resolve
+	 * immediately instead of failing until the user edits their PATH.
+	 */
+	fallbackDirs: string[];
+}
+
+export const LSP_SERVERS: LanguageServerSpec[] = [
+	{
+		id: "gopls",
+		language: "go",
+		languages: { ".go": "go" },
+		binaries: [{ command: "gopls", args: ["serve"] }],
+		rootMarkers: ["go.work", "go.mod"],
+		install: { requires: "go", command: ["go", "install", "golang.org/x/tools/gopls@latest"] },
+		fallbackDirs: ["~/go/bin"],
+	},
+	{
+		id: "typescript",
+		language: "typescript",
+		languages: {
+			".ts": "typescript",
+			".tsx": "typescriptreact",
+			".mts": "typescript",
+			".cts": "typescript",
+			".js": "javascript",
+			".jsx": "javascriptreact",
+			".mjs": "javascript",
+			".cjs": "javascript",
+		},
+		binaries: [{ command: "typescript-language-server", args: ["--stdio"] }],
+		rootMarkers: ["tsconfig.json", "jsconfig.json", "package.json", ".git"],
+		install: { requires: "npm", command: ["npm", "i", "-g", "typescript-language-server", "typescript"] },
+		fallbackDirs: [],
+	},
+	{
+		id: "pyright",
+		language: "python",
+		languages: { ".py": "python", ".pyi": "python" },
+		binaries: [
+			{ command: "pyright-langserver", args: ["--stdio"] },
+			{ command: "basedpyright-langserver", args: ["--stdio"] },
+		],
+		rootMarkers: ["pyrightconfig.json", "pyproject.toml", "setup.py", "requirements.txt", ".git"],
+		install: { requires: "npm", command: ["npm", "i", "-g", "pyright"] },
+		fallbackDirs: [],
+	},
+	{
+		id: "rust-analyzer",
+		language: "rust",
+		languages: { ".rs": "rust" },
+		binaries: [{ command: "rust-analyzer", args: [] }],
+		rootMarkers: ["Cargo.toml"],
+		install: { requires: "rustup", command: ["rustup", "component", "add", "rust-analyzer"] },
+		fallbackDirs: ["~/.cargo/bin"],
+	},
+];
+
+export function specForLanguage(language: string): LanguageServerSpec | undefined {
+	return LSP_SERVERS.find((spec) => spec.language === language.toLowerCase());
+}
+
+export function installCommandText(spec: LanguageServerSpec): string {
+	return spec.install.command.join(" ");
+}
+
+/**
+ * Markers that positively indicate the language is present in a directory.
+ * `.git` is a root-walk fallback, not evidence of any language.
+ */
+export function detectMarkers(spec: LanguageServerSpec): string[] {
+	return spec.rootMarkers.filter((marker) => marker !== ".git");
+}
+
+export function specForFile(filePath: string): LanguageServerSpec | undefined {
+	const extension = path.extname(filePath).toLowerCase();
+	if (!extension) return undefined;
+	return LSP_SERVERS.find((spec) => extension in spec.languages);
+}
+
+export function languageIdFor(spec: LanguageServerSpec, filePath: string): string {
+	return spec.languages[path.extname(filePath).toLowerCase()] ?? "plaintext";
+}
+
+export function supportedExtensions(): string[] {
+	return LSP_SERVERS.flatMap((spec) => Object.keys(spec.languages)).sort();
+}
+
+export type ExistsFn = (target: string) => boolean;
+
+/** Nearest ancestor holding a marker wins; `fallbackCwd` when the file sits outside any project. */
+export function findWorkspaceRoot(filePath: string, markers: string[], fallbackCwd: string, exists: ExistsFn = fs.existsSync): string {
+	let current = path.dirname(path.resolve(filePath));
+	while (true) {
+		for (const marker of markers) {
+			if (exists(path.join(current, marker))) return current;
+		}
+		const parent = path.dirname(current);
+		if (parent === current) return fallbackCwd;
+		current = parent;
+	}
+}
+
+export type WhichFn = (command: string) => string | undefined;
+
+function isExecutable(candidate: string): boolean {
+	try {
+		if (!fs.statSync(candidate).isFile()) return false;
+		// Windows has no X_OK bit; presence on PATH with a known extension is the test.
+		if (process.platform !== "win32") fs.accessSync(candidate, fs.constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/** Hand-rolled PATH scan — the package ships raw TS with peer deps only, so no `which` dependency. */
+export function defaultWhich(command: string): string | undefined {
+	if (command.includes("/") || command.includes(path.sep)) return isExecutable(command) ? command : undefined;
+	const extensions = process.platform === "win32" ? ["", ".cmd", ".exe", ".bat"] : [""];
+	for (const dir of (process.env.PATH ?? "").split(path.delimiter)) {
+		if (!dir) continue;
+		for (const extension of extensions) {
+			const candidate = path.join(dir, command + extension);
+			if (isExecutable(candidate)) return candidate;
+		}
+	}
+	return undefined;
+}
+
+function expandHome(dir: string): string {
+	return dir.startsWith("~/") ? path.join(os.homedir(), dir.slice(2)) : dir;
+}
+
+export function resolveBinary(spec: LanguageServerSpec, which: WhichFn = defaultWhich): ServerBinary | undefined {
+	for (const binary of spec.binaries) {
+		// Fallback candidates are absolute, which defaultWhich checks directly;
+		// routing them through `which` keeps a single injectable seam.
+		const candidates = [binary.command, ...spec.fallbackDirs.map((dir) => path.join(expandHome(dir), binary.command))];
+		for (const candidate of candidates) {
+			const resolved = which(candidate);
+			if (resolved) return { command: resolved, args: binary.args };
+		}
+	}
+	return undefined;
+}
+
+export function missingServerText(spec: LanguageServerSpec): string {
+	const names = spec.binaries.map((binary) => binary.command).join(" or ");
+	return [
+		`No language server for this file type: ${names} is not on PATH.`,
+		`The user can enable it (install: ${installCommandText(spec)}), or ask the assistant to via the lsp_enable tool.`,
+		"Until then, use grep/read for this file instead.",
+	].join("\n");
+}
+
+export interface PoolOptions extends LspClientOptions {
+	maxServers: number;
+	idleMs: number;
+}
+
+export interface PoolDeps {
+	createClient?(spec: LanguageServerSpec, binary: ServerBinary, root: string, options: LspClientOptions): LspClient;
+	now?(): number;
+}
+
+interface PoolEntry {
+	client: LspClient;
+	ready: Promise<LspClient>;
+	lastUsed: number;
+	idleTimer?: NodeJS.Timeout;
+}
+
+function defaultCreateClient(
+	_spec: LanguageServerSpec,
+	binary: ServerBinary,
+	root: string,
+	options: LspClientOptions,
+): LspClient {
+	return new LspClient(root, spawnTransport(binary.command, binary.args, root), options);
+}
+
+/**
+ * Live servers keyed by workspace root + language. Servers are expensive to
+ * start (gopls indexes a module) and cheap to keep, so they are spawned lazily,
+ * shared by every caller including broker-connected subagents, and reclaimed on
+ * idle or LRU pressure.
+ */
+export class LspServerPool {
+	private readonly entries = new Map<string, PoolEntry>();
+	private readonly createClient: NonNullable<PoolDeps["createClient"]>;
+	private readonly now: () => number;
+
+	constructor(
+		private readonly options: PoolOptions,
+		deps: PoolDeps = {},
+	) {
+		this.createClient = deps.createClient ?? defaultCreateClient;
+		this.now = deps.now ?? Date.now;
+	}
+
+	get size(): number {
+		return this.entries.size;
+	}
+
+	async acquire(spec: LanguageServerSpec, binary: ServerBinary, root: string, signal?: AbortSignal): Promise<LspClient> {
+		const key = `${root} ${spec.id}`;
+		const existing = this.entries.get(key);
+		if (existing && existing.client.dead) {
+			this.forget(key, existing);
+			existing.client.killNow();
+		}
+
+		let entry = this.entries.get(key);
+		if (!entry) {
+			const client = this.createClient(spec, binary, root, this.options);
+			const created: PoolEntry = { client, ready: client.initialize().then(() => client), lastUsed: this.now() };
+			this.entries.set(key, created);
+			// A failed handshake must not stay cached as a poisoned promise.
+			created.ready.catch(() => {
+				if (this.entries.get(key) === created) this.forget(key, created);
+				client.killNow();
+			});
+			entry = created;
+		}
+
+		entry.lastUsed = this.now();
+		this.armIdleTimer(key, entry);
+		this.evictOverCap(key);
+		return abortable(entry.ready, signal);
+	}
+
+	async shutdownAll(): Promise<void> {
+		const entries = [...this.entries.entries()];
+		this.entries.clear();
+		await Promise.all(
+			entries.map(async ([, entry]) => {
+				if (entry.idleTimer) clearTimeout(entry.idleTimer);
+				try {
+					await entry.client.dispose();
+				} catch {
+					/* one stuck server must not block the rest of shutdown */
+				}
+			}),
+		);
+	}
+
+	/** Emergency sweep for `process.on("exit")`, where nothing async can run. */
+	killAllSync(): void {
+		for (const [, entry] of this.entries) {
+			if (entry.idleTimer) clearTimeout(entry.idleTimer);
+			entry.client.killNow();
+		}
+		this.entries.clear();
+	}
+
+	private forget(key: string, entry: PoolEntry): void {
+		if (entry.idleTimer) clearTimeout(entry.idleTimer);
+		if (this.entries.get(key) === entry) this.entries.delete(key);
+	}
+
+	private armIdleTimer(key: string, entry: PoolEntry): void {
+		if (entry.idleTimer) clearTimeout(entry.idleTimer);
+		entry.idleTimer = setTimeout(() => {
+			this.forget(key, entry);
+			void entry.client.dispose();
+		}, this.options.idleMs);
+		entry.idleTimer.unref?.();
+	}
+
+	private evictOverCap(keepKey: string): void {
+		while (this.entries.size > Math.max(1, this.options.maxServers)) {
+			let oldestKey: string | undefined;
+			let oldestEntry: PoolEntry | undefined;
+			for (const [key, entry] of this.entries) {
+				if (key === keepKey) continue;
+				if (!oldestEntry || entry.lastUsed < oldestEntry.lastUsed) {
+					oldestKey = key;
+					oldestEntry = entry;
+				}
+			}
+			if (!oldestKey || !oldestEntry) return;
+			this.forget(oldestKey, oldestEntry);
+			void oldestEntry.client.dispose();
+		}
+	}
+}

--- a/install/pi-router/src/lsp.ts
+++ b/install/pi-router/src/lsp.ts
@@ -1,0 +1,508 @@
+/**
+ * `lsp` — code intelligence for pi, which has none natively.
+ *
+ * One composite call replaces a multi-turn read/grep loop, which saves tokens
+ * twice: fewer round trips, and less context growth before compaction.
+ *
+ * The same tool is registered in two roles. In the main process it drives a
+ * pool of language servers directly. In a dispatch child it forwards to the
+ * parent's pool over the broker socket, so a fan-out shares one warm server
+ * instead of cold-starting one per child. `runLspOperation` is the single
+ * orchestration core behind both, and is what the broker serves.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { StringEnum } from "@mariozechner/pi-ai";
+import { Text } from "@mariozechner/pi-tui";
+import { Type } from "typebox";
+import {
+	getLspPrefsPath,
+	isSubagent,
+	LSP_BROKER_ENV,
+	LSP_BROKER_TOKEN_ENV,
+	LSP_DIAGNOSTICS_WAIT_MS,
+	LSP_IDLE_MS,
+	LSP_MAX_REFERENCES,
+	LSP_MAX_SERVERS,
+	LSP_REQUEST_TIMEOUT_MS,
+	LSP_WARMUP_TIMEOUT_MS,
+} from "./config.js";
+import { LspBrokerClient, startLspBroker, type LspBrokerHandle } from "./lsp-broker.js";
+import {
+	buildLspOffer,
+	detectWorkspaceServers,
+	installServer,
+	loadDismissedLanguages,
+	saveDismissedLanguages,
+	type InstallResult,
+} from "./lsp-install.js";
+import type { LspClient } from "./lsp-client.js";
+import {
+	createLineReader,
+	displayPath,
+	formatDiagnostics,
+	formatHover,
+	formatLocations,
+	formatSymbols,
+	normalizeLocations,
+	type LspDiagnostic,
+} from "./lsp-format.js";
+import {
+	LSP_OPERATIONS,
+	pathToUri,
+	POSITION_OPERATIONS,
+	toLspPosition,
+	type LspOperation,
+	type LspOperationParams,
+} from "./lsp-protocol.js";
+import {
+	findWorkspaceRoot,
+	languageIdFor,
+	LSP_SERVERS,
+	LspServerPool,
+	missingServerText,
+	resolveBinary,
+	specForFile,
+	specForLanguage,
+	supportedExtensions,
+	type WhichFn,
+} from "./lsp-servers.js";
+
+const LspParams = Type.Object({
+	operation: StringEnum(LSP_OPERATIONS, {
+		description: "definition, references and hover require line + column; documentSymbol and diagnostics take only path.",
+	}),
+	path: Type.String({ description: "File to query, absolute or relative to the working directory." }),
+	line: Type.Optional(Type.Number({ description: "1-based line. Required for definition, references and hover." })),
+	column: Type.Optional(
+		Type.Number({ description: "1-based column in UTF-16 units, as editors count. Required for definition, references and hover." }),
+	),
+});
+
+export interface LspRunDeps {
+	pool: LspServerPool;
+	which?: WhichFn;
+	readFile?(target: string): string;
+	exists?(target: string): boolean;
+	maxReferences?: number;
+	diagnosticsWaitMs?: number;
+}
+
+/** Models sometimes echo pi's `@file` mention syntax into tool arguments. */
+export function normalizeToolPath(rawPath: string, cwd: string): string {
+	const stripped = rawPath.trim().replace(/^@/, "");
+	return path.isAbsolute(stripped) ? stripped : path.resolve(cwd, stripped);
+}
+
+/**
+ * Per-operation requiredness. `Type.Union` would express this in the schema but
+ * is banned here: it breaks Google's API, which is the same reason `StringEnum`
+ * exists. A thrown message is what pi turns into an error the model can act on.
+ */
+export function assertOperationParams(params: LspOperationParams): void {
+	if (!LSP_OPERATIONS.includes(params.operation)) {
+		throw new Error(`Unknown lsp operation "${params.operation}". Valid operations: ${LSP_OPERATIONS.join(", ")}.`);
+	}
+	if (typeof params.path !== "string" || params.path.trim() === "") throw new Error("lsp requires a `path`.");
+	if (!POSITION_OPERATIONS.has(params.operation)) return;
+	const missing = [
+		typeof params.line === "number" ? null : "line",
+		typeof params.column === "number" ? null : "column",
+	].filter(Boolean);
+	if (missing.length > 0) {
+		throw new Error(
+			`lsp ${params.operation} requires \`${missing.join("` and `")}\` (1-based). Use documentSymbol first to locate the symbol if you do not know its position.`,
+		);
+	}
+}
+
+async function queryClient(
+	client: LspClient,
+	params: LspOperationParams,
+	target: string,
+	cwd: string,
+	deps: LspRunDeps,
+	generation: number,
+	signal?: AbortSignal,
+): Promise<string> {
+	const uri = pathToUri(target);
+	const shown = displayPath(target, cwd);
+	const readLine = createLineReader(deps.readFile);
+	const textDocument = { uri };
+
+	switch (params.operation) {
+		case "definition": {
+			const position = toLspPosition(params.line as number, params.column as number);
+			const result = await client.request("textDocument/definition", { textDocument, position }, { signal });
+			const locations = normalizeLocations(result);
+			if (locations.length === 0) return `No definition found at ${shown}:${params.line}:${params.column}`;
+			return formatLocations(locations, { cwd, readLine, limit: locations.length });
+		}
+		case "references": {
+			const position = toLspPosition(params.line as number, params.column as number);
+			const result = await client.request(
+				"textDocument/references",
+				{ textDocument, position, context: { includeDeclaration: false } },
+				{ signal },
+			);
+			const locations = normalizeLocations(result);
+			if (locations.length === 0) return `No references found at ${shown}:${params.line}:${params.column}`;
+			return formatLocations(locations, {
+				cwd,
+				readLine,
+				limit: deps.maxReferences ?? LSP_MAX_REFERENCES,
+				label: "references",
+			});
+		}
+		case "hover": {
+			const position = toLspPosition(params.line as number, params.column as number);
+			const result = await client.request("textDocument/hover", { textDocument, position }, { signal });
+			const rendered = formatHover(result);
+			return rendered || `No hover information at ${shown}:${params.line}:${params.column}`;
+		}
+		case "documentSymbol": {
+			const result = await client.request("textDocument/documentSymbol", { textDocument }, { signal });
+			const rendered = formatSymbols(result, cwd);
+			return rendered || `No symbols found in ${shown}`;
+		}
+		case "diagnostics": {
+			const { items, fresh } = await client.waitForDiagnostics(
+				uri,
+				generation,
+				deps.diagnosticsWaitMs ?? LSP_DIAGNOSTICS_WAIT_MS,
+				signal,
+			);
+			const rendered = formatDiagnostics(items as LspDiagnostic[], target, cwd);
+			if (!rendered) return `No diagnostics reported for ${shown}`;
+			return fresh ? rendered : `${rendered}\n(may be stale — the language server did not publish in time)`;
+		}
+	}
+}
+
+/**
+ * The single code path that answers every query, whoever asked: the main-loop
+ * tool, and the broker on behalf of a subagent.
+ *
+ * Environmental dead ends (unknown file type, server not installed) return
+ * text rather than throwing. The model cannot install gopls, and an error
+ * invites a retry loop; text lets it fall back to grep.
+ */
+export async function runLspOperation(
+	params: LspOperationParams,
+	cwd: string,
+	deps: LspRunDeps,
+	signal?: AbortSignal,
+): Promise<string> {
+	assertOperationParams(params);
+	const exists = deps.exists ?? fs.existsSync;
+	const readFile = deps.readFile ?? ((target: string) => fs.readFileSync(target, "utf8"));
+
+	const target = normalizeToolPath(params.path, cwd);
+	if (!exists(target)) throw new Error(`File not found: ${params.path}`);
+
+	const spec = specForFile(target);
+	if (!spec) {
+		const extension = path.extname(target) || "this file type";
+		return `No language server is configured for ${extension}. Supported: ${supportedExtensions().join(", ")}. Use grep/read for this file instead.`;
+	}
+	const binary = resolveBinary(spec, deps.which);
+	if (!binary) return missingServerText(spec);
+	const root = findWorkspaceRoot(target, spec.rootMarkers, cwd);
+
+	let lastError: Error | undefined;
+	for (let attempt = 0; attempt < 2; attempt++) {
+		const client = await deps.pool.acquire(spec, binary, root, signal);
+		try {
+			// Capture before syncing: an ensureDocument that provokes a publish must
+			// count as newer than what we already had cached.
+			const generation = client.diagnosticsGeneration();
+			await client.ensureDocument(pathToUri(target), readFile(target), languageIdFor(spec, target));
+			return await queryClient(client, params, target, cwd, deps, generation, signal);
+		} catch (error) {
+			lastError = error as Error;
+			// Only a died-under-us server earns a second spawn. Retrying a timeout or
+			// a genuine LSP error would just double the wait.
+			if (!client.dead || signal?.aborted) throw lastError;
+		}
+	}
+	throw lastError ?? new Error("lsp request failed");
+}
+
+/** What dispatch needs to hand a child access to the parent's pool. */
+export interface LspBrokerProvider {
+	ensure(): Promise<Record<string, string>>;
+	active(): boolean;
+}
+
+export interface LspToolDeps {
+	pool?: LspServerPool;
+	which?: WhichFn;
+	brokerClient?: LspBrokerClient;
+	startBroker?: typeof startLspBroker;
+	prefsPath?: string;
+	install?: typeof installServer;
+	detect?: typeof detectWorkspaceServers;
+}
+
+const TOOL_DESCRIPTION = [
+	"Code intelligence through a language server.",
+	"definition: where a symbol is defined. references: every use of a symbol. hover: type signature and docs.",
+	"documentSymbol: the outline of one file. diagnostics: compiler and type errors for one file.",
+	`Supports ${supportedExtensions().join(", ")}, and needs that language's server on PATH (gopls, typescript-language-server, pyright, rust-analyzer).`,
+	"Prefer this over grep for anything about symbols — it resolves through imports and types instead of matching text.",
+	`References are capped at ${LSP_MAX_REFERENCES}. The first query in a workspace can take a while as the server indexes.`,
+].join(" ");
+
+const EXIT_SWEEP_KEY = Symbol.for("weave.pi.lsp.exitSweep");
+
+interface ExitSweepState {
+	sweep(): void;
+}
+
+/**
+ * pi loads extensions with moduleCache:false, so `/reload` re-executes this
+ * module. Without the symbol guard every reload would add another exit
+ * listener; the guard instead re-points the one listener at the newest pool.
+ */
+function installExitSweep(sweep: () => void): void {
+	const store = globalThis as unknown as Record<symbol, ExitSweepState | undefined>;
+	const existing = store[EXIT_SWEEP_KEY];
+	if (existing) {
+		existing.sweep = sweep;
+		return;
+	}
+	const state: ExitSweepState = { sweep };
+	store[EXIT_SWEEP_KEY] = state;
+	process.on("exit", () => state.sweep());
+}
+
+function toolResult(text: string, params: LspOperationParams) {
+	return {
+		content: [{ type: "text" as const, text }],
+		details: { operation: params.operation, path: params.path },
+	};
+}
+
+function renderLspCall(args: Partial<LspOperationParams>, theme: { fg(key: string, text: string): string; bold(text: string): string }): Text {
+	const position = typeof args.line === "number" ? `:${args.line}${typeof args.column === "number" ? `:${args.column}` : ""}` : "";
+	const target = `${args.path ?? ""}${position}`;
+	return new Text(
+		`${theme.fg("toolTitle", theme.bold("lsp "))}${theme.fg("accent", args.operation ?? "")}${target ? ` ${theme.fg("dim", target)}` : ""}`,
+		0,
+		0,
+	);
+}
+
+/**
+ * Registers the `lsp` tool for this process's role and, in the main process,
+ * returns the broker provider for index.ts to hand to dispatch. dispatch never
+ * imports this module — composition stays in index.ts.
+ */
+export function registerLsp(pi: ExtensionAPI, deps: LspToolDeps = {}): LspBrokerProvider | undefined {
+	if (isSubagent()) {
+		registerBrokerBackedTool(pi, deps);
+		return undefined;
+	}
+	return registerPoolBackedTool(pi, deps);
+}
+
+function registerBrokerBackedTool(pi: ExtensionAPI, deps: LspToolDeps): void {
+	const socketPath = process.env[LSP_BROKER_ENV];
+	const token = process.env[LSP_BROKER_TOKEN_ENV];
+	// A child spawned without a broker simply has no lsp tool, rather than one
+	// that always fails.
+	if (!deps.brokerClient && (!socketPath || !token)) return;
+
+	const client =
+		deps.brokerClient ??
+		new LspBrokerClient(socketPath as string, token as string, LSP_WARMUP_TIMEOUT_MS + LSP_REQUEST_TIMEOUT_MS);
+
+	pi.registerTool({
+		name: "lsp",
+		label: "LSP",
+		description: TOOL_DESCRIPTION,
+		parameters: LspParams,
+		executionMode: "parallel",
+
+		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+			assertOperationParams(params as LspOperationParams);
+			// The parent may be cold-starting a server on our behalf, so the child
+			// sends its own cwd and lets the parent resolve paths against it.
+			const text = await client.execute(
+				{ ...(params as LspOperationParams), path: normalizeToolPath(params.path, ctx.cwd) },
+				ctx.cwd,
+				signal,
+			);
+			return toolResult(text, params as LspOperationParams);
+		},
+
+		renderCall: renderLspCall,
+	});
+
+	pi.on("session_shutdown", () => client.close());
+}
+
+function registerPoolBackedTool(pi: ExtensionAPI, deps: LspToolDeps): LspBrokerProvider {
+	const pool =
+		deps.pool ??
+		new LspServerPool({
+			maxServers: LSP_MAX_SERVERS,
+			idleMs: LSP_IDLE_MS,
+			requestTimeoutMs: LSP_REQUEST_TIMEOUT_MS,
+			warmupTimeoutMs: LSP_WARMUP_TIMEOUT_MS,
+		});
+	const runDeps: LspRunDeps = { pool, which: deps.which };
+
+	pi.registerTool({
+		name: "lsp",
+		label: "LSP",
+		description: TOOL_DESCRIPTION,
+		parameters: LspParams,
+		executionMode: "parallel",
+
+		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+			const text = await runLspOperation(params as LspOperationParams, ctx.cwd, runDeps, signal);
+			return toolResult(text, params as LspOperationParams);
+		},
+
+		renderCall: renderLspCall,
+	});
+
+	registerLspEnable(pi, deps);
+
+	let broker: LspBrokerHandle | undefined;
+	let starting: Promise<LspBrokerHandle> | undefined;
+	const start = deps.startBroker ?? startLspBroker;
+
+	const provider: LspBrokerProvider = {
+		active: () => broker !== undefined,
+		async ensure(): Promise<Record<string, string>> {
+			if (!starting) {
+				starting = start((params, cwd, signal) => runLspOperation(params, cwd, runDeps, signal)).then((handle) => {
+					broker = handle;
+					return handle;
+				});
+				starting.catch(() => {
+					// A broker that will not listen must not wedge every later fan-out.
+					starting = undefined;
+				});
+			}
+			const handle = await starting;
+			return { [LSP_BROKER_ENV]: handle.socketPath, [LSP_BROKER_TOKEN_ENV]: handle.token };
+		},
+	};
+
+	pi.on("session_shutdown", async () => {
+		const handle = broker;
+		broker = undefined;
+		starting = undefined;
+		// Close the socket before the servers so no child request arrives at a
+		// pool that is already tearing down.
+		await handle?.close();
+		await pool.shutdownAll();
+	});
+
+	installExitSweep(() => {
+		pool.killAllSync();
+		broker?.removeSocket();
+	});
+	return provider;
+}
+
+const LspEnableParams = Type.Object({
+	language: StringEnum(LSP_SERVERS.map((spec) => spec.language) as ["go", "typescript", "python", "rust"], {
+		description: "Language whose server to install or dismiss.",
+	}),
+	action: Type.Optional(
+		StringEnum(["install", "dismiss"] as const, {
+			description: 'Default "install". "dismiss" records that the user does not want this language server offered again.',
+		}),
+	),
+});
+
+/**
+ * The consent-gated half of provisioning, registered in the main process only
+ * — subagents never get it, so a fan-out cannot trigger installs. A
+ * before_agent_start addendum tells the assistant which detected languages
+ * lack a server so it can offer once; this tool is how a user's "yes" (or
+ * "stop asking") takes effect.
+ */
+function registerLspEnable(pi: ExtensionAPI, deps: LspToolDeps): void {
+	const prefsPath = deps.prefsPath ?? getLspPrefsPath();
+	const install = deps.install ?? installServer;
+	const detect = deps.detect ?? detectWorkspaceServers;
+
+	// Lazily built once per session; undefined once resolved (installed,
+	// dismissed, or nothing to offer) so the addendum disappears from later turns.
+	let offer: string | undefined;
+	let offerComputed = false;
+	const resetOffer = (): void => {
+		offer = undefined;
+		offerComputed = false;
+	};
+	pi.on("session_start", resetOffer);
+
+	pi.on("before_agent_start", (event: { systemPrompt: string }, ctx: { cwd: string }) => {
+		if (!offerComputed) {
+			offerComputed = true;
+			const missing = detect(ctx.cwd).filter((spec) => !resolveBinary(spec, deps.which));
+			offer = buildLspOffer(missing, loadDismissedLanguages(prefsPath));
+		}
+		if (!offer) return undefined;
+		return { systemPrompt: `${event.systemPrompt}\n\n${offer}` };
+	});
+
+	pi.registerTool({
+		name: "lsp_enable",
+		label: "LSP enable",
+		description: [
+			"Install a language server so the lsp tool works for that language, or record the user's wish not to be offered it again.",
+			"Only call this after the user has explicitly agreed (install) or declined (dismiss) in conversation — never preemptively.",
+		].join(" "),
+		parameters: LspEnableParams,
+
+		async execute(_toolCallId, params, signal) {
+			const spec = specForLanguage(params.language);
+			if (!spec) throw new Error(`Unknown language "${params.language}".`);
+
+			if (params.action === "dismiss") {
+				const dismissed = loadDismissedLanguages(prefsPath);
+				dismissed.add(spec.language);
+				saveDismissedLanguages(prefsPath, dismissed);
+				offer = undefined;
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: `Noted — the ${spec.language} language server will not be offered again. The user can re-enable it any time by asking to enable ${spec.language} LSP support.`,
+						},
+					],
+					details: { language: spec.language, action: "dismiss" },
+				};
+			}
+
+			const result: InstallResult = await install(spec, { which: deps.which }, signal);
+			if (result.ok) {
+				offer = undefined;
+				// An earlier dismissal is void once the user asks for the install.
+				const dismissed = loadDismissedLanguages(prefsPath);
+				if (dismissed.delete(spec.language)) saveDismissedLanguages(prefsPath, dismissed);
+			}
+			return {
+				content: [{ type: "text" as const, text: result.text }],
+				details: { language: spec.language, action: "install", ok: result.ok },
+				isError: !result.ok,
+			};
+		},
+
+		renderCall(args, theme) {
+			return new Text(
+				`${theme.fg("toolTitle", theme.bold("lsp_enable "))}${theme.fg("accent", args.language ?? "")}${args.action === "dismiss" ? theme.fg("dim", " dismiss") : ""}`,
+				0,
+				0,
+			);
+		},
+	});
+}

--- a/install/pi-router/src/lsp.ts
+++ b/install/pi-router/src/lsp.ts
@@ -262,6 +262,16 @@ const TOOL_DESCRIPTION = [
 	`References are capped at ${LSP_MAX_REFERENCES}. The first query in a workspace can take a while as the server indexes.`,
 ].join(" ");
 
+const TOOL_PROMPT_SNIPPET = "Language-server code intelligence: definition, references, hover, documentSymbol, diagnostics (Go, TS/JS, Python, Rust)";
+
+// The description alone does not change tool choice: models reach for text
+// search on symbol questions by habit. These land in the system prompt's
+// Guidelines section, which is what actually steers the pick.
+const TOOL_PROMPT_GUIDELINES = [
+	"Use lsp instead of grep for symbol questions — where a symbol is defined or used, its type or signature, a file's structure, or compile errors. Text search matches strings; lsp resolves through imports and types.",
+	"To find every usage of a symbol: locate its declaration first (grep or lsp documentSymbol), then call lsp references at that exact line and column — a text match list is not a references answer.",
+];
+
 const EXIT_SWEEP_KEY = Symbol.for("weave.pi.lsp.exitSweep");
 
 interface ExitSweepState {
@@ -330,6 +340,8 @@ function registerBrokerBackedTool(pi: ExtensionAPI, deps: LspToolDeps): void {
 		name: "lsp",
 		label: "LSP",
 		description: TOOL_DESCRIPTION,
+		promptSnippet: TOOL_PROMPT_SNIPPET,
+		promptGuidelines: TOOL_PROMPT_GUIDELINES,
 		parameters: LspParams,
 		executionMode: "parallel",
 
@@ -366,6 +378,8 @@ function registerPoolBackedTool(pi: ExtensionAPI, deps: LspToolDeps): LspBrokerP
 		name: "lsp",
 		label: "LSP",
 		description: TOOL_DESCRIPTION,
+		promptSnippet: TOOL_PROMPT_SNIPPET,
+		promptGuidelines: TOOL_PROMPT_GUIDELINES,
 		parameters: LspParams,
 		executionMode: "parallel",
 

--- a/install/pi-router/src/lsp.ts
+++ b/install/pi-router/src/lsp.ts
@@ -125,6 +125,7 @@ async function queryClient(
 	cwd: string,
 	deps: LspRunDeps,
 	generation: number,
+	syncAction: "open" | "change" | "none",
 	signal?: AbortSignal,
 ): Promise<string> {
 	const uri = pathToUri(target);
@@ -168,9 +169,15 @@ async function queryClient(
 			return rendered || `No symbols found in ${shown}`;
 		}
 		case "diagnostics": {
+			// A no-op sync means the server already analyzed exactly this buffer, so
+			// whatever it last published for the file IS current — demanding a newer
+			// generation would burn the whole wait window and then mislabel a
+			// perfectly fresh result as stale. Only a real didOpen/didChange (which
+			// provokes a republish) requires a publish newer than the pre-sync mark.
+			const sinceGeneration = syncAction === "none" ? 0 : generation;
 			const { items, fresh } = await client.waitForDiagnostics(
 				uri,
-				generation,
+				sinceGeneration,
 				deps.diagnosticsWaitMs ?? LSP_DIAGNOSTICS_WAIT_MS,
 				signal,
 			);
@@ -218,8 +225,8 @@ export async function runLspOperation(
 			// Capture before syncing: an ensureDocument that provokes a publish must
 			// count as newer than what we already had cached.
 			const generation = client.diagnosticsGeneration();
-			await client.ensureDocument(pathToUri(target), readFile(target), languageIdFor(spec, target));
-			return await queryClient(client, params, target, cwd, deps, generation, signal);
+			const syncAction = await client.ensureDocument(pathToUri(target), readFile(target), languageIdFor(spec, target));
+			return await queryClient(client, params, target, cwd, deps, generation, syncAction, signal);
 		} catch (error) {
 			lastError = error as Error;
 			// Only a died-under-us server earns a second spawn. Retrying a timeout or

--- a/install/pi-router/test/e2e.sh
+++ b/install/pi-router/test/e2e.sh
@@ -133,9 +133,9 @@ phase "Phase 2 — generated pricing + savings contract"
 if with_timeout 30 env PI_CODING_AGENT_DIR="$PI_DIR" \
   pi -e "$UNIT_SUITE" --no-session --offline --model weave/claude-sonnet-4-6 \
   -p "Run the unit suite." >"$WORK/unit.out" 2>&1 </dev/null; then
-  [ "$(grep -Ec '^(✔ |ok [0-9]+ - )' "$WORK/unit.out" || true)" = "89" ] \
+  [ "$(grep -Ec '^(✔ |ok [0-9]+ - )' "$WORK/unit.out" || true)" = "92" ] \
     && ok "pricing, force-model, UI, compaction, served-window, and LSP unit suite passed" \
-    || bad "unit suite did not report all 89 passes (see $WORK/unit.out)"
+    || bad "unit suite did not report all 92 passes (see $WORK/unit.out)"
 else
   bad "unit suite failed to load through pi (see $WORK/unit.out)"
 fi

--- a/install/pi-router/test/e2e.sh
+++ b/install/pi-router/test/e2e.sh
@@ -133,9 +133,9 @@ phase "Phase 2 — generated pricing + savings contract"
 if with_timeout 30 env PI_CODING_AGENT_DIR="$PI_DIR" \
   pi -e "$UNIT_SUITE" --no-session --offline --model weave/claude-sonnet-4-6 \
   -p "Run the unit suite." >"$WORK/unit.out" 2>&1 </dev/null; then
-  [ "$(grep -Ec '^(✔ |ok [0-9]+ - )' "$WORK/unit.out" || true)" = "34" ] \
-    && ok "pricing, force-model, UI, compaction, and served-window unit suite passed" \
-    || bad "unit suite did not report all 34 passes (see $WORK/unit.out)"
+  [ "$(grep -Ec '^(✔ |ok [0-9]+ - )' "$WORK/unit.out" || true)" = "87" ] \
+    && ok "pricing, force-model, UI, compaction, served-window, and LSP unit suite passed" \
+    || bad "unit suite did not report all 87 passes (see $WORK/unit.out)"
 else
   bad "unit suite failed to load through pi (see $WORK/unit.out)"
 fi

--- a/install/pi-router/test/e2e.sh
+++ b/install/pi-router/test/e2e.sh
@@ -133,9 +133,9 @@ phase "Phase 2 — generated pricing + savings contract"
 if with_timeout 30 env PI_CODING_AGENT_DIR="$PI_DIR" \
   pi -e "$UNIT_SUITE" --no-session --offline --model weave/claude-sonnet-4-6 \
   -p "Run the unit suite." >"$WORK/unit.out" 2>&1 </dev/null; then
-  [ "$(grep -Ec '^(✔ |ok [0-9]+ - )' "$WORK/unit.out" || true)" = "87" ] \
+  [ "$(grep -Ec '^(✔ |ok [0-9]+ - )' "$WORK/unit.out" || true)" = "89" ] \
     && ok "pricing, force-model, UI, compaction, served-window, and LSP unit suite passed" \
-    || bad "unit suite did not report all 87 passes (see $WORK/unit.out)"
+    || bad "unit suite did not report all 89 passes (see $WORK/unit.out)"
 else
   bad "unit suite failed to load through pi (see $WORK/unit.out)"
 fi

--- a/install/pi-router/test/lsp.test.ts
+++ b/install/pi-router/test/lsp.test.ts
@@ -1,0 +1,880 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import test from "node:test";
+import { LspBrokerClient, startLspBroker } from "../src/lsp-broker.js";
+import { LspClient, planDocumentSync, type LspTransport, type TransportClose } from "../src/lsp-client.js";
+import {
+	createLineReader,
+	formatDiagnostics,
+	formatHover,
+	formatLocations,
+	formatSymbols,
+	normalizeLocations,
+} from "../src/lsp-format.js";
+import {
+	createFrameParser,
+	encodeFrame,
+	fromLspPosition,
+	pathToUri,
+	toLspPosition,
+	uriToPath,
+	type JsonRpcMessage,
+} from "../src/lsp-protocol.js";
+import {
+	findWorkspaceRoot,
+	LSP_SERVERS,
+	LspServerPool,
+	missingServerText,
+	resolveBinary,
+	specForFile,
+} from "../src/lsp-servers.js";
+import {
+	buildLspOffer,
+	detectWorkspaceServers,
+	installServer,
+	loadDismissedLanguages,
+	saveDismissedLanguages,
+} from "../src/lsp-install.js";
+import { assertOperationParams, normalizeToolPath, registerLsp, runLspOperation } from "../src/lsp.js";
+
+const CLIENT_OPTIONS = { requestTimeoutMs: 1000, warmupTimeoutMs: 1000 };
+const FAST_OPTIONS = { requestTimeoutMs: 20, warmupTimeoutMs: 20 };
+const GOPLS = LSP_SERVERS[0];
+const GOPLS_BINARY = { command: "/usr/bin/gopls", args: ["serve"] };
+
+// ---------- harnesses ----------
+
+interface FakeTransport {
+	transport: LspTransport;
+	sent: JsonRpcMessage[];
+	receive(message: JsonRpcMessage): void;
+	close(info: TransportClose): void;
+	onRequest(method: string, handler: (message: JsonRpcMessage) => void): void;
+	killed(): boolean;
+}
+
+/** Drives LspClient without a process: every frame it writes lands in `sent`. */
+function fakeTransport(options: { autoHandshake?: boolean } = {}): FakeTransport {
+	const sent: JsonRpcMessage[] = [];
+	const handlers = new Map<string, (message: JsonRpcMessage) => void>();
+	let messageHandler: (message: JsonRpcMessage) => void = () => undefined;
+	let closeHandler: (info: TransportClose) => void = () => undefined;
+	let killed = false;
+
+	const parser = createFrameParser((message) => {
+		sent.push(message);
+		if (options.autoHandshake && (message.method === "initialize" || message.method === "shutdown")) {
+			queueMicrotask(() => messageHandler({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } }));
+			return;
+		}
+		const handler = message.method ? handlers.get(message.method) : undefined;
+		if (handler) queueMicrotask(() => handler(message));
+	});
+
+	return {
+		transport: {
+			send: (data) => parser.push(data),
+			onMessage: (handler) => {
+				messageHandler = handler;
+			},
+			onClose: (handler) => {
+				closeHandler = handler;
+			},
+			kill: () => {
+				killed = true;
+			},
+			killNow: () => {
+				killed = true;
+			},
+		},
+		sent,
+		receive: (message) => messageHandler(message),
+		close: (info) => closeHandler(info),
+		onRequest: (method, handler) => handlers.set(method, handler),
+		killed: () => killed,
+	};
+}
+
+function tempDir(): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), "weave-lsp-test-"));
+}
+
+function goProject(): { dir: string; file: string } {
+	const dir = tempDir();
+	fs.writeFileSync(path.join(dir, "go.mod"), "module example.com/x\n");
+	const file = path.join(dir, "main.go");
+	fs.writeFileSync(file, "package main\n\nfunc Main() {}\n");
+	return { dir, file };
+}
+
+function poolThatMustNotSpawn(): LspServerPool {
+	return new LspServerPool(
+		{ maxServers: 1, idleMs: 60_000, ...CLIENT_OPTIONS },
+		{
+			createClient: () => {
+				throw new Error("the pool must not be touched for this input");
+			},
+		},
+	);
+}
+
+// ---------- lsp-protocol ----------
+
+test("the frame parser reassembles a message fed one byte at a time", () => {
+	const received: JsonRpcMessage[] = [];
+	const parser = createFrameParser((message) => received.push(message));
+	const frame = encodeFrame({ id: 7, method: "textDocument/hover" });
+	for (const byte of frame) parser.push(Buffer.from([byte]));
+	assert.deepEqual(received, [{ id: 7, method: "textDocument/hover" }]);
+});
+
+test("the frame parser splits several frames out of one chunk", () => {
+	const received: JsonRpcMessage[] = [];
+	const parser = createFrameParser((message) => received.push(message));
+	parser.push(Buffer.concat([encodeFrame({ id: 1 }), encodeFrame({ id: 2 }), encodeFrame({ id: 3 })]));
+	assert.deepEqual(
+		received.map((message) => message.id),
+		[1, 2, 3],
+	);
+});
+
+test("Content-Length counts UTF-8 bytes, not characters", () => {
+	const frame = encodeFrame({ text: "héllo — ünïcode ✓" });
+	const declared = Number(/Content-Length: (\d+)/.exec(frame.toString("ascii", 0, 60))?.[1]);
+	const bodyBytes = frame.length - frame.indexOf("\r\n\r\n") - 4;
+	assert.equal(declared, bodyBytes);
+	assert.notEqual(declared, JSON.stringify({ text: "héllo — ünïcode ✓" }).length);
+
+	const received: JsonRpcMessage[] = [];
+	createFrameParser((message) => received.push(message)).push(frame);
+	assert.deepEqual(received, [{ text: "héllo — ünïcode ✓" } as unknown as JsonRpcMessage]);
+});
+
+test("the frame parser tolerates extra headers and a malformed body without losing the stream", () => {
+	const received: JsonRpcMessage[] = [];
+	const parser = createFrameParser((message) => received.push(message));
+	const body = Buffer.from("not json", "utf8");
+	parser.push(
+		Buffer.concat([
+			Buffer.from(`Content-Length: ${body.length}\r\nContent-Type: application/vscode-jsonrpc\r\n\r\n`, "ascii"),
+			body,
+			encodeFrame({ id: 99 }),
+		]),
+	);
+	assert.deepEqual(received, [{ id: 99 }]);
+});
+
+test("the frame parser reports an overflowing peer instead of buffering forever", () => {
+	const errors: Error[] = [];
+	const received: JsonRpcMessage[] = [];
+	const parser = createFrameParser(
+		(message) => received.push(message),
+		(error) => errors.push(error),
+	);
+	// A header promising more than the cap, followed by a body that never ends.
+	parser.push(Buffer.from("Content-Length: 999999999\r\n\r\n", "ascii"));
+	parser.push(Buffer.alloc(17 * 1024 * 1024));
+	assert.equal(errors.length, 1);
+	assert.match(errors[0].message, /exceeded/);
+
+	// Once tripped it stays quiet so the owner can tear the peer down.
+	parser.push(encodeFrame({ id: 1 }));
+	assert.deepEqual(received, []);
+});
+
+test("file paths survive a URI round trip with spaces and non-ASCII", () => {
+	for (const original of ["/tmp/plain.go", "/tmp/with space/mod ule.go", "/tmp/ünïcode/日本語.ts"]) {
+		assert.equal(uriToPath(pathToUri(original)), original);
+	}
+	assert.match(pathToUri("/tmp/with space/a.go"), /%20/);
+});
+
+test("positions convert between 1-based tool arguments and 0-based LSP", () => {
+	assert.deepEqual(toLspPosition(41, 8), { line: 40, character: 7 });
+	assert.deepEqual(fromLspPosition({ line: 40, character: 7 }), { line: 41, column: 8 });
+	// Line 0 is not addressable in the 1-based model, and must not go negative.
+	assert.deepEqual(toLspPosition(0, 0), { line: 0, character: 0 });
+	assert.deepEqual(fromLspPosition(undefined), { line: 1, column: 1 });
+});
+
+// ---------- lsp-servers ----------
+
+test("specForFile maps extensions to servers and leaves unknown ones unmatched", () => {
+	assert.equal(specForFile("/a/main.go")?.id, "gopls");
+	assert.equal(specForFile("/a/App.tsx")?.id, "typescript");
+	assert.equal(specForFile("/a/mod.PY")?.id, "pyright");
+	assert.equal(specForFile("/a/lib.rs")?.id, "rust-analyzer");
+	assert.equal(specForFile("/a/notes.txt"), undefined);
+	assert.equal(specForFile("/a/Makefile"), undefined);
+});
+
+test("findWorkspaceRoot picks the nearest marker, not the outermost", () => {
+	const root = tempDir();
+	const inner = path.join(root, "services", "api");
+	fs.mkdirSync(inner, { recursive: true });
+	fs.mkdirSync(path.join(root, ".git"));
+	fs.writeFileSync(path.join(inner, "go.mod"), "module api\n");
+
+	assert.equal(findWorkspaceRoot(path.join(inner, "main.go"), GOPLS.rootMarkers, root), inner);
+	// A file above the nested module still belongs to the outer tree.
+	assert.equal(
+		findWorkspaceRoot(path.join(root, "tool.go"), ["go.mod", ".git"], root),
+		root,
+	);
+});
+
+test("findWorkspaceRoot falls back to the working directory when nothing marks a root", () => {
+	const root = tempDir();
+	assert.equal(findWorkspaceRoot(path.join(root, "stray.go"), ["go.mod"], "/fallback/cwd"), "/fallback/cwd");
+});
+
+test("resolveBinary takes the first candidate on PATH", () => {
+	const pyright = LSP_SERVERS.find((spec) => spec.id === "pyright");
+	assert.ok(pyright);
+	assert.deepEqual(resolveBinary(pyright, (command) => (command === "basedpyright-langserver" ? "/opt/bin/based" : undefined)), {
+		command: "/opt/bin/based",
+		args: ["--stdio"],
+	});
+	assert.deepEqual(resolveBinary(pyright, () => "/usr/bin/found"), { command: "/usr/bin/found", args: ["--stdio"] });
+	assert.equal(resolveBinary(pyright, () => undefined), undefined);
+});
+
+test("missingServerText names the binary and how to install it", () => {
+	const text = missingServerText(GOPLS);
+	assert.match(text, /gopls is not on PATH/);
+	assert.match(text, /go install golang\.org\/x\/tools\/gopls@latest/);
+});
+
+test("the pool reuses one server per root and language", async () => {
+	let spawns = 0;
+	const pool = new LspServerPool(
+		{ maxServers: 4, idleMs: 60_000, ...CLIENT_OPTIONS },
+		{
+			createClient: (_spec, _binary, root, options) => {
+				spawns += 1;
+				return new LspClient(root, fakeTransport({ autoHandshake: true }).transport, options);
+			},
+		},
+	);
+	const first = await pool.acquire(GOPLS, GOPLS_BINARY, "/repo");
+	const second = await pool.acquire(GOPLS, GOPLS_BINARY, "/repo");
+	assert.equal(first, second);
+	assert.equal(spawns, 1);
+
+	await pool.acquire(GOPLS, GOPLS_BINARY, "/other-repo");
+	assert.equal(spawns, 2);
+	assert.equal(pool.size, 2);
+});
+
+test("the pool evicts the least recently used server once over its cap", async () => {
+	let spawns = 0;
+	let clock = 0;
+	const pool = new LspServerPool(
+		{ maxServers: 2, idleMs: 60_000, ...CLIENT_OPTIONS },
+		{
+			now: () => (clock += 1000),
+			createClient: (_spec, _binary, root, options) => {
+				spawns += 1;
+				return new LspClient(root, fakeTransport({ autoHandshake: true }).transport, options);
+			},
+		},
+	);
+	await pool.acquire(GOPLS, GOPLS_BINARY, "/a");
+	await pool.acquire(GOPLS, GOPLS_BINARY, "/b");
+	await pool.acquire(GOPLS, GOPLS_BINARY, "/c");
+	assert.equal(pool.size, 2);
+	assert.equal(spawns, 3);
+
+	// /a was the oldest, so it went; asking for it again pays a fresh spawn.
+	await pool.acquire(GOPLS, GOPLS_BINARY, "/a");
+	assert.equal(spawns, 4);
+});
+
+test("the pool replaces a server that died rather than handing it out again", async () => {
+	let spawns = 0;
+	const transports: FakeTransport[] = [];
+	const pool = new LspServerPool(
+		{ maxServers: 4, idleMs: 60_000, ...CLIENT_OPTIONS },
+		{
+			createClient: (_spec, _binary, root, options) => {
+				spawns += 1;
+				const fake = fakeTransport({ autoHandshake: true });
+				transports.push(fake);
+				return new LspClient(root, fake.transport, options);
+			},
+		},
+	);
+	const first = await pool.acquire(GOPLS, GOPLS_BINARY, "/repo");
+	transports[0].close({ code: 1, stderr: "gopls: out of memory" });
+	assert.equal(first.dead, true);
+
+	const second = await pool.acquire(GOPLS, GOPLS_BINARY, "/repo");
+	assert.notEqual(first, second);
+	assert.equal(spawns, 2);
+});
+
+// ---------- lsp-client ----------
+
+test("planDocumentSync opens once, versions each change, and skips an unchanged buffer", () => {
+	assert.deepEqual(planDocumentSync(undefined, "a"), { action: "open", version: 1 });
+	assert.deepEqual(planDocumentSync({ version: 1, text: "a" }, "a"), { action: "none" });
+	assert.deepEqual(planDocumentSync({ version: 1, text: "a" }, "b"), { action: "change", version: 2 });
+	assert.deepEqual(planDocumentSync({ version: 7, text: "a" }, "b"), { action: "change", version: 8 });
+});
+
+test("the client syncs a document as didOpen then didChange, and stays quiet when it has not moved", async () => {
+	const fake = fakeTransport();
+	const client = new LspClient("/repo", fake.transport, CLIENT_OPTIONS);
+	const uri = "file:///repo/main.go";
+
+	await client.ensureDocument(uri, "one", "go");
+	await client.ensureDocument(uri, "one", "go");
+	await client.ensureDocument(uri, "two", "go");
+
+	const notifications = fake.sent.filter((message) => message.method?.startsWith("textDocument/did"));
+	assert.deepEqual(
+		notifications.map((message) => message.method),
+		["textDocument/didOpen", "textDocument/didChange"],
+	);
+	assert.equal((notifications[0].params as { textDocument: { version: number; languageId: string } }).textDocument.version, 1);
+	assert.equal((notifications[0].params as { textDocument: { languageId: string } }).textDocument.languageId, "go");
+	assert.equal((notifications[1].params as { textDocument: { version: number } }).textDocument.version, 2);
+});
+
+test("concurrent requests resolve against their own ids", async () => {
+	const fake = fakeTransport();
+	const client = new LspClient("/repo", fake.transport, CLIENT_OPTIONS);
+	const hover = client.request("textDocument/hover", {});
+	const definition = client.request("textDocument/definition", {});
+
+	const ids = fake.sent.map((message) => message.id as number);
+	assert.equal(new Set(ids).size, 2);
+	// Answer out of order: correlation must be by id, not arrival.
+	fake.receive({ id: ids[1], result: "definition-result" });
+	fake.receive({ id: ids[0], result: "hover-result" });
+
+	assert.equal(await hover, "hover-result");
+	assert.equal(await definition, "definition-result");
+});
+
+test("the client answers workspace/configuration with one null per item", () => {
+	const fake = fakeTransport();
+	// eslint-disable-next-line no-new
+	new LspClient("/repo", fake.transport, CLIENT_OPTIONS);
+	fake.receive({ id: 41, method: "workspace/configuration", params: { items: [{ section: "go" }, { section: "gopls" }] } });
+
+	const reply = fake.sent.find((message) => message.id === 41);
+	assert.deepEqual(reply?.result, [null, null]);
+});
+
+test("the client refuses an unknown server request instead of leaving it hanging", () => {
+	const fake = fakeTransport();
+	// eslint-disable-next-line no-new
+	new LspClient("/repo", fake.transport, CLIENT_OPTIONS);
+	fake.receive({ id: 55, method: "workspace/inventedRequest", params: {} });
+
+	const reply = fake.sent.find((message) => message.id === 55);
+	assert.equal(reply?.error?.code, -32601);
+	assert.match(reply?.error?.message ?? "", /workspace\/inventedRequest/);
+});
+
+test("a server that exits rejects everything in flight with its exit code and last stderr line", async () => {
+	const fake = fakeTransport();
+	const client = new LspClient("/repo", fake.transport, CLIENT_OPTIONS);
+	const pending = client.request("textDocument/hover", {});
+	fake.close({ code: 2, stderr: "loading packages\ngopls: fatal: cannot find module\n" });
+
+	await assert.rejects(() => pending, /code 2.*cannot find module/s);
+	assert.equal(client.dead, true);
+});
+
+test("a request that outlives its budget cancels upstream but leaves the server running", async () => {
+	const fake = fakeTransport();
+	const client = new LspClient("/repo", fake.transport, FAST_OPTIONS);
+	await assert.rejects(() => client.request("textDocument/references", {}), /still be indexing/);
+
+	assert.ok(fake.sent.some((message) => message.method === "$/cancelRequest"));
+	assert.equal(fake.killed(), false);
+	assert.equal(client.dead, false);
+});
+
+test("waitForDiagnostics resolves on a publish newer than the caller's generation", async () => {
+	const fake = fakeTransport();
+	const client = new LspClient("/repo", fake.transport, CLIENT_OPTIONS);
+	const uri = "file:///repo/app.py";
+	const generation = client.diagnosticsGeneration();
+	const pending = client.waitForDiagnostics(uri, generation, 1000);
+
+	fake.receive({
+		method: "textDocument/publishDiagnostics",
+		params: { uri, diagnostics: [{ range: { start: { line: 9, character: 4 }, end: { line: 9, character: 5 } }, severity: 1, message: "boom" }] },
+	});
+
+	const result = await pending;
+	assert.equal(result.fresh, true);
+	assert.equal(result.items.length, 1);
+});
+
+test("waitForDiagnostics gives up rather than blocking when the server stays silent", async () => {
+	const fake = fakeTransport();
+	const client = new LspClient("/repo", fake.transport, CLIENT_OPTIONS);
+	const result = await client.waitForDiagnostics("file:///repo/app.py", 0, 20);
+	assert.equal(result.fresh, false);
+	assert.deepEqual(result.items, []);
+});
+
+// ---------- lsp-format ----------
+
+test("normalizeLocations understands every shape a server may answer with", () => {
+	const range = { start: { line: 40, character: 7 }, end: { line: 40, character: 12 } };
+	assert.deepEqual(normalizeLocations(null), []);
+	assert.deepEqual(normalizeLocations({ uri: "file:///r/a.go", range }), [{ path: "/r/a.go", line: 41, column: 8 }]);
+	assert.deepEqual(normalizeLocations([{ uri: "file:///r/a.go", range }]), [{ path: "/r/a.go", line: 41, column: 8 }]);
+	// LocationLink must land on the name, not the whole declaration body.
+	assert.deepEqual(
+		normalizeLocations([
+			{
+				targetUri: "file:///r/b.go",
+				targetRange: { start: { line: 3, character: 0 }, end: { line: 20, character: 1 } },
+				targetSelectionRange: range,
+			},
+		]),
+		[{ path: "/r/b.go", line: 41, column: 8 }],
+	);
+});
+
+test("a capped references list says how many it is hiding", () => {
+	const locations = Array.from({ length: 247 }, (_unused, index) => ({ path: "/r/a.go", line: index + 1, column: 3 }));
+	const text = formatLocations(locations, { cwd: "/r", readLine: () => undefined, limit: 100, label: "references" });
+	const lines = text.split("\n");
+	assert.equal(lines[0], "247 references (showing first 100)");
+	assert.equal(lines.length, 101);
+	assert.equal(lines[1], "a.go:1:3:");
+});
+
+test("locations render grep-style with the source line, relative when inside the working directory", () => {
+	const readLine = createLineReader(() => "func Main() {\n\treturn\n}");
+	const text = formatLocations([{ path: "/r/pkg/a.go", line: 1, column: 6 }], { cwd: "/r", readLine, limit: 10 });
+	assert.equal(text, "pkg/a.go:1:6: func Main() {");
+	// Outside the working directory the absolute path is kept.
+	const outside = formatLocations([{ path: "/elsewhere/b.go", line: 1, column: 1 }], { cwd: "/r", readLine: () => undefined, limit: 10 });
+	assert.equal(outside, "/elsewhere/b.go:1:1:");
+});
+
+test("hover renders markup, a language-tagged string, and an array of both", () => {
+	assert.equal(formatHover({ contents: { kind: "markdown", value: "**Main** does a thing" } }), "**Main** does a thing");
+	assert.equal(formatHover({ contents: { language: "go", value: "func Main()" } }), "```go\nfunc Main()\n```");
+	assert.equal(formatHover({ contents: ["plain text", { language: "go", value: "func Main()" }] }), "plain text\n\n```go\nfunc Main()\n```");
+	assert.equal(formatHover(null), "");
+});
+
+test("symbols render as a tree when hierarchical and flat when the server sends SymbolInformation", () => {
+	const range = { start: { line: 4, character: 0 }, end: { line: 9, character: 1 } };
+	const tree = formatSymbols(
+		[{ name: "Server", kind: 23, range, selectionRange: range, children: [{ name: "Start", kind: 6, detail: "func()", range, selectionRange: range }] }],
+		"/r",
+	);
+	assert.equal(tree, "Struct Server :5\n  Method Start func() :5");
+
+	const flat = formatSymbols(
+		[{ name: "Start", kind: 12, containerName: "Server", location: { uri: "file:///r/a.go", range } }],
+		"/r",
+	);
+	assert.equal(flat, "Function Start (in Server) a.go:5");
+});
+
+test("diagnostics lead with a severity summary and tag their source", () => {
+	const at = (line: number) => ({ start: { line, character: 4 }, end: { line, character: 9 } });
+	const text = formatDiagnostics(
+		[
+			{ range: at(9), severity: 1, source: "pyright", message: '"x" is not defined' },
+			{ range: at(20), severity: 2, source: "pyright", message: "unused import\n  os" },
+		],
+		"/r/app.py",
+		"/r",
+	);
+	assert.equal(
+		text,
+		['1 error, 1 warning', 'error app.py:10:5: "x" is not defined [pyright]', "warning app.py:21:5: unused import os [pyright]"].join("\n"),
+	);
+	assert.equal(formatDiagnostics([], "/r/app.py", "/r"), "");
+});
+
+// ---------- lsp tool core ----------
+
+test("position operations refuse to run without line and column, and name what is missing", () => {
+	assert.throws(() => assertOperationParams({ operation: "definition", path: "a.go" }), /`line` and `column`/);
+	assert.throws(() => assertOperationParams({ operation: "hover", path: "a.go", line: 4 }), /`column`/);
+	// File-scoped operations need neither.
+	assert.doesNotThrow(() => assertOperationParams({ operation: "documentSymbol", path: "a.go" }));
+	assert.doesNotThrow(() => assertOperationParams({ operation: "diagnostics", path: "a.go" }));
+	assert.throws(() => assertOperationParams({ operation: "rename" as never, path: "a.go" }), /Unknown lsp operation/);
+});
+
+test("tool paths tolerate the @ prefix models emit and resolve against the working directory", () => {
+	assert.equal(normalizeToolPath("@src/foo.go", "/repo"), "/repo/src/foo.go");
+	assert.equal(normalizeToolPath("  src/foo.go  ", "/repo"), "/repo/src/foo.go");
+	assert.equal(normalizeToolPath("/abs/foo.go", "/repo"), "/abs/foo.go");
+});
+
+test("an uninstalled language server is reported as text with an install hint, not an error", async () => {
+	const { dir, file } = goProject();
+	const text = await runLspOperation({ operation: "documentSymbol", path: file }, dir, {
+		pool: poolThatMustNotSpawn(),
+		which: () => undefined,
+	});
+	assert.match(text, /gopls is not on PATH/);
+	assert.match(text, /go install golang\.org\/x\/tools\/gopls@latest/);
+});
+
+test("an unsupported file type lists what is supported instead of failing", async () => {
+	const dir = tempDir();
+	const file = path.join(dir, "notes.txt");
+	fs.writeFileSync(file, "hello\n");
+	const text = await runLspOperation({ operation: "documentSymbol", path: file }, dir, { pool: poolThatMustNotSpawn() });
+	assert.match(text, /No language server is configured for \.txt/);
+	assert.match(text, /\.go/);
+});
+
+test("a path that does not exist throws so the model corrects it", async () => {
+	const dir = tempDir();
+	await assert.rejects(
+		() => runLspOperation({ operation: "documentSymbol", path: path.join(dir, "absent.go") }, dir, { pool: poolThatMustNotSpawn() }),
+		/File not found/,
+	);
+});
+
+test("a server that dies mid-request is respawned exactly once", async () => {
+	const { dir, file } = goProject();
+	let spawns = 0;
+	const pool = new LspServerPool(
+		{ maxServers: 4, idleMs: 60_000, ...CLIENT_OPTIONS },
+		{
+			createClient: (_spec, _binary, root, options) => {
+				spawns += 1;
+				const attempt = spawns;
+				const fake = fakeTransport({ autoHandshake: true });
+				fake.onRequest("textDocument/documentSymbol", (message) => {
+					if (attempt === 1) {
+						fake.close({ code: 2, stderr: "gopls: fatal" });
+						return;
+					}
+					const range = { start: { line: 2, character: 5 }, end: { line: 2, character: 9 } };
+					fake.receive({ id: message.id, result: [{ name: "Main", kind: 12, range, selectionRange: range }] });
+				});
+				return new LspClient(root, fake.transport, options);
+			},
+		},
+	);
+
+	const text = await runLspOperation({ operation: "documentSymbol", path: file }, dir, { pool, which: () => "/usr/bin/gopls" });
+	assert.equal(spawns, 2);
+	assert.equal(text, "Function Main :3");
+});
+
+test("a request that fails without killing the server is not retried", async () => {
+	const { dir, file } = goProject();
+	let spawns = 0;
+	const pool = new LspServerPool(
+		{ maxServers: 4, idleMs: 60_000, ...CLIENT_OPTIONS },
+		{
+			createClient: (_spec, _binary, root, options) => {
+				spawns += 1;
+				const fake = fakeTransport({ autoHandshake: true });
+				fake.onRequest("textDocument/documentSymbol", (message) => {
+					fake.receive({ id: message.id, error: { code: -32603, message: "internal server error" } });
+				});
+				return new LspClient(root, fake.transport, options);
+			},
+		},
+	);
+
+	await assert.rejects(
+		() => runLspOperation({ operation: "documentSymbol", path: file }, dir, { pool, which: () => "/usr/bin/gopls" }),
+		/internal server error/,
+	);
+	assert.equal(spawns, 1);
+});
+
+test("a definition query opens the document and reports the resolved site", async () => {
+	const { dir, file } = goProject();
+	const target = path.join(dir, "other.go");
+	fs.writeFileSync(target, "package main\n\nfunc Helper() {}\n");
+	let opened: string | undefined;
+
+	const pool = new LspServerPool(
+		{ maxServers: 4, idleMs: 60_000, ...CLIENT_OPTIONS },
+		{
+			createClient: (_spec, _binary, root, options) => {
+				const fake = fakeTransport({ autoHandshake: true });
+				fake.onRequest("textDocument/didOpen", (message) => {
+					opened = (message.params as { textDocument: { uri: string } }).textDocument.uri;
+				});
+				fake.onRequest("textDocument/definition", (message) => {
+					fake.receive({
+						id: message.id,
+						result: { uri: pathToUri(target), range: { start: { line: 2, character: 5 }, end: { line: 2, character: 11 } } },
+					});
+				});
+				return new LspClient(root, fake.transport, options);
+			},
+		},
+	);
+
+	const text = await runLspOperation({ operation: "definition", path: file, line: 3, column: 6 }, dir, {
+		pool,
+		which: () => "/usr/bin/gopls",
+	});
+	assert.equal(opened, pathToUri(file));
+	assert.equal(text, "other.go:3:6: func Helper() {}");
+});
+
+test("a definition with no result is reported as text at the queried position", async () => {
+	const { dir, file } = goProject();
+	const pool = new LspServerPool(
+		{ maxServers: 4, idleMs: 60_000, ...CLIENT_OPTIONS },
+		{
+			createClient: (_spec, _binary, root, options) => {
+				const fake = fakeTransport({ autoHandshake: true });
+				fake.onRequest("textDocument/definition", (message) => fake.receive({ id: message.id, result: null }));
+				return new LspClient(root, fake.transport, options);
+			},
+		},
+	);
+	const text = await runLspOperation({ operation: "definition", path: file, line: 3, column: 6 }, dir, {
+		pool,
+		which: () => "/usr/bin/gopls",
+	});
+	assert.equal(text, "No definition found at main.go:3:6");
+});
+
+// ---------- lsp-install ----------
+
+const TS_SPEC = LSP_SERVERS.find((spec) => spec.id === "typescript")!;
+const RUST_SPEC = LSP_SERVERS.find((spec) => spec.id === "rust-analyzer")!;
+
+/** Minimal fake ChildProcess for installServer: emits output then closes. */
+function fakeInstallProcess(code: number | null, output: string) {
+	const handlers = new Map<string, (arg: unknown) => void>();
+	const stream = { on: (_event: string, handler: (chunk: Buffer) => void) => queueMicrotask(() => output && handler(Buffer.from(output))) };
+	queueMicrotask(() => queueMicrotask(() => handlers.get("close")?.(code)));
+	return {
+		stdout: stream,
+		stderr: { on: () => undefined },
+		on: (event: string, handler: (arg: unknown) => void) => handlers.set(event, handler),
+		kill: () => true,
+	};
+}
+
+test("workspace detection reads positive markers at the root and one level down", () => {
+	const dir = tempDir();
+	fs.writeFileSync(path.join(dir, "go.mod"), "module x\n");
+	fs.mkdirSync(path.join(dir, "web"));
+	fs.writeFileSync(path.join(dir, "web", "tsconfig.json"), "{}");
+	assert.deepEqual(
+		detectWorkspaceServers(dir).map((spec) => spec.id),
+		["gopls", "typescript"],
+	);
+});
+
+test("workspace detection ignores dot dirs and vendored trees, and .git is never a language signal", () => {
+	const dir = tempDir();
+	fs.mkdirSync(path.join(dir, ".git"));
+	fs.mkdirSync(path.join(dir, "node_modules", "dep"), { recursive: true });
+	fs.writeFileSync(path.join(dir, "node_modules", "dep", "Cargo.toml"), "");
+	assert.deepEqual(detectWorkspaceServers(dir), []);
+});
+
+test("dismissals round-trip through the prefs file and tolerate a corrupt one", () => {
+	const prefsPath = path.join(tempDir(), ".weave_lsp.json");
+	assert.deepEqual([...loadDismissedLanguages(prefsPath)], []);
+	saveDismissedLanguages(prefsPath, new Set(["go", "rust"]));
+	assert.deepEqual([...loadDismissedLanguages(prefsPath)].sort(), ["go", "rust"]);
+	fs.writeFileSync(prefsPath, "not json{");
+	assert.deepEqual([...loadDismissedLanguages(prefsPath)], []);
+});
+
+test("the offer names missing languages, instructs consent-gated lsp_enable, and honors dismissals", () => {
+	const offer = buildLspOffer([GOPLS, TS_SPEC], new Set());
+	assert.ok(offer);
+	assert.match(offer, /go, typescript/);
+	assert.match(offer, /lsp_enable/);
+	assert.match(offer, /explicit go-ahead/);
+
+	const partial = buildLspOffer([GOPLS, TS_SPEC], new Set(["go"]));
+	assert.ok(partial);
+	assert.doesNotMatch(partial, /go,/);
+	assert.equal(buildLspOffer([GOPLS], new Set(["go"])), undefined);
+	assert.equal(buildLspOffer([], new Set()), undefined);
+});
+
+test("installServer refuses without the language toolchain, naming it", async () => {
+	const result = await installServer(RUST_SPEC, { which: () => undefined });
+	assert.equal(result.ok, false);
+	assert.match(result.text, /rustup/);
+	assert.match(result.text, /rustup component add rust-analyzer/);
+});
+
+test("installServer runs the registry argv and reports success once the binary resolves", async () => {
+	let spawned: { command: string; args: string[] } | undefined;
+	let installed = false;
+	const result = await installServer(RUST_SPEC, {
+		which: (command) => {
+			if (command === "rustup") return "/usr/bin/rustup";
+			return installed && command === "rust-analyzer" ? "/usr/bin/rust-analyzer" : undefined;
+		},
+		spawnFn: (command, args) => {
+			spawned = { command, args };
+			installed = true;
+			return fakeInstallProcess(0, "info: installing component") as never;
+		},
+	});
+	assert.deepEqual(spawned, { command: "rustup", args: ["component", "add", "rust-analyzer"] });
+	assert.equal(result.ok, true);
+	assert.match(result.text, /lsp tool now works for rust/);
+});
+
+test("a failed install surfaces the exit code and last output line", async () => {
+	const result = await installServer(RUST_SPEC, {
+		which: (command) => (command === "rustup" ? "/usr/bin/rustup" : undefined),
+		spawnFn: () => fakeInstallProcess(1, "error: no such component\n") as never,
+	});
+	assert.equal(result.ok, false);
+	assert.match(result.text, /exit 1/);
+	assert.match(result.text, /no such component/);
+});
+
+interface FakeTool {
+	execute(toolCallId: string, params: unknown, signal?: AbortSignal): Promise<{ content: Array<{ text: string }>; isError?: boolean }>;
+}
+
+/** Registers the real main-process tools against a fake pi; returns them by name. */
+function lspToolHarness(deps: Parameters<typeof registerLsp>[1]) {
+	const tools = new Map<string, FakeTool>();
+	const handlers = new Map<string, Array<(event: unknown, ctx: unknown) => unknown>>();
+	const pi = {
+		registerTool: (tool: { name: string }) => tools.set(tool.name, tool as unknown as FakeTool),
+		on: (event: string, handler: (event: unknown, ctx: unknown) => unknown) => {
+			handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+		},
+	} as never;
+	registerLsp(pi, deps);
+	return {
+		tool: (name: string) => tools.get(name),
+		emit: (event: string, payload: unknown, ctx: unknown) => (handlers.get(event) ?? []).map((handler) => handler(payload, ctx)),
+	};
+}
+
+test("lsp_enable dismiss persists the opt-out and the offer stops being injected", async () => {
+	const dir = tempDir();
+	fs.writeFileSync(path.join(dir, "go.mod"), "module x\n");
+	const prefsPath = path.join(dir, ".weave_lsp.json");
+	const harness = lspToolHarness({
+		prefsPath,
+		which: () => undefined,
+		detect: () => [GOPLS],
+		startBroker: (() => Promise.reject(new Error("not under test"))) as never,
+	});
+
+	const [before] = harness.emit("before_agent_start", { systemPrompt: "base" }, { cwd: dir }) as Array<{ systemPrompt: string } | undefined>;
+	assert.match(before?.systemPrompt ?? "", /Code intelligence \(LSP\)/);
+
+	const result = await harness.tool("lsp_enable")!.execute("t1", { language: "go", action: "dismiss" });
+	assert.match(result.content[0].text, /will not be offered again/);
+	assert.deepEqual([...loadDismissedLanguages(prefsPath)], ["go"]);
+
+	const [after] = harness.emit("before_agent_start", { systemPrompt: "base" }, { cwd: dir }) as Array<{ systemPrompt: string } | undefined>;
+	assert.equal(after, undefined);
+
+	// A fresh session re-detects but still respects the persisted dismissal.
+	harness.emit("session_start", {}, { cwd: dir });
+	const [nextSession] = harness.emit("before_agent_start", { systemPrompt: "base" }, { cwd: dir }) as Array<{ systemPrompt: string } | undefined>;
+	assert.equal(nextSession, undefined);
+});
+
+test("lsp_enable install runs the injected installer and a user-requested install clears an old dismissal", async () => {
+	const dir = tempDir();
+	const prefsPath = path.join(dir, ".weave_lsp.json");
+	saveDismissedLanguages(prefsPath, new Set(["go"]));
+	const installedFor: string[] = [];
+	const harness = lspToolHarness({
+		prefsPath,
+		which: () => undefined,
+		detect: () => [],
+		install: async (spec) => {
+			installedFor.push(spec.language);
+			return { ok: true, text: "Installed the go language server" };
+		},
+		startBroker: (() => Promise.reject(new Error("not under test"))) as never,
+	});
+
+	const result = await harness.tool("lsp_enable")!.execute("t1", { language: "go" });
+	assert.ok(!result.isError);
+	assert.deepEqual(installedFor, ["go"]);
+	assert.deepEqual([...loadDismissedLanguages(prefsPath)], []);
+});
+
+// ---------- lsp-broker (real sockets) ----------
+
+test("a child reaches the parent's runner over the broker socket", async () => {
+	const handle = await startLspBroker(async (params, cwd) => `${params.operation} ${params.path} @ ${cwd}`);
+	const client = new LspBrokerClient(handle.socketPath, handle.token, 5000);
+	try {
+		const text = await client.execute({ operation: "hover", path: "/repo/a.go", line: 2, column: 3 }, "/child/cwd");
+		assert.equal(text, "hover /repo/a.go @ /child/cwd");
+	} finally {
+		client.close();
+		await handle.close();
+	}
+});
+
+test("the broker hangs up on a connection that does not present the token", async () => {
+	const handle = await startLspBroker(async () => "must not be served");
+	const client = new LspBrokerClient(handle.socketPath, "0".repeat(handle.token.length), 2000);
+	try {
+		await assert.rejects(
+			() => client.execute({ operation: "hover", path: "/repo/a.go", line: 1, column: 1 }, "/child"),
+			/connection lost/,
+		);
+	} finally {
+		client.close();
+		await handle.close();
+	}
+});
+
+test("a failure inside the parent's runner re-throws in the child", async () => {
+	const handle = await startLspBroker(async () => {
+		throw new Error("language server exited (code 2): gopls: fatal");
+	});
+	const client = new LspBrokerClient(handle.socketPath, handle.token, 5000);
+	try {
+		await assert.rejects(
+			() => client.execute({ operation: "references", path: "/repo/a.go", line: 1, column: 1 }, "/child"),
+			/gopls: fatal/,
+		);
+	} finally {
+		client.close();
+		await handle.close();
+	}
+});
+
+test("a broker that goes away rejects the child's in-flight request rather than hanging", async () => {
+	const handle = await startLspBroker(() => new Promise<string>(() => undefined));
+	const client = new LspBrokerClient(handle.socketPath, handle.token, 5000);
+	const pending = client.execute({ operation: "hover", path: "/repo/a.go", line: 1, column: 1 }, "/child");
+	// Let the hello and the request land before the parent disappears.
+	await new Promise((resolve) => setTimeout(resolve, 50));
+	await handle.close();
+
+	await assert.rejects(() => pending, /LSP broker connection lost/);
+	client.close();
+});
+
+test("the broker socket is removed when it closes", async () => {
+	const handle = await startLspBroker(async () => "ok");
+	if (process.platform !== "win32") assert.equal(fs.existsSync(handle.socketPath), true);
+	await handle.close();
+	assert.equal(fs.existsSync(handle.socketPath), false);
+});

--- a/install/pi-router/test/lsp.test.ts
+++ b/install/pi-router/test/lsp.test.ts
@@ -329,9 +329,9 @@ test("the client syncs a document as didOpen then didChange, and stays quiet whe
 	const client = new LspClient("/repo", fake.transport, CLIENT_OPTIONS);
 	const uri = "file:///repo/main.go";
 
-	await client.ensureDocument(uri, "one", "go");
-	await client.ensureDocument(uri, "one", "go");
-	await client.ensureDocument(uri, "two", "go");
+	assert.equal(await client.ensureDocument(uri, "one", "go"), "open");
+	assert.equal(await client.ensureDocument(uri, "one", "go"), "none");
+	assert.equal(await client.ensureDocument(uri, "two", "go"), "change");
 
 	const notifications = fake.sent.filter((message) => message.method?.startsWith("textDocument/did"));
 	assert.deepEqual(
@@ -648,6 +648,56 @@ test("a definition with no result is reported as text at the queried position", 
 		which: () => "/usr/bin/gopls",
 	});
 	assert.equal(text, "No definition found at main.go:3:6");
+});
+
+test("repeat diagnostics on an unchanged file returns the cached publish as fresh, without waiting", async () => {
+	const { dir, file } = goProject();
+	const pool = new LspServerPool(
+		{ maxServers: 4, idleMs: 60_000, ...CLIENT_OPTIONS },
+		{
+			createClient: (_spec, _binary, root, options) => {
+				const fake = fakeTransport({ autoHandshake: true });
+				fake.onRequest("textDocument/didOpen", (message) => {
+					const uri = (message.params as { textDocument: { uri: string } }).textDocument.uri;
+					fake.receive({
+						method: "textDocument/publishDiagnostics",
+						params: { uri, diagnostics: [{ range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } }, severity: 2, message: "unused" }] },
+					});
+				});
+				return new LspClient(root, fake.transport, options);
+			},
+		},
+	);
+	const deps = { pool, which: () => "/usr/bin/gopls", diagnosticsWaitMs: 60_000 };
+
+	const first = await runLspOperation({ operation: "diagnostics", path: file }, dir, deps);
+	assert.match(first, /unused/);
+	// The 60s wait budget makes the assertion sharp: a second call that demanded
+	// a newer publish would hang here instead of returning the current cache.
+	const second = await runLspOperation({ operation: "diagnostics", path: file }, dir, deps);
+	assert.match(second, /unused/);
+	assert.doesNotMatch(second, /may be stale/);
+});
+
+test("fallback bin dirs honor GOBIN, the first GOPATH element, and CARGO_HOME", () => {
+	const seen: string[] = [];
+	const which = (command: string) => {
+		seen.push(command);
+		return undefined;
+	};
+
+	resolveBinary(GOPLS, which, { GOBIN: "/custom/gobin", GOPATH: `/work/gopath${path.delimiter}/second/gopath` });
+	assert.ok(seen.includes(path.join("/custom/gobin", "gopls")));
+	assert.ok(seen.includes(path.join("/work/gopath", "bin", "gopls")));
+	assert.ok(!seen.some((candidate) => candidate.includes(path.join("second", "gopath"))));
+
+	seen.length = 0;
+	resolveBinary(GOPLS, which, {});
+	assert.ok(seen.some((candidate) => candidate.endsWith(path.join("go", "bin", "gopls"))));
+
+	seen.length = 0;
+	resolveBinary(RUST_SPEC, which, { CARGO_HOME: "/opt/cargo" });
+	assert.ok(seen.includes(path.join("/opt/cargo", "bin", "rust-analyzer")));
 });
 
 // ---------- lsp-install ----------

--- a/install/pi-router/test/lsp.test.ts
+++ b/install/pi-router/test/lsp.test.ts
@@ -292,6 +292,72 @@ test("the pool evicts the least recently used server once over its cap", async (
 	assert.equal(spawns, 4);
 });
 
+test("entries still initializing are exempt from LRU eviction, so concurrent cold acquires all complete", async () => {
+	const fakes: FakeTransport[] = [];
+	const initIds: Array<{ fake: FakeTransport; id: number }> = [];
+	const pool = new LspServerPool(
+		{ maxServers: 1, idleMs: 60_000, ...CLIENT_OPTIONS },
+		{
+			createClient: (_spec, _binary, root, options) => {
+				const fake = fakeTransport();
+				fakes.push(fake);
+				fake.onRequest("initialize", (message) => initIds.push({ fake, id: message.id as number }));
+				fake.onRequest("shutdown", (message) => fake.receive({ id: message.id as number, result: null }));
+				return new LspClient(root, fake.transport, options);
+			},
+		},
+	);
+
+	// Two cold acquires over a cap of 1 — both handshakes still pending.
+	const first = pool.acquire(GOPLS, GOPLS_BINARY, "/a");
+	const second = pool.acquire(GOPLS, GOPLS_BINARY, "/b");
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.equal(fakes.length, 2);
+	assert.deepEqual(
+		fakes.map((fake) => fake.killed()),
+		[false, false],
+	);
+
+	for (const { fake, id } of initIds) fake.receive({ id, result: { capabilities: {} } });
+	const [clientA, clientB] = await Promise.all([first, second]);
+	assert.equal(clientA.dead, false);
+	assert.equal(clientB.dead, false);
+
+	// With both settled, the next acquire enforces the cap again.
+	const third = pool.acquire(GOPLS, GOPLS_BINARY, "/c");
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.equal(fakes.slice(0, 2).some((fake) => fake.killed()), true);
+	for (const { fake, id } of initIds.slice(2)) fake.receive({ id, result: { capabilities: {} } });
+	await third;
+});
+
+test("the idle timer defers disposal while a request is in flight", async () => {
+	const fakes: FakeTransport[] = [];
+	const pool = new LspServerPool(
+		{ maxServers: 4, idleMs: 40, ...CLIENT_OPTIONS },
+		{
+			createClient: (_spec, _binary, root, options) => {
+				const fake = fakeTransport({ autoHandshake: true });
+				fakes.push(fake);
+				return new LspClient(root, fake.transport, options);
+			},
+		},
+	);
+	const client = await pool.acquire(GOPLS, GOPLS_BINARY, "/repo");
+	const pending = client.request("textDocument/references", {});
+
+	// Two idle windows pass with the request still outstanding — no disposal.
+	await new Promise((resolve) => setTimeout(resolve, 100));
+	assert.equal(fakes[0].killed(), false);
+
+	const id = fakes[0].sent.find((message) => message.method === "textDocument/references")?.id as number;
+	fakes[0].receive({ id, result: [] });
+	await pending;
+	// Once idle for real, the next window reclaims it.
+	await new Promise((resolve) => setTimeout(resolve, 100));
+	assert.equal(fakes[0].killed(), true);
+});
+
 test("the pool replaces a server that died rather than handing it out again", async () => {
 	let spawns = 0;
 	const transports: FakeTransport[] = [];
@@ -784,6 +850,37 @@ test("installServer runs the registry argv and reports success once the binary r
 	assert.deepEqual(spawned, { command: "rustup", args: ["component", "add", "rust-analyzer"] });
 	assert.equal(result.ok, true);
 	assert.match(result.text, /lsp tool now works for rust/);
+});
+
+test("a cancelled install settles only after the child exits, escalating SIGTERM to SIGKILL", async () => {
+	const signals: string[] = [];
+	const handlers = new Map<string, (arg: unknown) => void>();
+	// A child that ignores SIGTERM and dies only on SIGKILL.
+	const stubbornChild = {
+		stdout: { on: () => undefined },
+		stderr: { on: () => undefined },
+		on: (event: string, handler: (arg: unknown) => void) => handlers.set(event, handler),
+		kill: (signal: string) => {
+			signals.push(signal);
+			if (signal === "SIGKILL") queueMicrotask(() => handlers.get("close")?.(null));
+			return true;
+		},
+	};
+
+	const started = Date.now();
+	const result = await installServer(RUST_SPEC, {
+		which: (command) => (command === "rustup" ? "/usr/bin/rustup" : undefined),
+		spawnFn: () => stubbornChild as never,
+		timeoutMs: 30,
+		killGraceMs: 40,
+	});
+
+	// Settled via close after the SIGKILL escalation — not at SIGTERM time.
+	assert.deepEqual(signals, ["SIGTERM", "SIGKILL"]);
+	assert.ok(Date.now() - started >= 60, "must wait out timeout + kill grace before settling");
+	assert.equal(result.ok, false);
+	assert.match(result.text, /timed out/);
+	assert.match(result.text, /stopped/);
 });
 
 test("a failed install surfaces the exit code and last output line", async () => {

--- a/install/pi-router/test/unit-suite.ts
+++ b/install/pi-router/test/unit-suite.ts
@@ -6,6 +6,7 @@ import "./force-model.test.js";
 import "./ui.test.js";
 import "./compaction.test.js";
 import "./routed-model.test.js";
+import "./lsp.test.js";
 
 // Pi 0.74 also requires an extension-shaped default export before evaluating
 // the module. Test registration itself happens through the side-effect imports.


### PR DESCRIPTION
## What

Adds an LSP subsystem to the pi extension: one `lsp` tool exposing **definition / references / hover / documentSymbol / diagnostics**, backed by lazily spawned language servers keyed by workspace root + language — gopls, typescript-language-server, pyright/basedpyright, and rust-analyzer. Composite code-intelligence calls replace multi-turn read/grep loops, which pays twice: fewer round trips, and slower context growth before compaction.

## How it works

- **Server pool (main process only):** servers spawn on first query for their language, idle out after `WEAVE_PI_LSP_IDLE_MS`, and are LRU-evicted past `WEAVE_PI_LSP_MAX_SERVERS`. Documents sync via versioned didOpen/didChange behind a per-client mutex; server-initiated requests are always answered so a server can never hang the session.
- **Subagent broker:** `dispatch` children get the same `lsp` tool but forward queries to the parent's warm pool over a token-authenticated local socket (Unix socket in a 0700 tmpdir; named pipe on Windows) — N children share one warm gopls instead of cold-starting N. Children are only handed the tool when a broker is actually listening.
- **Opt-in installs, three consent-gated rungs — nothing installs silently:**
  1. `npx @workweave/router --pi --lsp go,typescript` installs servers at install time (missing toolchains warn and skip, never fail the install).
  2. When the workspace contains a language whose server is missing, the assistant offers once in conversation; a yes runs the install through the main-process-only `lsp_enable` tool, and a "don't ask again" persists per language in `<agentDir>/.weave_lsp.json`.
  3. A bundled `install-lsps` skill covers toolchain prerequisites (Go, Node/npm, rustup), each install individually confirmed.
- **Failure philosophy:** environmental dead ends (unsupported file type, server not installed) return actionable text so the model falls back to grep instead of retry-looping; genuine misuse (missing line/column, nonexistent file) throws so the model self-corrects.
- Everything disables with `WEAVE_PI_NO_LSP=1`. Zero new npm dependencies; the new `src/` files and skill ride the existing prepack copy + `pi.extensions`/`pi.skills` fields.

## Testing

- 53 new `node:test` cases in the existing pi-loaded unit suite (87 total, all passing through pi's own TypeScript loader): frame parser byte-splitting/overflow, URI/position round trips, workspace-root resolution against real temp trees, fake-transport client tests (document sync versions, request correlation, server-request answers, crash/timeout behavior), formatter shapes, pool reuse/LRU/poison recovery, crash-retry-once, real-socket broker round trips (auth reject, error propagation, drop handling), workspace detection, dismissal persistence, and consent-gated install paths.
- `bash -n install.sh` clean; the prepack script verified to bundle the skill.

🤖 Generated with [Weave Router](https://router.workweave.ai)
