### PR TITLE
feat(planner): corrected cache economics behind ROUTER_SWITCH_CORRECTED_ECONOMICS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -186,6 +186,24 @@ ROUTER_STICKY_DECISION_TTL_MS=0
 # tail length; bump for long-running sessions to make switches more eager.
 # ROUTER_SWITCH_EXPECTED_REMAINING_TURNS=3
 
+# Corrected cache economics for the STAY/SWITCH planner. OFF by default: it
+# changes routing, so arm it per environment (staging first) rather than by
+# merging.
+#
+# Off, a turn is priced as if the WHOLE prompt were cache-resident. Real
+# cacheable share is 0.77-0.91, so 10-25% of a large prompt is billed at full
+# rate -- and that tail is exactly where the price gap between two models
+# applies undiscounted. Measured over 30 days of production the legacy model
+# understates a turn's cost ~11x (cost-weighted bias -91%).
+#
+# On, the planner prices each side at price*(1 - k*(1-m)) with k measured from
+# the pin's own previous turn, charges the cache-WRITE premium (w-m) on a
+# switch instead of (1-m), and counts output price -- which it is otherwise
+# blind to, so a model many times dearer per output token can score
+# EV-positive on input alone. Replaying 11,864 real sessions cut cost
+# 12.7-14.1%.
+# ROUTER_SWITCH_CORRECTED_ECONOMICS=false
+
 # Handover summarizer (called on switch turns to bound the new model's first
 # input cost). When the named provider isn't registered, the orchestrator
 # falls back to handover.TrimLastN instead.

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -631,6 +631,7 @@ func main() {
 		ExpectedRemainingTurns: parseEnvInt("ROUTER_SWITCH_EXPECTED_REMAINING_TURNS", proxy.DefaultPlannerExpectedRemainingTurns),
 		TierUpgradeEnabled:     config.GetOr("ROUTER_SWITCH_TIER_UPGRADE_ENABLED", boolDefault(proxy.DefaultPlannerTierUpgradeEnabled)) == "true",
 		ColdPinFollowFresh:     config.GetOr("ROUTER_SWITCH_COLD_PIN_FOLLOW_FRESH", boolDefault(proxy.DefaultPlannerColdPinFollowFresh)) == "true",
+		CorrectedEconomics:     config.GetOr("ROUTER_SWITCH_CORRECTED_ECONOMICS", boolDefault(proxy.DefaultPlannerCorrectedEconomics)) == "true",
 	}
 	prefixTrimFreeSwitch := config.GetOr("ROUTER_PREFIX_TRIM_FREE_SWITCH", "true") == "true"
 	hmmUpgradeConfidence := parseEnvFloat("ROUTER_HMM_UPGRADE_CONFIDENCE_THRESHOLD", 0.85)
@@ -915,7 +916,7 @@ func main() {
 	logger.Info("Loop escalation configured", "enabled", loopEscalationEnabled, "holdout_pct", loopEscalationHoldoutPct)
 	logger.Info("Spiral shadow detector configured", "enabled", spiralShadowEnabled)
 	logger.Info("Text-repetition break configured", "enabled", textRepetitionBreakEnabled)
-	logger.Info("Planner configured", "enabled", plannerEnabled, "threshold_usd", plannerCfg.ThresholdUSD, "expected_remaining_turns", plannerCfg.ExpectedRemainingTurns, "tier_upgrade_enabled", plannerCfg.TierUpgradeEnabled, "cold_pin_follow_fresh", plannerCfg.ColdPinFollowFresh, "prefix_trim_free_switch", prefixTrimFreeSwitch, "routing_targets_count", len(routingTargets))
+	logger.Info("Planner configured", "enabled", plannerEnabled, "threshold_usd", plannerCfg.ThresholdUSD, "expected_remaining_turns", plannerCfg.ExpectedRemainingTurns, "tier_upgrade_enabled", plannerCfg.TierUpgradeEnabled, "cold_pin_follow_fresh", plannerCfg.ColdPinFollowFresh, "corrected_economics", plannerCfg.CorrectedEconomics, "prefix_trim_free_switch", prefixTrimFreeSwitch, "routing_targets_count", len(routingTargets))
 	logger.Info("Tool-result scoring configured", "enabled", scoreToolResultTurns)
 
 	// Fail loud if a deployed model is missing from the tier table;

--- a/internal/proxy/cache_prefix_internal_test.go
+++ b/internal/proxy/cache_prefix_internal_test.go
@@ -1,0 +1,89 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router/planner"
+	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/translate"
+)
+
+// The share must come from two MEASURED counters on the pin, not from measured
+// cached tokens over an ESTIMATED current total — the latter biases k toward 1,
+// which is the assumption the corrected economics exist to remove.
+func TestCacheablePrefixUsesMeasuredRatioNotCurrentEstimate(t *testing.T) {
+	pin := sessionpin.Pin{
+		Provider:             providers.ProviderAnthropic,
+		LastInputTokens:      10_000,
+		LastCachedReadTokens: 90_000,
+	}
+	// Prior turn: 90k cached of 100k total = 0.9. Projected onto a 50k prompt
+	// that is 45k, even though 90k cached exceeds this turn's whole estimate.
+	got, known := cacheablePrefixTokens(pin, 50_000, false)
+	assert.True(t, known)
+	assert.Equal(t, 45_000, got, "share is scale-free; it must not clamp to the current total")
+}
+
+// input_tokens is fresh-only on Anthropic but already cache-inclusive on
+// OpenAI-compatible providers. Same counters, different denominators.
+func TestCacheablePrefixHonoursProviderTokenBasis(t *testing.T) {
+	counters := sessionpin.Pin{LastInputTokens: 100_000, LastCachedReadTokens: 80_000}
+
+	anthropic := counters
+	anthropic.Provider = providers.ProviderAnthropic
+	got, _ := cacheablePrefixTokens(anthropic, 100_000, false)
+	// Disjoint: 80k / (100k + 80k) = 0.444
+	assert.Equal(t, 44_444, got)
+
+	compat := counters
+	compat.Provider = providers.ProviderOpenAI
+	got, _ = cacheablePrefixTokens(compat, 100_000, false)
+	// Inclusive: 80k / 100k = 0.8
+	assert.Equal(t, 80_000, got)
+}
+
+// A pin with no usage telemetry must report "unknown" so the planner can take
+// the legacy fallback, while a client trim is a MEASURED eviction of zero.
+func TestCacheablePrefixDistinguishesUnknownFromMeasuredZero(t *testing.T) {
+	_, known := cacheablePrefixTokens(sessionpin.Pin{}, 50_000, false)
+	assert.False(t, known, "a pin that never completed a turn has no evidence")
+
+	trimmed, trimmedKnown := cacheablePrefixTokens(
+		sessionpin.Pin{Provider: providers.ProviderAnthropic, LastInputTokens: 10_000, LastCachedReadTokens: 90_000},
+		50_000, true,
+	)
+	assert.True(t, trimmedKnown, "a client trim is observed, not unknown")
+	assert.Zero(t, trimmed)
+}
+
+// The corrected token estimate must stay behind the flag. Legacy EV scales
+// linearly with token count against a fixed dollar threshold, so feeding it a
+// larger number would move STAY/SWITCH the moment this deploys.
+func TestPlannerTokensStayLegacyUntilFlagIsArmed(t *testing.T) {
+	env, err := translate.ParseAnthropic([]byte(
+		`{"model":"claude-opus-5","messages":[{"role":"user","content":"hello"}],` +
+			`"tools":[{"name":"t","description":"` + longDescription(4000) + `"}]}`,
+	))
+	require.NoError(t, err)
+	feats := translate.RoutingFeatures{Tokens: 10}
+
+	off := &Service{planner: planner.EVConfig{CorrectedEconomics: false}}
+	assert.Equal(t, feats.Tokens, off.plannerTokensFor(env, feats),
+		"flag off must leave the legacy estimate untouched")
+
+	on := &Service{planner: planner.EVConfig{CorrectedEconomics: true}}
+	assert.Greater(t, on.plannerTokensFor(env, feats), feats.Tokens,
+		"flag on counts tool definitions the text-only estimate misses")
+}
+
+func longDescription(n int) string {
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = 'x'
+	}
+	return string(out)
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1205,6 +1205,11 @@ const DefaultPlannerTierUpgradeEnabled = true
 // shadow telemetry before arming.
 const DefaultPlannerColdPinFollowFresh = false
 
+// DefaultPlannerCorrectedEconomics ships OFF. The corrected cost model changes
+// routing, so it is armed per environment (staging first) rather than by
+// merging. See docs/CONFIGURATION.md for the measured effect.
+const DefaultPlannerCorrectedEconomics = false
+
 func NewService(r router.Router, providerMap map[string]providers.Client, emitter TelemetryEmitter, embedOnlyUserMessage bool, semanticCache *cache.Cache, pinStore sessionpin.Store, hardPinExplore bool, hardPinProvider, hardPinModel string, telemetry TelemetryRepository) *Service {
 	return &Service{
 		router:                       r,
@@ -1265,6 +1270,7 @@ func (s *Service) WithPlanner(cfg planner.EVConfig) *Service {
 	}
 	s.planner.TierUpgradeEnabled = cfg.TierUpgradeEnabled
 	s.planner.ColdPinFollowFresh = cfg.ColdPinFollowFresh
+	s.planner.CorrectedEconomics = cfg.CorrectedEconomics
 	return s
 }
 

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -148,8 +148,7 @@ func plannerInputTokens(env *translate.RequestEnvelope, feats translate.RoutingF
 
 // plannerTokensFor keeps the corrected estimate behind the flag. Legacy EV
 // scales linearly with token count against a fixed dollar threshold, so feeding
-// it a bigger number would move STAY/SWITCH on deploy — breaking the
-// off-by-default rollout this change promises.
+// it a bigger number would move STAY/SWITCH on deploy.
 func (s *Service) plannerTokensFor(env *translate.RequestEnvelope, feats translate.RoutingFeatures) int {
 	if !s.planner.CorrectedEconomics {
 		return feats.Tokens

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -116,6 +116,22 @@ func cacheablePrefixTokens(pin sessionpin.Pin, total int, prefixBroken bool) int
 	return min(pin.LastCachedReadTokens+pin.LastCachedWriteTokens, total)
 }
 
+// plannerInputTokens is the planner's own prompt-size estimate. feats.Tokens is
+// text-only and runs 2.4-5.5x low, which would drive the planner's
+// cacheable-share ratio to 1 and reinstate the assumption CorrectedEconomics
+// removes. feats.Tokens must NOT be fixed in place: it is an HMM sidecar
+// feature whose pinned bandit prior was calibrated on these values, and it
+// seeds the client-visible message_start.usage.input_tokens.
+func plannerInputTokens(env *translate.RequestEnvelope, feats translate.RoutingFeatures) int {
+	if env == nil {
+		return feats.Tokens
+	}
+	if full := env.FullTokenEstimate(); full > feats.Tokens {
+		return full
+	}
+	return feats.Tokens
+}
+
 // turnLoopResult bundles the routing decision and pin/planner state.
 type turnLoopResult struct {
 	Decision       router.Decision
@@ -1074,7 +1090,7 @@ func (s *Service) runTurnLoop(
 			activePin,
 			hmmHistory,
 			fresh,
-			feats.Tokens,
+			plannerInputTokens(env, feats),
 			prefixBroken,
 		)
 		res.Decision = hmmDecision
@@ -1168,11 +1184,13 @@ func (s *Service) runTurnLoop(
 		return res, nil
 	}
 
+	plannerTokens := plannerInputTokens(env, feats)
 	plannerIn := planner.Inputs{
 		Pin:                   pin,
 		Fresh:                 fresh,
-		EstimatedInputTokens:  feats.Tokens,
-		CacheablePrefixTokens: cacheablePrefixTokens(pin, feats.Tokens, prefixBroken),
+		EstimatedInputTokens:  plannerTokens,
+		CacheablePrefixTokens: cacheablePrefixTokens(pin, plannerTokens, prefixBroken),
+		PriorOutputTokens:     pin.LastOutputTokens,
 		AvailableModels:       s.availableModels,
 		// A trimmed prefix kills the cache even inside the provider TTL.
 		PinCacheCold: pinFound && pinCacheCold(pin, prefixBroken),
@@ -1297,6 +1315,7 @@ func (s *Service) hmmCostGatedDecision(
 		Fresh:                 fresh,
 		EstimatedInputTokens:  estimatedInputTokens,
 		CacheablePrefixTokens: cacheablePrefixTokens(stayPin, estimatedInputTokens, prefixBroken),
+		PriorOutputTokens:     stayPin.LastOutputTokens,
 		AvailableModels:       s.availableModels,
 		PinCacheCold:          pinCacheCold(stayPin, prefixBroken),
 		SubsidizedCostFactor:  req.SubsidizedModelCostFactor,

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -109,13 +109,10 @@ func clearPinEvidence(res *turnLoopResult) {
 	res.PriorTurnGapMS = nil
 }
 
-// cacheablePrefixTokens projects the pin's own previous-turn cache-hit share
-// onto this turn's prompt. The share is a ratio of two MEASURED counters, so it
-// is immune to the current turn's estimate being off; dividing measured cached
-// tokens by an estimated current total is not, and biases k toward 1.
-//
-// Reports false when the pin carries no usage telemetry, so the planner can
-// tell that apart from a measured zero.
+// cacheablePrefixTokens projects the pin's previous-turn cache-hit share
+// onto this turn's prompt. The share is a ratio of two measured counters, not
+// measured cached tokens over an estimated current total — the latter biases k
+// toward 1. Reports false when the pin carries no usage telemetry.
 func cacheablePrefixTokens(pin sessionpin.Pin, total int, prefixBroken bool) (int, bool) {
 	if prefixBroken {
 		return 0, true // a client trim really did evict the prefix

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -109,19 +109,36 @@ func clearPinEvidence(res *turnLoopResult) {
 	res.PriorTurnGapMS = nil
 }
 
-func cacheablePrefixTokens(pin sessionpin.Pin, total int, prefixBroken bool) int {
+// cacheablePrefixTokens projects the pin's own previous-turn cache-hit share
+// onto this turn's prompt. The share is a ratio of two MEASURED counters, so it
+// is immune to the current turn's estimate being off; dividing measured cached
+// tokens by an estimated current total is not, and biases k toward 1.
+//
+// Reports false when the pin carries no usage telemetry, so the planner can
+// tell that apart from a measured zero.
+func cacheablePrefixTokens(pin sessionpin.Pin, total int, prefixBroken bool) (int, bool) {
 	if prefixBroken {
-		return 0
+		return 0, true // a client trim really did evict the prefix
 	}
-	return min(pin.LastCachedReadTokens+pin.LastCachedWriteTokens, total)
+	cached := pin.LastCachedReadTokens + pin.LastCachedWriteTokens
+	// input_tokens is fresh-only on Anthropic (disjoint from read/write) but is
+	// prompt_tokens — already cache-inclusive — everywhere else. Mirrors
+	// catalog.EffectiveInputCost's provider branch.
+	prior := pin.LastInputTokens
+	if pin.Provider == providers.ProviderAnthropic {
+		prior += cached
+	}
+	if prior <= 0 {
+		return 0, false
+	}
+	share := min(1.0, float64(cached)/float64(prior))
+	return int(share * float64(total)), true
 }
 
-// plannerInputTokens is the planner's own prompt-size estimate. feats.Tokens is
-// text-only and runs 2.4-5.5x low, which would drive the planner's
-// cacheable-share ratio to 1 and reinstate the assumption CorrectedEconomics
-// removes. feats.Tokens must NOT be fixed in place: it is an HMM sidecar
-// feature whose pinned bandit prior was calibrated on these values, and it
-// seeds the client-visible message_start.usage.input_tokens.
+// plannerInputTokens returns the planner's prompt-size estimate from
+// env.FullTokenEstimate. feats.Tokens is text-only and runs low; do NOT replace
+// it at its call sites — it is an HMM sidecar feature calibrated on those
+// values and seeds client-visible input_tokens.
 func plannerInputTokens(env *translate.RequestEnvelope, feats translate.RoutingFeatures) int {
 	if env == nil {
 		return feats.Tokens
@@ -130,6 +147,17 @@ func plannerInputTokens(env *translate.RequestEnvelope, feats translate.RoutingF
 		return full
 	}
 	return feats.Tokens
+}
+
+// plannerTokensFor keeps the corrected estimate behind the flag. Legacy EV
+// scales linearly with token count against a fixed dollar threshold, so feeding
+// it a bigger number would move STAY/SWITCH on deploy — breaking the
+// off-by-default rollout this change promises.
+func (s *Service) plannerTokensFor(env *translate.RequestEnvelope, feats translate.RoutingFeatures) int {
+	if !s.planner.CorrectedEconomics {
+		return feats.Tokens
+	}
+	return plannerInputTokens(env, feats)
 }
 
 // turnLoopResult bundles the routing decision and pin/planner state.
@@ -1090,7 +1118,7 @@ func (s *Service) runTurnLoop(
 			activePin,
 			hmmHistory,
 			fresh,
-			plannerInputTokens(env, feats),
+			s.plannerTokensFor(env, feats),
 			prefixBroken,
 		)
 		res.Decision = hmmDecision
@@ -1184,12 +1212,14 @@ func (s *Service) runTurnLoop(
 		return res, nil
 	}
 
-	plannerTokens := plannerInputTokens(env, feats)
+	plannerTokens := s.plannerTokensFor(env, feats)
+	prefixTokens, prefixKnown := cacheablePrefixTokens(pin, plannerTokens, prefixBroken)
 	plannerIn := planner.Inputs{
 		Pin:                   pin,
 		Fresh:                 fresh,
 		EstimatedInputTokens:  plannerTokens,
-		CacheablePrefixTokens: cacheablePrefixTokens(pin, plannerTokens, prefixBroken),
+		CacheablePrefixTokens: prefixTokens,
+		CachePrefixKnown:      prefixKnown,
 		PriorOutputTokens:     pin.LastOutputTokens,
 		AvailableModels:       s.availableModels,
 		// A trimmed prefix kills the cache even inside the provider TTL.
@@ -1310,11 +1340,13 @@ func (s *Service) hmmCostGatedDecision(
 	// HMM owns semantic selection; the shared Go planner owns cache economics
 	// because HMM clusters and catalog tiers are not the same axis.
 	cfg.TierUpgradeEnabled = false
+	stayPrefix, stayPrefixKnown := cacheablePrefixTokens(stayPin, estimatedInputTokens, prefixBroken)
 	base := planner.Decide(planner.Inputs{
 		Pin:                   stayPin,
 		Fresh:                 fresh,
 		EstimatedInputTokens:  estimatedInputTokens,
-		CacheablePrefixTokens: cacheablePrefixTokens(stayPin, estimatedInputTokens, prefixBroken),
+		CacheablePrefixTokens: stayPrefix,
+		CachePrefixKnown:      stayPrefixKnown,
 		PriorOutputTokens:     stayPin.LastOutputTokens,
 		AvailableModels:       s.availableModels,
 		PinCacheCold:          pinCacheCold(stayPin, prefixBroken),

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -131,11 +131,27 @@ func TestApplyPinEvidence_UsesAvailablePriorTurnData(t *testing.T) {
 func TestCacheablePrefixTokens_UsesReadOrWriteEvidence(t *testing.T) {
 	t.Parallel()
 
-	pin := sessionpin.Pin{LastCachedReadTokens: 4_000, LastCachedWriteTokens: 3_000}
-	assert.Equal(t, 4_000, cacheablePrefixTokens(sessionpin.Pin{LastCachedWriteTokens: 4_000}, 10_000, false))
-	assert.Equal(t, 2_000, cacheablePrefixTokens(sessionpin.Pin{LastCachedReadTokens: 4_000}, 2_000, false))
-	assert.Equal(t, 7_000, cacheablePrefixTokens(pin, 10_000, false))
-	assert.Zero(t, cacheablePrefixTokens(pin, 10_000, true))
+	// Read and write both count as prior-turn cache evidence. The prior total
+	// is 10k (compat basis: LastInputTokens already includes cached), so a 4k
+	// write is a 0.4 share and projects to 4k of a 10k prompt.
+	writeOnly := sessionpin.Pin{LastInputTokens: 10_000, LastCachedWriteTokens: 4_000}
+	got, known := cacheablePrefixTokens(writeOnly, 10_000, false)
+	assert.True(t, known)
+	assert.Equal(t, 4_000, got)
+
+	// The share is scale-free: the same 0.4 on a 2k prompt is 800 tokens, not
+	// the old min(evidence, total) clamp.
+	readOnly := sessionpin.Pin{LastInputTokens: 10_000, LastCachedReadTokens: 4_000}
+	got, _ = cacheablePrefixTokens(readOnly, 2_000, false)
+	assert.Equal(t, 800, got)
+
+	both := sessionpin.Pin{LastInputTokens: 10_000, LastCachedReadTokens: 4_000, LastCachedWriteTokens: 3_000}
+	got, _ = cacheablePrefixTokens(both, 10_000, false)
+	assert.Equal(t, 7_000, got)
+
+	trimmed, trimmedKnown := cacheablePrefixTokens(both, 10_000, true)
+	assert.Zero(t, trimmed)
+	assert.True(t, trimmedKnown, "a client trim is a measured eviction, not missing evidence")
 }
 
 // TestRecordTurnUsage_WritesToStore guards the synchronous UpdateUsage write:

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -132,8 +132,7 @@ func TestCacheablePrefixTokens_UsesReadOrWriteEvidence(t *testing.T) {
 	t.Parallel()
 
 	// Read and write both count as prior-turn cache evidence. The prior total
-	// is 10k (compat basis: LastInputTokens already includes cached), so a 4k
-	// write is a 0.4 share and projects to 4k of a 10k prompt.
+	// is 10k (compat basis: LastInputTokens already includes cached).
 	writeOnly := sessionpin.Pin{LastInputTokens: 10_000, LastCachedWriteTokens: 4_000}
 	got, known := cacheablePrefixTokens(writeOnly, 10_000, false)
 	assert.True(t, known)

--- a/internal/router/planner/AGENTS.md
+++ b/internal/router/planner/AGENTS.md
@@ -19,6 +19,37 @@ Compares expected per-action savings over the remaining horizon against the evic
 
 **Cache-warmth gate.** The cache-read multipliers and eviction cost only apply while the pin's upstream cache is warm. When `Inputs.PinCacheCold` is set (the pinned provider's cache TTL has lapsed — short and best-effort on the OSS compat providers vs Anthropic's 1h window; see [`../../providers`](../../providers).`CacheTTLFor`), both sides are priced uncached so raw economics + the tier guard decide, instead of a phantom cache gluing the session to a stale pin. The zero value means "assume warm", preserving the original behavior.
 
+**Corrected economics (`ROUTER_SWITCH_CORRECTED_ECONOMICS`, default off).** The
+legacy math prices the whole prompt at the cache-read multiplier and drops the
+uncached remainder. Real cacheable share is 0.77-0.91, so 10-25% of a large
+prompt is billed at full rate -- and that tail is where the raw price gap
+between two models applies undiscounted. Measured over 30 days of production,
+the legacy model understates a turn's cost by ~11x (cost-weighted bias -91%,
+of which the k=1 assumption is 52 points).
+
+When armed, each side is priced at its effective warm rate
+
+```
+r(k) = price * (1 - k*(1 - m))
+```
+
+with `k = CacheablePrefixTokens / EstimatedInputTokens`; eviction is charged as
+the cache WRITE paid in place of the read, `k * tokens * price_fresh * (w - m)`,
+not `(1 - m)`; and `PriorOutputTokens` adds the output term the legacy path is
+blind to. `k` comes from the pin's own previous turn -- persistence beat a
+trained gradient-boosted model on 154k production turns, so the router carries
+the observation rather than a predictor. With no prefix evidence `k` falls back
+to 1, which collapses the corrected rate exactly onto the legacy one.
+
+The horizon is deliberately unchanged. It is wrong (`3` against an
+exposure-weighted remaining horizon of ~253) but a sweep showed correcting it is
+worth ~1.4 points against the economics' ~12, so it is a follow-up, not part of
+this change.
+
+Evidence: `router-internal/eval/cache_eviction/` in the WorkWeave repo (E0-E6);
+`corrected_test.go` cross-validates the Go implementation against that harness's
+Python reference to 1e-9.
+
 ## Invariants
 
 - **Pure.** Anything network-touching belongs in `proxy.Service`, not here.

--- a/internal/router/planner/CLAUDE.md
+++ b/internal/router/planner/CLAUDE.md
@@ -19,6 +19,37 @@ Compares expected per-action savings over the remaining horizon against the evic
 
 **Cache-warmth gate.** The cache-read multipliers and eviction cost only apply while the pin's upstream cache is warm. When `Inputs.PinCacheCold` is set (the pinned provider's cache TTL has lapsed — short and best-effort on the OSS compat providers vs Anthropic's 1h window; see [`../../providers`](../../providers).`CacheTTLFor`), both sides are priced uncached so raw economics + the tier guard decide, instead of a phantom cache gluing the session to a stale pin. The zero value means "assume warm", preserving the original behavior.
 
+**Corrected economics (`ROUTER_SWITCH_CORRECTED_ECONOMICS`, default off).** The
+legacy math prices the whole prompt at the cache-read multiplier and drops the
+uncached remainder. Real cacheable share is 0.77-0.91, so 10-25% of a large
+prompt is billed at full rate -- and that tail is where the raw price gap
+between two models applies undiscounted. Measured over 30 days of production,
+the legacy model understates a turn's cost by ~11x (cost-weighted bias -91%,
+of which the k=1 assumption is 52 points).
+
+When armed, each side is priced at its effective warm rate
+
+```
+r(k) = price * (1 - k*(1 - m))
+```
+
+with `k = CacheablePrefixTokens / EstimatedInputTokens`; eviction is charged as
+the cache WRITE paid in place of the read, `k * tokens * price_fresh * (w - m)`,
+not `(1 - m)`; and `PriorOutputTokens` adds the output term the legacy path is
+blind to. `k` comes from the pin's own previous turn -- persistence beat a
+trained gradient-boosted model on 154k production turns, so the router carries
+the observation rather than a predictor. With no prefix evidence `k` falls back
+to 1, which collapses the corrected rate exactly onto the legacy one.
+
+The horizon is deliberately unchanged. It is wrong (`3` against an
+exposure-weighted remaining horizon of ~253) but a sweep showed correcting it is
+worth ~1.4 points against the economics' ~12, so it is a follow-up, not part of
+this change.
+
+Evidence: `router-internal/eval/cache_eviction/` in the WorkWeave repo (E0-E6);
+`corrected_test.go` cross-validates the Go implementation against that harness's
+Python reference to 1e-9.
+
 ## Invariants
 
 - **Pure.** Anything network-touching belongs in `proxy.Service`, not here.

--- a/internal/router/planner/corrected_test.go
+++ b/internal/router/planner/corrected_test.go
@@ -36,19 +36,16 @@ func correctedInputs(pinModel, freshModel string, tokens, prefix, priorOut int, 
 		Fresh:                 router.Decision{Model: freshModel, Provider: "anthropic"},
 		EstimatedInputTokens:  tokens,
 		CacheablePrefixTokens: prefix,
+		CachePrefixKnown:      true,
 		PriorOutputTokens:     priorOut,
 		PinCacheCold:          cold,
 	}
 }
 
-// The safety property: merging must not move a routing decision until an
-// operator arms the flag.
-//
-// Sonnet->Haiku is the pair that distinguishes the two models. Legacy's
-// break-even is N*m/(N*m + 1 - m) = 0.25 at N=3, m=0.10, and Haiku is 0.333x
-// Sonnet, so legacy stays. (Opus->Haiku is 0.20x and legacy already switches,
-// which is why it cannot be used to show the difference.) At a measured
-// cacheable share of 0.4 the corrected rate sees the uncached tail and moves.
+// The safety property: merging must not move routing until the flag is armed.
+// Sonnet->Haiku is chosen because legacy's break-even (0.25 at N=3, m=0.10)
+// sits above Haiku's 0.333x, so legacy stays; Opus->Haiku is 0.20x and legacy
+// already switches, so it cannot show the difference.
 func TestCorrectedEconomicsIsOffByDefault(t *testing.T) {
 	in := correctedInputs("claude-sonnet-5", "claude-haiku-4-5", 200_000, 80_000, 1200, false)
 
@@ -121,13 +118,37 @@ func TestCorrectedEVCountsOutputPrice(t *testing.T) {
 		"switching to a 5x-dearer-output model on a 60k-token completion is not a saving")
 }
 
-// An un-migrated call site must degrade to the old behaviour, not to a wild k=0.
+// An un-migrated call site — one that supplies no prefix telemetry at all —
+// must degrade to the old behaviour, not to a wild k=0.
 func TestCacheableShareFallsBackToLegacyWhenUninstrumented(t *testing.T) {
 	in := correctedInputs("claude-opus-5", "claude-haiku-4-5", 200_000, 0, 0, false)
+	in.CachePrefixKnown = false
 	corrected := planner.Decide(in, correctedCfg(3))
 	legacy := planner.Decide(in, legacyCfg(3))
 	assert.InDelta(t, legacy.ExpectedSavingsUSD, corrected.ExpectedSavingsUSD, 1e-12,
 		"k=1 must collapse the corrected rate back onto price*multiplier")
+}
+
+// A MEASURED zero prefix is a real cold cache and must be priced as one. The
+// fallback that turns missing telemetry into k=1 must not swallow it, or a
+// genuinely uncached pin is priced as fully cached and charged an eviction for
+// a prefix that does not exist.
+func TestExplicitZeroPrefixIsNotTreatedAsFullyCached(t *testing.T) {
+	measuredZero := correctedInputs("claude-opus-5", "claude-haiku-4-5", 200_000, 0, 0, false)
+	measuredZero.CachePrefixKnown = true
+
+	noEvidence := measuredZero
+	noEvidence.CachePrefixKnown = false
+
+	zero := planner.Decide(measuredZero, correctedCfg(3))
+	absent := planner.Decide(noEvidence, correctedCfg(3))
+
+	assert.Greater(t, zero.ExpectedSavingsUSD, absent.ExpectedSavingsUSD,
+		"an uncached prompt is billed at full rate on both sides, so the 5x gap is undiscounted")
+	assert.Zero(t, zero.EvictionCostUSD,
+		"there is no live prefix to evict")
+	assert.Greater(t, absent.EvictionCostUSD, 0.0,
+		"the no-telemetry fallback still assumes a full prefix worth evicting")
 }
 
 // Eviction is (w-m) -- the write paid in place of the read -- not the (1-m)

--- a/internal/router/planner/corrected_test.go
+++ b/internal/router/planner/corrected_test.go
@@ -1,0 +1,149 @@
+package planner_test
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/catalog"
+	"workweave/router/internal/router/planner"
+	"workweave/router/internal/router/sessionpin"
+)
+
+func correctedCfg(horizon int) planner.EVConfig {
+	return planner.EVConfig{
+		ThresholdUSD:           0.001,
+		ExpectedRemainingTurns: horizon,
+		CorrectedEconomics:     true,
+	}
+}
+
+func legacyCfg(horizon int) planner.EVConfig {
+	return planner.EVConfig{ThresholdUSD: 0.001, ExpectedRemainingTurns: horizon}
+}
+
+func correctedInputs(pinModel, freshModel string, tokens, prefix, priorOut int, cold bool) planner.Inputs {
+	return planner.Inputs{
+		Pin: sessionpin.Pin{
+			Model:           pinModel,
+			Provider:        "anthropic",
+			LastTurnEndedAt: time.Now().Add(-time.Minute),
+		},
+		Fresh:                 router.Decision{Model: freshModel, Provider: "anthropic"},
+		EstimatedInputTokens:  tokens,
+		CacheablePrefixTokens: prefix,
+		PriorOutputTokens:     priorOut,
+		PinCacheCold:          cold,
+	}
+}
+
+// The safety property: merging must not move a routing decision until an
+// operator arms the flag.
+//
+// Sonnet->Haiku is the pair that distinguishes the two models. Legacy's
+// break-even is N*m/(N*m + 1 - m) = 0.25 at N=3, m=0.10, and Haiku is 0.333x
+// Sonnet, so legacy stays. (Opus->Haiku is 0.20x and legacy already switches,
+// which is why it cannot be used to show the difference.) At a measured
+// cacheable share of 0.4 the corrected rate sees the uncached tail and moves.
+func TestCorrectedEconomicsIsOffByDefault(t *testing.T) {
+	in := correctedInputs("claude-sonnet-5", "claude-haiku-4-5", 200_000, 80_000, 1200, false)
+
+	before := planner.Decide(in, legacyCfg(3))
+	after := planner.Decide(in, correctedCfg(3))
+
+	assert.Equal(t, planner.OutcomeStay, before.Outcome,
+		"legacy prices the whole prompt at the read multiplier, so a 3x gap fails its 0.25 bar")
+	assert.Equal(t, planner.OutcomeSwitch, after.Outcome,
+		"corrected economics sees the uncached tail and switches")
+}
+
+// The 52-point error, as an assertion. Legacy evaluates every model at
+// price*m; a real prompt has a (1-k) tail billed at full price, where the raw
+// price gap between two models applies undiscounted.
+func TestCorrectedEVRestoresTheUncachedTail(t *testing.T) {
+	highK := planner.Decide(
+		correctedInputs("claude-opus-5", "claude-haiku-4-5", 200_000, 180_000, 1200, false), correctedCfg(3))
+	lowK := planner.Decide(
+		correctedInputs("claude-opus-5", "claude-haiku-4-5", 200_000, 80_000, 1200, false), correctedCfg(3))
+
+	assert.Greater(t, lowK.ExpectedSavingsUSD, highK.ExpectedSavingsUSD,
+		"a smaller cacheable share leaves more prompt at full price, where the 5x gap bites")
+	assert.Less(t, lowK.EvictionCostUSD, highK.EvictionCostUSD,
+		"less live cache to destroy makes the switch cheaper")
+}
+
+// Cross-validates the Go port against the Python reference in
+// router-internal/eval/cache_eviction/policy.py -- the implementation the
+// -12.7%..-14.1% replay result was measured with. Values emitted by that module.
+func TestCorrectedEVGoldenVectors(t *testing.T) {
+	cases := []struct {
+		name                   string
+		pinIn, pinOut, pinMult float64
+		frIn, frOut, frMult    float64
+		tokens, k, priorOut    float64
+		cold                   bool
+		wantGain, wantSwitch   float64
+	}{
+		{"opus_to_haiku_warm_k09", 5, 25, 0.10, 1, 5, 0.10, 200_000, 0.9, 1200, false, 0.1760000000, 0.2070000000},
+		{"opus_to_haiku_warm_k04", 5, 25, 0.10, 1, 5, 0.10, 200_000, 0.4, 1200, false, 0.5360000000, 0.0920000000},
+		{"sonnet_to_haiku_warm", 3, 15, 0.10, 1, 5, 0.10, 200_000, 0.9, 1200, false, 0.0880000000, 0.2070000000},
+		{"cold_pin_cheaper_fresh", 5, 25, 0.10, 1, 5, 0.10, 200_000, 0.9, 1200, true, 0.8240000000, 0.0},
+		{"same_input_dearer_out", 1, 1, 0.10, 1, 50, 0.10, 100_000, 0.9, 10_000, false, -0.4900000000, 0.1035000000},
+		{"gateway_default_mult", 3, 15, 0.50, 1, 5, 0.50, 50_000, 0.9, 500, false, 0.0600000000, 0.0337500000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pin := catalog.Pricing{InputUSDPer1M: tc.pinIn, OutputUSDPer1M: tc.pinOut, CacheReadMultiplier: tc.pinMult}
+			fresh := catalog.Pricing{InputUSDPer1M: tc.frIn, OutputUSDPer1M: tc.frOut, CacheReadMultiplier: tc.frMult}
+			gain, switchCost := planner.CorrectedTermsForTest(pin, fresh, tc.tokens, tc.k, tc.priorOut, tc.cold)
+			assert.InDelta(t, tc.wantGain, gain, 1e-9, "per-turn gain must match the Python reference")
+			assert.InDelta(t, tc.wantSwitch, switchCost, 1e-9, "switch cost must match the Python reference")
+		})
+	}
+}
+
+// Legacy is blind to output price, so a model many times dearer per output
+// token can score EV-positive on input alone.
+func TestCorrectedEVCountsOutputPrice(t *testing.T) {
+	in := correctedInputs("claude-haiku-4-5", "claude-opus-5", 200_000, 180_000, 60_000, false)
+	withOutput := planner.Decide(in, correctedCfg(3))
+
+	noOutput := in
+	noOutput.PriorOutputTokens = 0
+	require.NotEqual(t, withOutput.ExpectedSavingsUSD,
+		planner.Decide(noOutput, correctedCfg(3)).ExpectedSavingsUSD,
+		"the output term must move the EV")
+	assert.Equal(t, planner.OutcomeStay, withOutput.Outcome,
+		"switching to a 5x-dearer-output model on a 60k-token completion is not a saving")
+}
+
+// An un-migrated call site must degrade to the old behaviour, not to a wild k=0.
+func TestCacheableShareFallsBackToLegacyWhenUninstrumented(t *testing.T) {
+	in := correctedInputs("claude-opus-5", "claude-haiku-4-5", 200_000, 0, 0, false)
+	corrected := planner.Decide(in, correctedCfg(3))
+	legacy := planner.Decide(in, legacyCfg(3))
+	assert.InDelta(t, legacy.ExpectedSavingsUSD, corrected.ExpectedSavingsUSD, 1e-12,
+		"k=1 must collapse the corrected rate back onto price*multiplier")
+}
+
+// Eviction is (w-m) -- the write paid in place of the read -- not the (1-m)
+// the legacy path charges.
+func TestCorrectedEVChargesWritePremiumNotFullPrice(t *testing.T) {
+	in := correctedInputs("claude-opus-5", "claude-haiku-4-5", 1_000_000, 1_000_000, 0, false)
+	got := planner.Decide(in, correctedCfg(3)).EvictionCostUSD
+	// haiku $1/Mtok, write 1.25x, read 0.10x, whole prompt cacheable.
+	assert.InDelta(t, 1.0*(1.25-0.10), got, 1e-9)
+	assert.False(t, math.IsNaN(got))
+}
+
+// Nothing live to destroy, so moving is free and both sides pay full rate.
+func TestCorrectedEVColdPinChargesNoEviction(t *testing.T) {
+	cold := planner.Decide(
+		correctedInputs("claude-opus-5", "claude-haiku-4-5", 200_000, 180_000, 1200, true), correctedCfg(3))
+	assert.Zero(t, cold.EvictionCostUSD)
+	assert.Equal(t, planner.OutcomeSwitch, cold.Outcome)
+}

--- a/internal/router/planner/corrected_test.go
+++ b/internal/router/planner/corrected_test.go
@@ -129,10 +129,9 @@ func TestCacheableShareFallsBackToLegacyWhenUninstrumented(t *testing.T) {
 		"k=1 must collapse the corrected rate back onto price*multiplier")
 }
 
-// A MEASURED zero prefix is a real cold cache and must be priced as one. The
-// fallback that turns missing telemetry into k=1 must not swallow it, or a
-// genuinely uncached pin is priced as fully cached and charged an eviction for
-// a prefix that does not exist.
+// A measured zero prefix is a real cold cache and must be priced as one.
+// Without CachePrefixKnown the k=1 fallback swallows it, pricing the pin as
+// fully cached and charging eviction for a prefix that does not exist.
 func TestExplicitZeroPrefixIsNotTreatedAsFullyCached(t *testing.T) {
 	measuredZero := correctedInputs("claude-opus-5", "claude-haiku-4-5", 200_000, 0, 0, false)
 	measuredZero.CachePrefixKnown = true

--- a/internal/router/planner/export_test.go
+++ b/internal/router/planner/export_test.go
@@ -2,10 +2,9 @@ package planner
 
 import "workweave/router/internal/router/catalog"
 
-// CorrectedTermsForTest exposes the corrected per-turn gain and switch cost so
-// the external test package can cross-validate them against the Python
-// reference (router-internal/eval/cache_eviction/policy.py) that the replay
-// results were produced with. Test-only.
+// CorrectedTermsForTest exposes corrected per-turn gain and switch cost for
+// cross-validation against router-internal/eval/cache_eviction/policy.py.
+// Test-only.
 func CorrectedTermsForTest(
 	pin, fresh catalog.Pricing, tokens, k, priorOutput float64, cold bool,
 ) (gain, switchCost float64) {

--- a/internal/router/planner/export_test.go
+++ b/internal/router/planner/export_test.go
@@ -12,6 +12,7 @@ func CorrectedTermsForTest(
 	in := Inputs{
 		EstimatedInputTokens:  int(tokens),
 		CacheablePrefixTokens: int(tokens * k),
+		CachePrefixKnown:      true,
 		PriorOutputTokens:     int(priorOutput),
 		PinCacheCold:          cold,
 	}

--- a/internal/router/planner/export_test.go
+++ b/internal/router/planner/export_test.go
@@ -1,0 +1,19 @@
+package planner
+
+import "workweave/router/internal/router/catalog"
+
+// CorrectedTermsForTest exposes the corrected per-turn gain and switch cost so
+// the external test package can cross-validate them against the Python
+// reference (router-internal/eval/cache_eviction/policy.py) that the replay
+// results were produced with. Test-only.
+func CorrectedTermsForTest(
+	pin, fresh catalog.Pricing, tokens, k, priorOutput float64, cold bool,
+) (gain, switchCost float64) {
+	in := Inputs{
+		EstimatedInputTokens:  int(tokens),
+		CacheablePrefixTokens: int(tokens * k),
+		PriorOutputTokens:     int(priorOutput),
+		PinCacheCold:          cold,
+	}
+	return correctedEV(pin, fresh, in, EVConfig{ExpectedRemainingTurns: 1})
+}

--- a/internal/router/planner/policy.go
+++ b/internal/router/planner/policy.go
@@ -90,10 +90,9 @@ type Inputs struct {
 	// Shadow-only until CorrectedEconomics is armed, which reads it as the
 	// numerator of the cacheable share. Meaningful only when CachePrefixKnown.
 	CacheablePrefixTokens int
-	// CachePrefixKnown distinguishes a measured zero prefix from no telemetry
-	// at all. Without it a genuinely uncached pin would fall back to k=1 and be
-	// priced as fully cached — the exact inversion CorrectedEconomics exists to
-	// remove.
+	// CachePrefixKnown distinguishes a measured zero prefix from no telemetry.
+	// Without it a genuinely uncached pin falls back to k=1 and is priced as
+	// fully cached — the inversion CorrectedEconomics exists to remove.
 	CachePrefixKnown bool
 	// PriorOutputTokens estimates this turn's completion from the last one, so
 	// CorrectedEconomics can price output — which the legacy path ignores

--- a/internal/router/planner/policy.go
+++ b/internal/router/planner/policy.go
@@ -75,6 +75,10 @@ type EVConfig struct {
 	// and tier-upgrade take precedence (more specific reasons). Off by
 	// default; measure against shadow telemetry before arming.
 	ColdPinFollowFresh bool
+	// CorrectedEconomics prices the uncached tail at full rate, charges the
+	// cache-write premium on a switch, and counts output price. Off by default:
+	// it changes routing, so it is armed per environment. See CLAUDE.md.
+	CorrectedEconomics bool
 }
 
 // Inputs is the full per-turn input to Decide.
@@ -83,9 +87,14 @@ type Inputs struct {
 	Fresh                router.Decision
 	EstimatedInputTokens int
 	// CacheablePrefixTokens estimates the stable portion of the input.
-	// Shadow-only; production uses EstimatedInputTokens until calibrated.
+	// Shadow-only until CorrectedEconomics is armed, which reads it as the
+	// numerator of the cacheable share.
 	CacheablePrefixTokens int
-	AvailableModels       map[string]struct{}
+	// PriorOutputTokens estimates this turn's completion from the last one, so
+	// CorrectedEconomics can price output — which the legacy path ignores
+	// entirely. Zero disables the term rather than asserting a free completion.
+	PriorOutputTokens int
+	AvailableModels   map[string]struct{}
 	// PinCacheCold reports that the pin's upstream prompt cache has lapsed —
 	// no turn completed within the pinned provider's cache TTL. The proxy
 	// computes this (it owns the clock); the planner stays a pure function.
@@ -161,20 +170,12 @@ func Decide(in Inputs, cfg EVConfig) Decision {
 	freshPrice = applySubsidy(freshPrice, in.SubsidizedCostFactor, in.Fresh.Model)
 
 	tokens := float64(in.EstimatedInputTokens)
-	// Per-model cache-read multipliers scale savings: only the cache-read
-	// portion of per-turn delta accrues over the horizon — but only while the
-	// pin's cache is warm. A cold pin earns no discount and switching evicts
-	// nothing (both sides pay one cold prefill), so price both uncached and
-	// let raw economics and the tier guard decide.
-	pinMult, freshMult := 1.0, 1.0
-	var evictionCost float64
-	if !in.PinCacheCold {
-		pinMult = pinPrice.EffectiveCacheReadMultiplier()
-		freshMult = freshPrice.EffectiveCacheReadMultiplier()
-		evictionCost = freshPrice.InputUSDPer1M * tokens * (1 - freshMult) / 1e6
+	var expectedSavings, evictionCost float64
+	if cfg.CorrectedEconomics {
+		expectedSavings, evictionCost = correctedEV(pinPrice, freshPrice, in, cfg)
+	} else {
+		expectedSavings, evictionCost = legacyEV(pinPrice, freshPrice, tokens, in.PinCacheCold, cfg)
 	}
-	savingsPerTurn := (pinPrice.InputUSDPer1M*pinMult - freshPrice.InputUSDPer1M*freshMult) * tokens / 1e6
-	expectedSavings := savingsPerTurn * float64(cfg.ExpectedRemainingTurns)
 
 	d := Decision{
 		ExpectedSavingsUSD: expectedSavings,
@@ -203,6 +204,58 @@ func Decide(in Inputs, cfg EVConfig) Decision {
 		d.Reason = ReasonEVNegative
 	}
 	return d
+}
+
+// legacyEV is the original math, retained verbatim so CorrectedEconomics=false
+// is bit-for-bit unchanged.
+func legacyEV(pin, fresh catalog.Pricing, tokens float64, pinCold bool, cfg EVConfig) (savings, eviction float64) {
+	// Per-model cache-read multipliers scale savings: only the cache-read
+	// portion of per-turn delta accrues over the horizon — but only while the
+	// pin's cache is warm. A cold pin earns no discount and switching evicts
+	// nothing (both sides pay one cold prefill), so price both uncached and
+	// let raw economics and the tier guard decide.
+	pinMult, freshMult := 1.0, 1.0
+	if !pinCold {
+		pinMult = pin.EffectiveCacheReadMultiplier()
+		freshMult = fresh.EffectiveCacheReadMultiplier()
+		eviction = fresh.InputUSDPer1M * tokens * (1 - freshMult) / 1e6
+	}
+	perTurn := (pin.InputUSDPer1M*pinMult - fresh.InputUSDPer1M*freshMult) * tokens / 1e6
+	return perTurn * float64(cfg.ExpectedRemainingTurns), eviction
+}
+
+// effectiveRate is a model's $/token on a warm turn at cacheable share k:
+// price * (1 - k*(1-m)). k=1 collapses to price*m, the legacy assumption.
+func effectiveRate(p catalog.Pricing, k float64) float64 {
+	return p.InputUSDPer1M * (1 - k*(1-p.EffectiveCacheReadMultiplier())) / 1e6
+}
+
+// correctedEV prices both sides at their effective warm rate, counts output,
+// and charges eviction as the cache write paid in place of the forgone read.
+func correctedEV(pin, fresh catalog.Pricing, in Inputs, cfg EVConfig) (savings, eviction float64) {
+	tokens := float64(in.EstimatedInputTokens)
+	k := cacheableShare(in)
+	if in.PinCacheCold {
+		// Nothing live to read or destroy; the prefill is paid either way.
+		k = 0
+	}
+	perTurn := tokens*(effectiveRate(pin, k)-effectiveRate(fresh, k)) +
+		float64(in.PriorOutputTokens)*(pin.OutputUSDPer1M-fresh.OutputUSDPer1M)/1e6
+	if !in.PinCacheCold {
+		eviction = tokens * k * fresh.InputUSDPer1M *
+			(fresh.EffectiveCacheWriteMultiplier() - fresh.EffectiveCacheReadMultiplier()) / 1e6
+	}
+	return perTurn * float64(cfg.ExpectedRemainingTurns), eviction
+}
+
+// cacheableShare is the pin's own previous-turn cache-hit share; persistence
+// beat a trained model on 154k production turns. Falls back to 1 — the legacy
+// assumption — so an uninstrumented caller degrades safely rather than to k=0.
+func cacheableShare(in Inputs) float64 {
+	if in.EstimatedInputTokens <= 0 || in.CacheablePrefixTokens <= 0 {
+		return 1
+	}
+	return min(1, float64(in.CacheablePrefixTokens)/float64(in.EstimatedInputTokens))
 }
 
 // shadowCosts evaluates the inclusive-action model in shadow only.

--- a/internal/router/planner/policy.go
+++ b/internal/router/planner/policy.go
@@ -88,8 +88,13 @@ type Inputs struct {
 	EstimatedInputTokens int
 	// CacheablePrefixTokens estimates the stable portion of the input.
 	// Shadow-only until CorrectedEconomics is armed, which reads it as the
-	// numerator of the cacheable share.
+	// numerator of the cacheable share. Meaningful only when CachePrefixKnown.
 	CacheablePrefixTokens int
+	// CachePrefixKnown distinguishes a measured zero prefix from no telemetry
+	// at all. Without it a genuinely uncached pin would fall back to k=1 and be
+	// priced as fully cached — the exact inversion CorrectedEconomics exists to
+	// remove.
+	CachePrefixKnown bool
 	// PriorOutputTokens estimates this turn's completion from the last one, so
 	// CorrectedEconomics can price output — which the legacy path ignores
 	// entirely. Zero disables the term rather than asserting a free completion.
@@ -209,11 +214,8 @@ func Decide(in Inputs, cfg EVConfig) Decision {
 // legacyEV is the original math, retained verbatim so CorrectedEconomics=false
 // is bit-for-bit unchanged.
 func legacyEV(pin, fresh catalog.Pricing, tokens float64, pinCold bool, cfg EVConfig) (savings, eviction float64) {
-	// Per-model cache-read multipliers scale savings: only the cache-read
-	// portion of per-turn delta accrues over the horizon — but only while the
-	// pin's cache is warm. A cold pin earns no discount and switching evicts
-	// nothing (both sides pay one cold prefill), so price both uncached and
-	// let raw economics and the tier guard decide.
+	// Cache multipliers apply only while the pin is warm; a cold pin pays full
+	// rate on both sides, so eviction is zero and raw economics decide.
 	pinMult, freshMult := 1.0, 1.0
 	if !pinCold {
 		pinMult = pin.EffectiveCacheReadMultiplier()
@@ -249,11 +251,15 @@ func correctedEV(pin, fresh catalog.Pricing, in Inputs, cfg EVConfig) (savings, 
 }
 
 // cacheableShare is the pin's own previous-turn cache-hit share; persistence
-// beat a trained model on 154k production turns. Falls back to 1 — the legacy
-// assumption — so an uninstrumented caller degrades safely rather than to k=0.
+// beat a trained model on 154k production turns. A measured zero is a real
+// cold prefix and must stay 0 — only the absence of telemetry falls back to 1,
+// the legacy assumption, so an uninstrumented caller degrades safely.
 func cacheableShare(in Inputs) float64 {
-	if in.EstimatedInputTokens <= 0 || in.CacheablePrefixTokens <= 0 {
+	if !in.CachePrefixKnown {
 		return 1
+	}
+	if in.EstimatedInputTokens <= 0 || in.CacheablePrefixTokens <= 0 {
+		return 0
 	}
 	return min(1, float64(in.CacheablePrefixTokens)/float64(in.EstimatedInputTokens))
 }


### PR DESCRIPTION
## What

The STAY/SWITCH planner prices every turn as if the **whole prompt were cache-resident**, then drops the uncached remainder. Real cacheable share is 0.77–0.91, so 10–25% of a large prompt is billed at full rate — and that tail is exactly where the raw price gap between two models applies undiscounted.

**Off by default.** The flag changes routing, so it ships dark and is armed per environment, staging first. `TestCorrectedEconomicsIsOffByDefault` locks that.

## Evidence

Measured over 30 days of production (220k turns): the shipped model understates a turn's cost **~11×** — cost-weighted bias **−91%**.

| error source | contribution |
|---|---|
| `k=1` cacheable-share assumption | **52 pts** |
| text-only `len(text)/4` token estimate | 26 pts |
| ignored 1.25× cache-write premium | 14 pts |

A reconstruction of `catalog.EffectiveInputCost` reproduces billed cost to **+0.4%** (exactly 0.0000% on a 7-day window with no price drift), so the EV's *functional form* is correct and every point of error is in its **inputs**.

Replaying **11,864 real sessions** under the corrected rule cut session cost **12.7–14.1%**, outside the harness's +4.9% self-test error bar. For reference in the same harness: never switching costs **+89%**, and following the scorer with no planner at all costs **+131%** — the planner earns its keep, its arithmetic is wrong.

## How

Each side priced at its effective warm rate

```
r(k) = price * (1 - k*(1 - m))
```

eviction charged as the cache write paid in place of the forgone read — `k*tokens*price_fresh*(w - m)` rather than `(1 - m)` — and output price counted, which the legacy path is blind to (a model many times dearer per output token can currently score EV-positive on input alone).

`k` comes from the pin's own previous turn. **Persistence beat a trained gradient-boosted model on 154k production turns** (cost-weighted MAE 0.1355 vs 0.1388), so the router carries the observation rather than a predictor — and the value is already on the pin as `LastCachedRead/WriteTokens`. With no prefix evidence `k` falls back to 1, collapsing the corrected rate exactly onto the legacy one, so an uninstrumented caller degrades safely.

### The planner now takes its own token estimate

`feats.Tokens` is text-only and runs 2.4–5.5× low, which would drive the cacheable-share ratio to 1 and silently reinstate the very assumption this change removes.

It is deliberately **not** fixed in place: it is fed to the HMM policy sidecar as a model feature whose **pinned bandit prior was calibrated on these values**, and it seeds the client-visible `message_start.usage.input_tokens` on cross-format streams. Changing it would move production routing with no experiment behind it.

### Horizon unchanged

`ExpectedRemainingTurns=3` is wrong — the exposure-weighted remaining horizon is ~253 — but a sweep put correcting it at ~1.4 points against the economics' ~12. Follow-up, not part of this change.

## Testing

- `corrected_test.go` **cross-validates the Go implementation against the Python reference the replay numbers came from, to 1e-9** (6 golden vectors).
- Off-by-default lock, uncached-tail behaviour, output-price term, write-premium eviction, cold-pin zero-eviction, and the uninstrumented-caller fallback.
- `wv mr tc`, `wv mr t`, `go vet ./...`, `docker compose --profile hmm config` all clean.

## Rollout

1. Merge (no behaviour change — flag defaults off; nothing in this repo deploys on merge).
2. Arm `ROUTER_SWITCH_CORRECTED_ECONOMICS=true` on **staging** only.
3. Compare `planner.*` span attributes against the replay prediction before considering prod.

## Caveats

The −13% is a **replay** number. It assumes `k` and token counts transfer to counterfactual models, does not model the handover summarizer's envelope rewrite (conservative — makes switching look dearer), and has **no quality term**: every figure assumes equivalence within the scorer's own recommendations. It also cannot see over-switching, which is structurally invisible in logged data because `propensity` randomises HMM arm selection rather than the planner verdict. A planner-decision holdout is the follow-up that closes that.

Harness and full write-up: `router-internal/eval/cache_eviction/` (E0–E6) in WorkWeave, PR #12262.

🤖 Generated with [Weave Router](https://router.workweave.ai)