### PR TITLE
fix(proxy): route OpenAI Responses tool turns natively

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -5138,7 +5138,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	responsesBody, _ := ctx.Value(codexResponsesBodyContextKey{}).([]byte)
 	responsesBodyCandidate, _ := ctx.Value(openAIResponsesBodyCandidateContextKey{}).([]byte)
 	responsesPassthrough := len(responsesBody) > 0
-	nativeResponsesBodyAvailable := responsesPassthrough || len(responsesBodyCandidate) > 0
+	nativeResponsesBodyAvailable := responsesPassthrough
 	reasoningConfigurationHash := env.ReasoningConfigurationSHA256()
 	if nativeResponsesHash, ok := ctx.Value(nativeResponsesReasoningHashContextKey{}).(string); ok {
 		reasoningConfigurationHash = nativeResponsesHash
@@ -5159,11 +5159,12 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// compaction below, or runTurnLoop's switch handover); see toolResultBytesPtr.
 	inboundLastUser := env.LastUserMessage()
 
-	// Proactive context-window compaction, as in ProxyMessages. Skip it when
-	// the original Responses body must be preserved because compaction rewrites
-	// the chat envelope without updating that native body.
+	// Proactive context-window compaction, as in ProxyMessages. Native Codex
+	// bodies must skip it because compaction rewrites the chat envelope without
+	// updating that native body; portable candidates are compacted after routing
+	// if the selected provider does not use native Responses.
 	var compResOAI compactionResult
-	if !nativeResponsesBodyAvailable {
+	if !responsesPassthrough && len(responsesBodyCandidate) == 0 {
 		maxEligibleWindowOAI := s.maxEligibleContextWindow(baseExcludedOAI, enabledProviders, env.SignatureTokenSavings())
 		var compErrOAI error
 		compResOAI, compErrOAI = s.maybeCompact(ctx, env, turntype.DetectFromEnvelope(env, feats, subAgentHint), outputReserveOAI, maxEligibleWindowOAI, r.Header)
@@ -5249,9 +5250,44 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	pinAgeSec := routeRes.PinAgeSec
 	s.logPlannerOutcome(ctx, routeRes)
 
+	useNativeResponses := func(d router.Decision) bool {
+		if d.Provider != providers.ProviderOpenAI {
+			return false
+		}
+		if responsesPassthrough {
+			return true
+		}
+		return len(responsesBodyCandidate) > 0 && translate.UseOpenAIResponsesAPI(
+			d.Provider, router.Lookup(d.Model), feats.HasTools)
+	}
+
+	// Portable Responses requests can still use proactive compaction. Defer it
+	// until after routing so native OpenAI reasoning requests retain their exact
+	// input body while other providers receive the compacted chat envelope.
+	if len(responsesBodyCandidate) > 0 && !useNativeResponses(decision) {
+		maxEligibleWindowOAI := s.maxEligibleContextWindow(baseExcludedOAI, enabledProviders, env.SignatureTokenSavings())
+		var compErrOAI error
+		compResOAI, compErrOAI = s.maybeCompact(ctx, env, tt, outputReserveOAI, maxEligibleWindowOAI, r.Header)
+		if compErrOAI != nil {
+			log.Warn("Compaction could not fit request to any eligible model",
+				"err", compErrOAI, "final_estimate", compResOAI.FinalEstimate, "max_window", maxEligibleWindowOAI, "requested_model", feats.Model)
+			return compErrOAI
+		}
+		if compResOAI.Applied {
+			feats = env.RoutingFeatures(embedFlag)
+			log.Info("Proactive compaction applied",
+				"tool_results_cleared", compResOAI.ToolResultsCleared,
+				"summarized", compResOAI.Summarized,
+				"summary_model", compResOAI.SummaryModel,
+				"trimmed_to_recent", compResOAI.TrimmedToRecent,
+				"final_estimate", compResOAI.FinalEstimate,
+			)
+		}
+	}
+
 	// See the ProxyMessages cache-eligibility note: subsidized requests bypass the
 	// semantic cache (the key doesn't capture headroom-dependent model choice).
-	cacheEligible := s.semanticCacheAllowed(ctx) && s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !nativeResponsesBodyAvailable && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0
+	cacheEligible := s.semanticCacheAllowed(ctx) && s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !nativeResponsesBodyAvailable && !useNativeResponses(decision) && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0
 	if cacheEligible {
 		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatOpenAI, decision.Metadata.Embedding, decision.Metadata.ClusterIDs, decision.Metadata.ClusterRouterVersion, decision.Metadata.EffectiveKnobsHash); hit {
 			s.writeCachedResponse(w, resp, decision)
@@ -5348,17 +5384,6 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// so single-binding upstream errors don't strand the routing-marker chunk
 	// on the wire when the upstream never produces a first byte.
 	bindings := s.resolveBindingsForDispatch(ctx, decision)
-
-	useNativeResponses := func(d router.Decision) bool {
-		if d.Provider != providers.ProviderOpenAI {
-			return false
-		}
-		if responsesPassthrough {
-			return true
-		}
-		return len(responsesBodyCandidate) > 0 && translate.UseOpenAIResponsesAPI(
-			d.Provider, router.Lookup(d.Model), feats.HasTools)
-	}
 
 	// Subscription-only mode: the turn must serve on the caller's own
 	// subscription (Codex/Claude OAuth). If routing didn't resolve to a
@@ -5850,8 +5875,8 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 	}
 	chatBody, model := conversion.Body, conversion.Model
 	codexNativeRequest := codexResponsesRequest(ctx, r.Header)
-	// Retain original body for function-tool turns so OpenAI reasoning models
-	// get native Responses dispatch instead of the incompatible Chat Completions surface.
+	// Keep original body for tool turns so native Responses dispatch can be used
+	// when OpenAI reasoning models are selected.
 	if conversion.Requirements.FunctionTools {
 		candidateBody := conversion.OriginalBody
 		if clientAppCodex {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -5171,9 +5171,8 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		}
 		if compResOAI.Applied {
 			if len(responsesBodyCandidate) > 0 {
-				// The compacted chat envelope is authoritative when overflow required
-				// compaction before routing; the original Responses body is no longer
-				// safe to dispatch natively because it still contains the full history.
+				// Compaction rewrote the chat envelope; the original Responses body
+				// still has the full history and must not be dispatched natively.
 				responsesBodyCandidate = nil
 			}
 			feats = env.RoutingFeatures(embedFlag)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -370,9 +370,8 @@ type OpenAIAccountIDContextKey struct{}
 // Responses body to the Codex backend (its presence marks the passthrough).
 type codexResponsesBodyContextKey struct{}
 
-// openAIResponsesBodyCandidateContextKey carries the Responses body for
-// function-tool turns; OpenAI reasoning gets native dispatch, others get
-// the translated chat form.
+// openAIResponsesBodyCandidateContextKey carries the original Responses body
+// for function-tool turns so OpenAI reasoning models get native dispatch.
 type openAIResponsesBodyCandidateContextKey struct{}
 
 // nativeResponsesReasoningHashContextKey preserves reasoning that only native

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -5853,7 +5853,14 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 	// Retain original body for function-tool turns so OpenAI reasoning models
 	// get native Responses dispatch instead of the incompatible Chat Completions surface.
 	if conversion.Requirements.FunctionTools {
-		ctx = context.WithValue(ctx, openAIResponsesBodyCandidateContextKey{}, conversion.OriginalBody)
+		candidateBody := conversion.OriginalBody
+		if clientAppCodex {
+			candidateBody, err = translate.StripRoutingBadgeFromResponsesInput(candidateBody)
+			if err != nil {
+				return fmt.Errorf("strip candidate Responses routing badge: %w", err)
+			}
+		}
+		ctx = context.WithValue(ctx, openAIResponsesBodyCandidateContextKey{}, candidateBody)
 	}
 	// Keep original bytes only when the request is unrepresentable as Chat
 	// Completions (NativeOnly) or a Codex subscription is using its direct endpoint.

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -370,6 +370,11 @@ type OpenAIAccountIDContextKey struct{}
 // Responses body to the Codex backend (its presence marks the passthrough).
 type codexResponsesBodyContextKey struct{}
 
+// openAIResponsesBodyCandidateContextKey carries the original Responses body
+// when function tools make native dispatch preferable for a direct OpenAI
+// reasoning model, while keeping the request portable for other providers.
+type openAIResponsesBodyCandidateContextKey struct{}
+
 // nativeResponsesReasoningHashContextKey preserves reasoning that only native
 // Responses dispatch can represent.
 type nativeResponsesReasoningHashContextKey struct{}
@@ -5131,6 +5136,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// Subscriptions are credentials scoped to the routed model, not a pinned
 	// provider.
 	responsesBody, _ := ctx.Value(codexResponsesBodyContextKey{}).([]byte)
+	responsesBodyCandidate, _ := ctx.Value(openAIResponsesBodyCandidateContextKey{}).([]byte)
 	responsesPassthrough := len(responsesBody) > 0
 	reasoningConfigurationHash := env.ReasoningConfigurationSHA256()
 	if nativeResponsesHash, ok := ctx.Value(nativeResponsesReasoningHashContextKey{}).(string); ok {
@@ -5341,6 +5347,17 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// on the wire when the upstream never produces a first byte.
 	bindings := s.resolveBindingsForDispatch(ctx, decision)
 
+	useNativeResponses := func(d router.Decision) bool {
+		if d.Provider != providers.ProviderOpenAI {
+			return false
+		}
+		if responsesPassthrough {
+			return true
+		}
+		return len(responsesBodyCandidate) > 0 && translate.UseOpenAIResponsesAPI(
+			d.Provider, router.Lookup(d.Model), feats.HasTools)
+	}
+
 	// Subscription-only mode: the turn must serve on the caller's own
 	// subscription (Codex/Claude OAuth). If routing didn't resolve to a
 	// subscription-served credential, refuse (402) rather than dispatch to a
@@ -5377,7 +5394,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	// Inject verbose routing marker when policy debug is enabled; gated on
 	// verbatimPassthrough (verbatim OpenAI frames can't have chunks injected).
-	verbatimPassthrough := responsesPassthrough && decision.Provider == providers.ProviderOpenAI
+	verbatimPassthrough := useNativeResponses(decision)
 	debugEnabled, _ := ctx.Value(PolicyDebugEnabledContextKey{}).(bool)
 	if rw, ok := w.(*translate.ResponsesWriter); ok && marker != "" && !verbatimPassthrough && (debugEnabled || billing.SubscriptionOnlyFromContext(ctx)) {
 		rw.SetBadgeText(marker)
@@ -5466,15 +5483,27 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		// OpenRouter-only body fields that Fireworks/Bedrock/Makora/Together
 		// should not see. On failover to OpenRouter the body must be re-emitted.
 		attempt = func(actx context.Context, d router.Decision, p providers.Client) error {
+			useNative := useNativeResponses(d)
+			if rw, ok := w.(*translate.ResponsesWriter); ok {
+				if useNative {
+					rw.SetPassthrough()
+				} else {
+					rw.SetTranslated()
+				}
+			}
 			var prep providers.PreparedRequest
-			if responsesPassthrough && d.Provider == providers.ProviderOpenAI {
+			if useNative {
 				// Dispatch the caller's ORIGINAL Responses body (untranslated) to
 				// the OpenAI Responses endpoint, rewriting only the model. This keeps
 				// native Responses extensions lossless.
-				outBody, setErr := sjson.SetBytes(responsesBody, "model", d.Model)
+				nativeBody := responsesBody
+				if len(nativeBody) == 0 {
+					nativeBody = responsesBodyCandidate
+				}
+				outBody, setErr := sjson.SetBytes(nativeBody, "model", d.Model)
 				if setErr != nil {
-					log.Error("Failed to set routed model on Codex Responses body", "err", setErr, "decision_model", d.Model)
-					return fmt.Errorf("set codex model: %w", setErr)
+					log.Error("Failed to set routed model on OpenAI Responses body", "err", setErr, "decision_model", d.Model)
+					return fmt.Errorf("set OpenAI Responses model: %w", setErr)
 				}
 				prep = providers.PreparedRequest{
 					Body:     outBody,
@@ -5506,13 +5535,10 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			err := p.Proxy(actx, d, prep, proxyWriter, r)
 			// Post-commit: bytes already on the wire, render as an in-stream
 			// frame instead of a corrupting envelope (pre-commit goes through
-			// dispatchWithFallback). Gate on THIS attempt being the verbatim
-			// Codex backend, not responsesPassthrough alone: a native request can
-			// still route to Claude/OSS through the translating ResponsesWriter,
-			// which needs its own error frame — only the verbatim Codex attempt
-			// already delivered the upstream's own Responses error event.
-			verbatimCodex := responsesPassthrough && d.Provider == providers.ProviderOpenAI
-			if err != nil && !verbatimCodex && env.Stream() && preludeBuf.Committed() {
+			// dispatchWithFallback). Native Responses attempts already deliver
+			// the upstream's own Responses error event; translated attempts need
+			// an OpenAI-shaped error frame for the outer Responses writer.
+			if err != nil && !useNative && env.Stream() && preludeBuf.Committed() {
 				err = emitOpenAISSEErrorEvent(sink, err)
 			}
 			return err
@@ -5817,6 +5843,12 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 	}
 	chatBody, model := conversion.Body, conversion.Model
 	codexNativeRequest := codexResponsesRequest(ctx, r.Header)
+	// Function-tool requests remain portable for routing, but retain their
+	// original Responses body so direct OpenAI reasoning models can avoid the
+	// incompatible Chat Completions surface.
+	if conversion.Requirements.FunctionTools {
+		ctx = context.WithValue(ctx, openAIResponsesBodyCandidateContextKey{}, conversion.OriginalBody)
+	}
 	// Keep original bytes only when the request is unrepresentable as Chat
 	// Completions (NativeOnly) or a Codex subscription is using its direct endpoint.
 	if conversion.Requirements.NativeOnly || codexNativeRequest {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -5158,11 +5158,10 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// compaction below, or runTurnLoop's switch handover); see toolResultBytesPtr.
 	inboundLastUser := env.LastUserMessage()
 
-	// Proactive context-window compaction, as in ProxyMessages. Skipped for
-	// native bodies (would update the wrong copy) and portable candidates (deferred).
+	maxEligibleWindowOAI := s.maxEligibleContextWindow(baseExcludedOAI, enabledProviders, env.SignatureTokenSavings())
+	needsPreRouteCompaction := !responsesPassthrough && (len(responsesBodyCandidate) == 0 || env.ContextOverflowTokenEstimate()+outputReserveOAI > maxEligibleWindowOAI)
 	var compResOAI compactionResult
-	if !responsesPassthrough && len(responsesBodyCandidate) == 0 {
-		maxEligibleWindowOAI := s.maxEligibleContextWindow(baseExcludedOAI, enabledProviders, env.SignatureTokenSavings())
+	if needsPreRouteCompaction {
 		var compErrOAI error
 		compResOAI, compErrOAI = s.maybeCompact(ctx, env, turntype.DetectFromEnvelope(env, feats, subAgentHint), outputReserveOAI, maxEligibleWindowOAI, r.Header)
 		if compErrOAI != nil {
@@ -5171,6 +5170,12 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			return compErrOAI
 		}
 		if compResOAI.Applied {
+			if len(responsesBodyCandidate) > 0 {
+				// The compacted chat envelope is authoritative when overflow required
+				// compaction before routing; the original Responses body is no longer
+				// safe to dispatch natively because it still contains the full history.
+				responsesBodyCandidate = nil
+			}
 			feats = env.RoutingFeatures(embedFlag)
 			log.Info("Proactive compaction applied",
 				"tool_results_cleared", compResOAI.ToolResultsCleared,
@@ -5261,7 +5266,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// Portable Responses requests defer proactive compaction until after routing;
 	// native OpenAI reasoning keeps the original input, others get compacted chat.
 	if len(responsesBodyCandidate) > 0 && !useNativeResponses(decision) {
-		maxEligibleWindowOAI := s.maxEligibleContextWindow(baseExcludedOAI, enabledProviders, env.SignatureTokenSavings())
+		maxEligibleWindowOAI = s.maxEligibleContextWindow(baseExcludedOAI, enabledProviders, env.SignatureTokenSavings())
 		var compErrOAI error
 		compResOAI, compErrOAI = s.maybeCompact(ctx, env, tt, outputReserveOAI, maxEligibleWindowOAI, r.Header)
 		if compErrOAI != nil {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -5159,10 +5159,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// compaction below, or runTurnLoop's switch handover); see toolResultBytesPtr.
 	inboundLastUser := env.LastUserMessage()
 
-	// Proactive context-window compaction, as in ProxyMessages. Native Codex
-	// bodies must skip it because compaction rewrites the chat envelope without
-	// updating that native body; portable candidates are compacted after routing
-	// if the selected provider does not use native Responses.
+	// Proactive context-window compaction, as in ProxyMessages. Skipped for
+	// native bodies (compaction rewrites the envelope without updating the native
+	// copy); portable candidates defer until after routing.
 	var compResOAI compactionResult
 	if !responsesPassthrough && len(responsesBodyCandidate) == 0 {
 		maxEligibleWindowOAI := s.maxEligibleContextWindow(baseExcludedOAI, enabledProviders, env.SignatureTokenSavings())
@@ -5261,9 +5260,8 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			d.Provider, router.Lookup(d.Model), feats.HasTools)
 	}
 
-	// Portable Responses requests can still use proactive compaction. Defer it
-	// until after routing so native OpenAI reasoning requests retain their exact
-	// input body while other providers receive the compacted chat envelope.
+	// Portable Responses requests defer proactive compaction until after routing;
+	// native OpenAI reasoning keeps the original input, others get compacted chat.
 	if len(responsesBodyCandidate) > 0 && !useNativeResponses(decision) {
 		maxEligibleWindowOAI := s.maxEligibleContextWindow(baseExcludedOAI, enabledProviders, env.SignatureTokenSavings())
 		var compErrOAI error

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -5171,9 +5171,11 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		}
 		if compResOAI.Applied {
 			if len(responsesBodyCandidate) > 0 {
-				// Compaction rewrote the chat envelope; the original Responses body
-				// still has the full history and must not be dispatched natively.
-				responsesBodyCandidate = nil
+				responsesBodyCandidate, compErrOAI = translate.RebuildOpenAIResponsesBody(responsesBodyCandidate, env.OpenAIChatBody())
+				if compErrOAI != nil {
+					log.Error("Failed to rebuild compacted OpenAI Responses body", "err", compErrOAI)
+					return fmt.Errorf("rebuild compacted Responses body: %w", compErrOAI)
+				}
 			}
 			feats = env.RoutingFeatures(embedFlag)
 			log.Info("Proactive compaction applied",

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -370,9 +370,9 @@ type OpenAIAccountIDContextKey struct{}
 // Responses body to the Codex backend (its presence marks the passthrough).
 type codexResponsesBodyContextKey struct{}
 
-// openAIResponsesBodyCandidateContextKey carries the original Responses body
-// when function tools make native dispatch preferable for a direct OpenAI
-// reasoning model, while keeping the request portable for other providers.
+// openAIResponsesBodyCandidateContextKey carries the Responses body for
+// function-tool turns; OpenAI reasoning gets native dispatch, others get
+// the translated chat form.
 type openAIResponsesBodyCandidateContextKey struct{}
 
 // nativeResponsesReasoningHashContextKey preserves reasoning that only native
@@ -5567,9 +5567,8 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			err := p.Proxy(actx, d, prep, proxyWriter, r)
 			// Post-commit: bytes already on the wire, render as an in-stream
 			// frame instead of a corrupting envelope (pre-commit goes through
-			// dispatchWithFallback). Native Responses attempts already deliver
-			// the upstream's own Responses error event; translated attempts need
-			// an OpenAI-shaped error frame for the outer Responses writer.
+			// dispatchWithFallback). Native Responses dispatch delivers the
+			// upstream's own error event; translated dispatch needs an injected one.
 			if err != nil && !useNative && env.Stream() && preludeBuf.Committed() {
 				err = emitOpenAISSEErrorEvent(sink, err)
 			}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -5159,8 +5159,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	inboundLastUser := env.LastUserMessage()
 
 	// Proactive context-window compaction, as in ProxyMessages. Skipped for
-	// native bodies (compaction rewrites the envelope without updating the native
-	// copy); portable candidates defer until after routing.
+	// native bodies (would update the wrong copy) and portable candidates (deferred).
 	var compResOAI compactionResult
 	if !responsesPassthrough && len(responsesBodyCandidate) == 0 {
 		maxEligibleWindowOAI := s.maxEligibleContextWindow(baseExcludedOAI, enabledProviders, env.SignatureTokenSavings())

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -5138,6 +5138,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	responsesBody, _ := ctx.Value(codexResponsesBodyContextKey{}).([]byte)
 	responsesBodyCandidate, _ := ctx.Value(openAIResponsesBodyCandidateContextKey{}).([]byte)
 	responsesPassthrough := len(responsesBody) > 0
+	nativeResponsesBodyAvailable := responsesPassthrough || len(responsesBodyCandidate) > 0
 	reasoningConfigurationHash := env.ReasoningConfigurationSHA256()
 	if nativeResponsesHash, ok := ctx.Value(nativeResponsesReasoningHashContextKey{}).(string); ok {
 		reasoningConfigurationHash = nativeResponsesHash
@@ -5158,10 +5159,11 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// compaction below, or runTurnLoop's switch handover); see toolResultBytesPtr.
 	inboundLastUser := env.LastUserMessage()
 
-	// Proactive context-window compaction, as in ProxyMessages. Skipped for
-	// Codex passthrough bodies, which are forwarded verbatim.
+	// Proactive context-window compaction, as in ProxyMessages. Skip it when
+	// the original Responses body must be preserved because compaction rewrites
+	// the chat envelope without updating that native body.
 	var compResOAI compactionResult
-	if !responsesPassthrough {
+	if !nativeResponsesBodyAvailable {
 		maxEligibleWindowOAI := s.maxEligibleContextWindow(baseExcludedOAI, enabledProviders, env.SignatureTokenSavings())
 		var compErrOAI error
 		compResOAI, compErrOAI = s.maybeCompact(ctx, env, turntype.DetectFromEnvelope(env, feats, subAgentHint), outputReserveOAI, maxEligibleWindowOAI, r.Header)
@@ -5249,7 +5251,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	// See the ProxyMessages cache-eligibility note: subsidized requests bypass the
 	// semantic cache (the key doesn't capture headroom-dependent model choice).
-	cacheEligible := s.semanticCacheAllowed(ctx) && s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !responsesPassthrough && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0
+	cacheEligible := s.semanticCacheAllowed(ctx) && s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !nativeResponsesBodyAvailable && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0
 	if cacheEligible {
 		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatOpenAI, decision.Metadata.Embedding, decision.Metadata.ClusterIDs, decision.Metadata.ClusterRouterVersion, decision.Metadata.EffectiveKnobsHash); hit {
 			s.writeCachedResponse(w, resp, decision)
@@ -5499,6 +5501,11 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 				nativeBody := responsesBody
 				if len(nativeBody) == 0 {
 					nativeBody = responsesBodyCandidate
+				}
+				nativeBody, affinityErr := translate.ApplyOpenAIResponsesSessionAffinity(nativeBody, opts.SessionAffinity)
+				if affinityErr != nil {
+					log.Error("Failed to set OpenAI Responses prompt cache key", "err", affinityErr, "decision_model", d.Model)
+					return fmt.Errorf("set OpenAI Responses prompt cache key: %w", affinityErr)
 				}
 				outBody, setErr := sjson.SetBytes(nativeBody, "model", d.Model)
 				if setErr != nil {
@@ -5843,9 +5850,8 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 	}
 	chatBody, model := conversion.Body, conversion.Model
 	codexNativeRequest := codexResponsesRequest(ctx, r.Header)
-	// Function-tool requests remain portable for routing, but retain their
-	// original Responses body so direct OpenAI reasoning models can avoid the
-	// incompatible Chat Completions surface.
+	// Retain original body for function-tool turns so OpenAI reasoning models
+	// get native Responses dispatch instead of the incompatible Chat Completions surface.
 	if conversion.Requirements.FunctionTools {
 		ctx = context.WithValue(ctx, openAIResponsesBodyCandidateContextKey{}, conversion.OriginalBody)
 	}

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -282,6 +282,53 @@ func TestService_AgentShadowEvaluationNeverRetriesSubscriptionOnDeploymentKey(t 
 	assert.True(t, provider.proxyCreds[0].OAuth, "the single attempt must use the supplied subscription")
 }
 
+func TestService_ProxyOpenAIResponses_FunctionToolsUseNativeEndpointForReasoningOpenAI(t *testing.T) {
+	provider := &fakeProvider{proxyResponse: func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp_1","object":"response","output":[]}`)
+	}}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-5.6-luna", Reason: "test"}}
+	svc := proxy.NewService(fr, map[string]providers.Client{
+		providers.ProviderOpenAI: provider,
+	}, nil, false, nil, nil, false, providers.ProviderOpenAI, "gpt-5.6-luna", nil)
+
+	body := []byte(`{"model":"auto","input":[{"type":"message","role":"user","content":"call the tool"}],"tools":[{"type":"function","name":"lookup","description":"Look something up","parameters":{"type":"object","properties":{}}}],"tool_choice":"auto"}`)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(""))
+
+	require.NoError(t, svc.ProxyOpenAIResponses(context.Background(), body, rec, req))
+	require.Len(t, provider.proxyBodies, 1)
+	assert.Equal(t, providers.EndpointResponses, provider.proxyEndpoints[0])
+	assert.Equal(t, "gpt-5.6-luna", gjson.GetBytes(provider.proxyBodies[0], "model").Str)
+	assert.True(t, gjson.GetBytes(provider.proxyBodies[0], "input").Exists())
+	assert.True(t, gjson.GetBytes(provider.proxyBodies[0], "tools").Exists())
+	assert.Equal(t, "auto", gjson.GetBytes(provider.proxyBodies[0], "tool_choice").Str)
+	assert.False(t, gjson.GetBytes(provider.proxyBodies[0], "messages").Exists())
+	assert.JSONEq(t, `{"id":"resp_1","object":"response","output":[]}`, rec.Body.String())
+}
+
+func TestService_ProxyOpenAIResponses_FunctionToolsStayPortableForOtherProviders(t *testing.T) {
+	provider := &fakeProvider{proxyResponse: func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"id":"chatcmpl_1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`)
+	}}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderFireworks, Model: "gpt-5.6-luna", Reason: "test"}}
+	svc := proxy.NewService(fr, map[string]providers.Client{
+		providers.ProviderFireworks: provider,
+	}, nil, false, nil, nil, false, providers.ProviderFireworks, "gpt-5.6-luna", nil)
+
+	body := []byte(`{"model":"auto","input":[{"type":"message","role":"user","content":"call the tool"}],"tools":[{"type":"function","name":"lookup","parameters":{"type":"object","properties":{}}}]}`)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(""))
+
+	require.NoError(t, svc.ProxyOpenAIResponses(context.Background(), body, rec, req))
+	require.Len(t, provider.proxyBodies, 1)
+	assert.Equal(t, providers.EndpointChatCompletions, provider.proxyEndpoints[0])
+	assert.True(t, gjson.GetBytes(provider.proxyBodies[0], "messages").Exists())
+	assert.False(t, gjson.GetBytes(provider.proxyBodies[0], "input").Exists())
+}
+
 func TestService_ProxyOpenAIResponses_CustomToolUsesNativeOpenAIFamily(t *testing.T) {
 	provider := &fakeProvider{proxyResponse: func(w http.ResponseWriter) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -308,6 +308,30 @@ func TestService_ProxyOpenAIResponses_FunctionToolsUseNativeEndpointForReasoning
 	assert.JSONEq(t, `{"id":"resp_1","object":"response","output":[]}`, rec.Body.String())
 }
 
+func TestService_ProxyOpenAIResponses_CodexCandidateStripsBadgeWithoutSubscription(t *testing.T) {
+	provider := &fakeProvider{proxyResponse: func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp_1","object":"response","output":[]}`)
+	}}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-5.6-luna", Reason: "test"}}
+	svc := proxy.NewService(fr, map[string]providers.Client{
+		providers.ProviderOpenAI: provider,
+	}, nil, false, nil, nil, false, providers.ProviderOpenAI, "gpt-5.6-luna", nil)
+
+	ctx := context.WithValue(context.Background(), proxy.ClientIdentityContextKey{}, proxy.ClientIdentity{ClientApp: proxy.ClientAppCodex})
+	body := []byte(`{"model":"auto","input":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"BADGE_PLACEHOLDERold answer"}]},{"type":"message","role":"user","content":"call the tool"}],"tools":[{"type":"function","name":"lookup","parameters":{"type":"object","properties":{}}}]}`)
+	const badge = "⁣⁠⁣⁠**Weave Router** — gpt-5.6-sol\\n\\n"
+	body = []byte(strings.Replace(string(body), "BADGE_PLACEHOLDER", badge, 1))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(""))
+
+	require.NoError(t, svc.ProxyOpenAIResponses(ctx, body, rec, req))
+	require.Len(t, provider.proxyBodies, 1)
+	assert.Equal(t, providers.EndpointResponses, provider.proxyEndpoints[0])
+	assert.Equal(t, "old answer", gjson.GetBytes(provider.proxyBodies[0], "input.0.content.0.text").Str)
+	assert.NotContains(t, string(provider.proxyBodies[0]), badge)
+}
+
 func TestService_ProxyOpenAIResponses_FunctionToolsStayPortableForOtherProviders(t *testing.T) {
 	provider := &fakeProvider{proxyResponse: func(w http.ResponseWriter) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -303,6 +303,7 @@ func TestService_ProxyOpenAIResponses_FunctionToolsUseNativeEndpointForReasoning
 	assert.True(t, gjson.GetBytes(provider.proxyBodies[0], "input").Exists())
 	assert.True(t, gjson.GetBytes(provider.proxyBodies[0], "tools").Exists())
 	assert.Equal(t, "auto", gjson.GetBytes(provider.proxyBodies[0], "tool_choice").Str)
+	assert.NotEmpty(t, gjson.GetBytes(provider.proxyBodies[0], "prompt_cache_key").Str)
 	assert.False(t, gjson.GetBytes(provider.proxyBodies[0], "messages").Exists())
 	assert.JSONEq(t, `{"id":"resp_1","object":"response","output":[]}`, rec.Body.String())
 }
@@ -352,7 +353,12 @@ func TestService_ProxyOpenAIResponses_CustomToolUsesNativeOpenAIFamily(t *testin
 	assert.Equal(t, originalEnvelope.ToolConfigurationSHA256(), fr.capturedReq.ToolConfigurationSHA256)
 	assert.Equal(t, map[string]struct{}{providers.ProviderOpenAI: {}}, fr.capturedReq.EnabledProviders)
 	require.Len(t, provider.proxyBodies, 1)
-	assert.JSONEq(t, `{"model":"gpt-5.5","input":"apply a patch","reasoning":{"effort":"high"},"tools":[{"type":"custom","name":"apply_patch"}]}`, string(provider.proxyBodies[0]))
+	assert.Equal(t, "gpt-5.5", gjson.GetBytes(provider.proxyBodies[0], "model").Str)
+	assert.Equal(t, "apply a patch", gjson.GetBytes(provider.proxyBodies[0], "input").Str)
+	assert.Equal(t, "high", gjson.GetBytes(provider.proxyBodies[0], "reasoning.effort").Str)
+	assert.Equal(t, "custom", gjson.GetBytes(provider.proxyBodies[0], "tools.0.type").Str)
+	assert.Equal(t, "apply_patch", gjson.GetBytes(provider.proxyBodies[0], "tools.0.name").Str)
+	assert.NotEmpty(t, gjson.GetBytes(provider.proxyBodies[0], "prompt_cache_key").Str)
 	assert.Equal(t, providers.EndpointResponses, provider.proxyEndpoints[0])
 	assert.JSONEq(t, `{"id":"resp_1","object":"response","output":[]}`, rec.Body.String())
 }

--- a/internal/translate/emit_openai_responses.go
+++ b/internal/translate/emit_openai_responses.go
@@ -30,6 +30,15 @@ func (e *RequestEnvelope) PrepareOpenAIResponses(in http.Header, opts EmitOption
 	return providers.PreparedRequest{Body: body, Endpoint: providers.EndpointResponses, Stats: stats}, nil
 }
 
+// ApplyOpenAIResponsesSessionAffinity adds the OpenAI Responses prompt-cache
+// key using the same precedence as Chat Completions emission.
+func ApplyOpenAIResponsesSessionAffinity(body []byte, sessionAffinity string) ([]byte, error) {
+	return applySessionAffinity(body, make(http.Header), EmitOptions{
+		TargetProvider:  providers.ProviderOpenAI,
+		SessionAffinity: sessionAffinity,
+	})
+}
+
 // ResponseTranslator is the common surface the proxy's cross-format OpenAI
 // dispatch drives. AnthropicSSETranslator (chat/completions) and
 // ResponsesToAnthropicWriter (Responses API) both implement it.

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -123,6 +123,9 @@ func validateJSONObject(body []byte) error {
 
 func (e *RequestEnvelope) SourceFormat() Format { return e.format }
 
+// OpenAIChatBody returns a copy of the current OpenAI Chat Completions body.
+func (e *RequestEnvelope) OpenAIChatBody() []byte { return append([]byte(nil), e.body...) }
+
 // Stream reports whether the request has "stream": true. Rejects numeric coercion.
 // For Gemini ingress, the handler injects a synthetic "stream": true.
 func (e *RequestEnvelope) Stream() bool {

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -544,9 +544,8 @@ func (t *ResponsesWriter) Header() http.Header { return t.inner.Header() }
 // routing, before Prelude).
 func (t *ResponsesWriter) SetPassthrough() { t.passthrough = true }
 
-// SetTranslated switches back to Chat Completions translation before any bytes
-// reach the client. This is used when a native Responses attempt fails before
-// commit and fallback dispatch selects a translated provider.
+// SetTranslated reverts to Chat Completions translation mode. Called on
+// pre-commit fallback when a native Responses attempt fails and a translated provider is selected.
 func (t *ResponsesWriter) SetTranslated() {
 	t.passthrough = false
 	t.passthroughBadge = false

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -544,6 +544,14 @@ func (t *ResponsesWriter) Header() http.Header { return t.inner.Header() }
 // routing, before Prelude).
 func (t *ResponsesWriter) SetPassthrough() { t.passthrough = true }
 
+// SetTranslated switches back to Chat Completions translation before any bytes
+// reach the client. This is used when a native Responses attempt fails before
+// commit and fallback dispatch selects a translated provider.
+func (t *ResponsesWriter) SetTranslated() {
+	t.passthrough = false
+	t.passthroughBadge = false
+}
+
 // SetPassthroughBadge switches to native Responses passthrough while opting
 // into a Codex-visible routed-model badge. It rewrites only existing text
 // fields in the first assistant message; event order, sequence numbers,

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -186,6 +186,9 @@ func responsesMessageContent(content json.RawMessage, role string) json.RawMessa
 	}
 	var text string
 	if json.Unmarshal(content, &text) == nil {
+		if text == "" {
+			return nil
+		}
 		return content
 	}
 	var parts []map[string]json.RawMessage

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -41,20 +42,174 @@ type ResponseTransform struct {
 	Path   string
 }
 
-// ResponsesToChatCompletions converts an OpenAI Responses API request into a
-// Chat Completions request so the existing proxy path can dispatch it
-// unchanged. Returns the rewritten body, whether streaming was requested, and
-// the requested model (empty if absent). Handles only the subset of the
-// Responses spec Codex actually emits: instructions, input items (message /
-// function_call / function_call_output), tools, tool_choice,
-// max_output_tokens, temperature, top_p, parallel_tool_calls, metadata.
-//
-// Codex's `reasoning` field is dropped intentionally: this runs before
-// routing, so the served provider (and its native thinking knob) is unknown.
-// Forwarding it as `reasoning_effort` broke every non-Gemini model — Codex
-// sends invalid values (e.g. "none"), and gpt-5.x rejects `reasoning_effort`
-// alongside tools, both causing an upstream 400 mid-stream. Per-provider
-// reasoning is still driven downstream from the request's own signals.
+// RebuildOpenAIResponsesBody replaces a Responses request's input with the
+// current, potentially compacted, Chat Completions message history.
+func RebuildOpenAIResponsesBody(originalBody, chatBody []byte) ([]byte, error) {
+	var responses map[string]json.RawMessage
+	err := json.Unmarshal(originalBody, &responses)
+	if err != nil {
+		return nil, fmt.Errorf("decode Responses body: %w", err)
+	}
+
+	var chat struct {
+		Messages []json.RawMessage `json:"messages"`
+	}
+	err = json.Unmarshal(chatBody, &chat)
+	if err != nil {
+		return nil, fmt.Errorf("decode compacted Chat Completions body: %w", err)
+	}
+	if chat.Messages == nil {
+		return nil, errors.New("compacted Chat Completions body has no messages")
+	}
+
+	input := make([]json.RawMessage, 0, len(chat.Messages))
+	instructions := make([]string, 0)
+	for _, rawMessage := range chat.Messages {
+		var message struct {
+			Role      string          `json:"role"`
+			Content   json.RawMessage `json:"content"`
+			ToolCalls []struct {
+				ID       string `json:"id"`
+				Function struct {
+					Name      string `json:"name"`
+					Arguments string `json:"arguments"`
+				} `json:"function"`
+			} `json:"tool_calls"`
+			ToolCallID string `json:"tool_call_id"`
+		}
+		err = json.Unmarshal(rawMessage, &message)
+		if err != nil {
+			return nil, fmt.Errorf("decode compacted Chat Completions message: %w", err)
+		}
+
+		switch message.Role {
+		case "system", "developer":
+			if text := chatMessageText(message.Content); text != "" {
+				instructions = append(instructions, text)
+			}
+		case "user", "assistant":
+			content := responsesMessageContent(message.Content, message.Role)
+			if content != nil {
+				item := struct {
+					Type    string          `json:"type"`
+					Role    string          `json:"role"`
+					Content json.RawMessage `json:"content"`
+				}{
+					Type:    "message",
+					Role:    message.Role,
+					Content: content,
+				}
+				encoded, marshalErr := json.Marshal(item)
+				if marshalErr != nil {
+					return nil, fmt.Errorf("encode Responses message: %w", marshalErr)
+				}
+				input = append(input, encoded)
+			}
+			for _, toolCall := range message.ToolCalls {
+				encoded, marshalErr := json.Marshal(struct {
+					Type      string `json:"type"`
+					CallID    string `json:"call_id"`
+					Name      string `json:"name"`
+					Arguments string `json:"arguments"`
+				}{
+					Type:      "function_call",
+					CallID:    toolCall.ID,
+					Name:      toolCall.Function.Name,
+					Arguments: toolCall.Function.Arguments,
+				})
+				if marshalErr != nil {
+					return nil, fmt.Errorf("encode Responses function call: %w", marshalErr)
+				}
+				input = append(input, encoded)
+			}
+		case "tool":
+			output := message.Content
+			if len(output) == 0 || string(output) == "null" {
+				output = json.RawMessage(`""`)
+			}
+			encoded, marshalErr := json.Marshal(struct {
+				Type   string          `json:"type"`
+				CallID string          `json:"call_id"`
+				Output json.RawMessage `json:"output"`
+			}{
+				Type:   "function_call_output",
+				CallID: message.ToolCallID,
+				Output: output,
+			})
+			if marshalErr != nil {
+				return nil, fmt.Errorf("encode Responses function output: %w", marshalErr)
+			}
+			input = append(input, encoded)
+		default:
+			input = append(input, rawMessage)
+		}
+	}
+
+	encodedInput, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("encode Responses input: %w", err)
+	}
+	responses["input"] = encodedInput
+	if len(instructions) > 0 {
+		encodedInstructions, marshalErr := json.Marshal(strings.Join(instructions, "\n\n"))
+		if marshalErr != nil {
+			return nil, fmt.Errorf("encode Responses instructions: %w", marshalErr)
+		}
+		responses["instructions"] = encodedInstructions
+	}
+	return json.Marshal(responses)
+}
+
+func chatMessageText(content json.RawMessage) string {
+	var text string
+	if json.Unmarshal(content, &text) == nil {
+		return text
+	}
+	var parts []struct {
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(content, &parts) != nil {
+		return ""
+	}
+	texts := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part.Text != "" {
+			texts = append(texts, part.Text)
+		}
+	}
+	return strings.Join(texts, "\n")
+}
+
+func responsesMessageContent(content json.RawMessage, role string) json.RawMessage {
+	if len(content) == 0 || string(content) == "null" {
+		return nil
+	}
+	var text string
+	if json.Unmarshal(content, &text) == nil {
+		return content
+	}
+	var parts []map[string]json.RawMessage
+	if json.Unmarshal(content, &parts) != nil {
+		return content
+	}
+	for _, part := range parts {
+		var partType string
+		if json.Unmarshal(part["type"], &partType) == nil && partType == "text" {
+			if role == "assistant" {
+				part["type"] = json.RawMessage(`"output_text"`)
+			} else {
+				part["type"] = json.RawMessage(`"input_text"`)
+			}
+		}
+	}
+	encoded, err := json.Marshal(parts)
+	if err != nil {
+		return content
+	}
+	return encoded
+}
+
+// ResponsesToChatCompletions converts a Responses request to Chat Completions.
 func ResponsesToChatCompletions(body []byte) ([]byte, bool, string, error) {
 	result, err := ConvertResponsesToChatCompletions(body)
 	if err != nil {

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -20,7 +20,7 @@ const codexResponsesBadgeSentinelForTest = "\u2063\u2060\u2063\u2060"
 
 func TestRebuildOpenAIResponsesBody_UsesCompactedChatHistory(t *testing.T) {
 	original := []byte(`{"model":"auto","instructions":"old instructions","input":"old input","tools":[{"type":"function","name":"lookup"}],"stream":true}`)
-	compactedChat := []byte(`{"messages":[{"role":"system","content":"new instructions"},{"role":"user","content":[{"type":"text","text":"look this up"}]},{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{\"q\":\"value\"}"}}]},{"role":"tool","tool_call_id":"call_1","content":"result"}]}`)
+	compactedChat := []byte(`{"messages":[{"role":"system","content":"new instructions"},{"role":"user","content":[{"type":"text","text":"look this up"}]},{"role":"assistant","content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{\"q\":\"value\"}"}}]},{"role":"tool","tool_call_id":"call_1","content":"result"}]}`)
 
 	rebuilt, err := translate.RebuildOpenAIResponsesBody(original, compactedChat)
 	require.NoError(t, err)

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -18,6 +18,24 @@ import (
 
 const codexResponsesBadgeSentinelForTest = "\u2063\u2060\u2063\u2060"
 
+func TestRebuildOpenAIResponsesBody_UsesCompactedChatHistory(t *testing.T) {
+	original := []byte(`{"model":"auto","instructions":"old instructions","input":"old input","tools":[{"type":"function","name":"lookup"}],"stream":true}`)
+	compactedChat := []byte(`{"messages":[{"role":"system","content":"new instructions"},{"role":"user","content":[{"type":"text","text":"look this up"}]},{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{\"q\":\"value\"}"}}]},{"role":"tool","tool_call_id":"call_1","content":"result"}]}`)
+
+	rebuilt, err := translate.RebuildOpenAIResponsesBody(original, compactedChat)
+	require.NoError(t, err)
+	assert.Equal(t, "auto", gjson.GetBytes(rebuilt, "model").Str)
+	assert.Equal(t, "new instructions", gjson.GetBytes(rebuilt, "instructions").Str)
+	assert.Equal(t, "look this up", gjson.GetBytes(rebuilt, "input.0.content.0.text").Str)
+	assert.Equal(t, "input_text", gjson.GetBytes(rebuilt, "input.0.content.0.type").Str)
+	assert.Equal(t, "function_call", gjson.GetBytes(rebuilt, "input.1.type").Str)
+	assert.Equal(t, "call_1", gjson.GetBytes(rebuilt, "input.1.call_id").Str)
+	assert.Equal(t, "{\"q\":\"value\"}", gjson.GetBytes(rebuilt, "input.1.arguments").Str)
+	assert.Equal(t, "function_call_output", gjson.GetBytes(rebuilt, "input.2.type").Str)
+	assert.Equal(t, "result", gjson.GetBytes(rebuilt, "input.2.output").Str)
+	assert.Equal(t, "lookup", gjson.GetBytes(rebuilt, "tools.0.name").Str)
+}
+
 func TestResponsesToChatCompletions_InstructionsAndInput(t *testing.T) {
 	body := []byte(`{
 		"model": "gpt-5",


### PR DESCRIPTION
Preserve portable Responses requests for routing, then use the native OpenAI Responses endpoint for reasoning models with function tools.

Co-Authored-By: Weave Router <noreply@workweave.ai>