### PR TITLE
Fix handling /force-model invocations by agent

### DIFF
--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -370,9 +370,8 @@ func (s *Service) applyForceModelHeader(
 }
 
 // handleForceModelCommand processes a user-issued directive and writes a
-// synthetic acknowledgment without dispatching upstream. inputTokens should
-// be the request's RoutingFeatures.Tokens so the token counter reflects actual
-// turn input, not just the synthetic response text.
+// synthetic acknowledgment without dispatching upstream. inputTokens is the
+// request's RoutingFeatures.Tokens so counts reflect actual turn input.
 func (s *Service) handleForceModelCommand(
 	ctx context.Context,
 	w http.ResponseWriter,

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -369,11 +369,10 @@ func (s *Service) applyForceModelHeader(
 	return canonicalModel, nil
 }
 
-// handleForceModelCommand processes a /force-model or /unforce-model directive:
-// writes (or expires) the session pin and returns a synthetic acknowledgment
-// response without dispatching upstream. inputTokens should be the request's
-// RoutingFeatures.Tokens so the token counter reflects actual turn input, not
-// just the synthetic response text.
+// handleForceModelCommand processes a user-issued directive and writes a
+// synthetic acknowledgment without dispatching upstream. inputTokens should
+// be the request's RoutingFeatures.Tokens so the token counter reflects actual
+// turn input, not just the synthetic response text.
 func (s *Service) handleForceModelCommand(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -383,6 +382,28 @@ func (s *Service) handleForceModelCommand(
 	sessionKey [sessionpin.SessionKeyLen]byte,
 	inputTokens int,
 ) error {
+	_, msg, err := s.applyForceModelCommand(ctx, env, cmd, installationID, sessionKey)
+	if err != nil {
+		return err
+	}
+	switch env.SourceFormat() {
+	case translate.FormatOpenAI:
+		return writeSyntheticOpenAIResponse(w, env, msg, inputTokens)
+	default:
+		return writeSyntheticAnthropicResponse(w, env, msg, inputTokens)
+	}
+}
+
+// applyForceModelCommand updates the session pin without deciding whether the
+// caller should receive a synthetic response. It returns the canonical model
+// when a force was applied.
+func (s *Service) applyForceModelCommand(
+	ctx context.Context,
+	env *translate.RequestEnvelope,
+	cmd translate.ForceModelResult,
+	installationID uuid.UUID,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+) (string, string, error) {
 	log := observability.FromContext(ctx)
 	role := roleForTier(catalog.TierFor(env.Model()))
 
@@ -394,21 +415,22 @@ func (s *Service) handleForceModelCommand(
 		if s.pinStore != nil && installationID != uuid.Nil {
 			if err := s.expireSessionPin(ctx, installationID, sessionKey, role, "user_unforced"); err != nil {
 				log.Error("/unforce-model: pin store upsert failed", "err", err)
-				return err
+				return "", "", err
 			}
 		}
 		msg = "✦ **Weave Router** → force-model cleared · resuming automatic model selection\n\n"
 		if env.SourceFormat() == translate.FormatOpenAI {
 			msg = "Weave Router: force-model cleared; resuming automatic model selection"
 		}
-		// Debug not Info: fires on every command use, not a major business event.
 		log.Debug("/unforce-model: session pin cleared",
 			"session_key_hex", fmt.Sprintf("%x", sessionKey),
 			"role", role,
 		)
-	} else if canonicalModel, provider, known := resolveForceModel(cmd.Model); !known {
-		// Not in the catalog (e.g. truncated "/force-model gpt-") — reject
-		// rather than pin something we can't honor; prior pin left untouched.
+		return "", msg, nil
+	}
+
+	canonicalModel, provider, known := resolveForceModel(cmd.Model)
+	if !known {
 		log.Info("/force-model: rejected unknown model",
 			"input_model", cmd.Model,
 			"session_key_hex", fmt.Sprintf("%x", sessionKey),
@@ -418,9 +440,11 @@ func (s *Service) handleForceModelCommand(
 		if env.SourceFormat() == translate.FormatOpenAI {
 			msg = fmt.Sprintf("Weave Router: force-model: %q isn't a recognized model; keeping automatic routing. Use a full model ID, e.g. claude-opus-5, gpt-5.5, or gemini-3-pro-preview.", cmd.Model)
 		}
-	} else if binding, reason := s.forcedModelBinding(ctx, canonicalModel, provider); reason != "" {
-		// Exclusions outrank the force. Pinning anyway would look accepted and
-		// then serve something else every turn; the prior pin is left untouched.
+		return "", msg, nil
+	}
+
+	binding, reason := s.forcedModelBinding(ctx, canonicalModel, provider)
+	if reason != "" {
 		log.Warn("/force-model: rejected excluded model",
 			"input_model", cmd.Model,
 			"canonical_model", canonicalModel,
@@ -433,30 +457,25 @@ func (s *Service) handleForceModelCommand(
 		if env.SourceFormat() == translate.FormatOpenAI {
 			msg = fmt.Sprintf("Weave Router: force-model rejected: %s; keeping automatic routing. Ask an admin to allow the provider, or force a model from one that is permitted.", reason)
 		}
-	} else {
-		if err := s.setForceModelPin(ctx, sessionKey, role, installationID, canonicalModel, binding); err != nil {
-			log.Error("/force-model: pin store upsert failed", "err", err)
-			return err
-		}
-		msg = fmt.Sprintf("✦ **Weave Router** → force-model applied: %s (%s) · Use /unforce-model to clear\n\n", canonicalModel, binding)
-		if env.SourceFormat() == translate.FormatOpenAI {
-			msg = fmt.Sprintf("Weave Router: force-model applied: %s (%s). Use /unforce-model to clear.", canonicalModel, binding)
-		}
-		log.Debug("/force-model: session pin set",
-			"input_model", cmd.Model,
-			"canonical_model", canonicalModel,
-			"provider", binding,
-			"session_key_hex", fmt.Sprintf("%x", sessionKey),
-			"role", role,
-		)
+		return "", msg, nil
 	}
 
-	switch env.SourceFormat() {
-	case translate.FormatOpenAI:
-		return writeSyntheticOpenAIResponse(w, env, msg, inputTokens)
-	default:
-		return writeSyntheticAnthropicResponse(w, env, msg, inputTokens)
+	if err := s.setForceModelPin(ctx, sessionKey, role, installationID, canonicalModel, binding); err != nil {
+		log.Error("/force-model: pin store upsert failed", "err", err)
+		return "", "", err
 	}
+	msg = fmt.Sprintf("✦ **Weave Router** → force-model applied: %s (%s) · Use /unforce-model to clear\n\n", canonicalModel, binding)
+	if env.SourceFormat() == translate.FormatOpenAI {
+		msg = fmt.Sprintf("Weave Router: force-model applied: %s (%s). Use /unforce-model to clear.", canonicalModel, binding)
+	}
+	log.Debug("/force-model: session pin set",
+		"input_model", cmd.Model,
+		"canonical_model", canonicalModel,
+		"provider", binding,
+		"session_key_hex", fmt.Sprintf("%x", sessionKey),
+		"role", role,
+	)
+	return canonicalModel, msg, nil
 }
 
 // writeSyntheticAnthropicResponse writes a minimal Anthropic Messages API

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2604,14 +2604,10 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		}
 	}
 
-	// Sanitize only after command extraction. A client-side skill can encode
-	// its output as a plain user string following an assistant tool_use; doing
-	// this first would erase the provenance needed to avoid executing it.
-	// A dangling tool_use left by a prior mid-stream failure 400s permanently
-	// on providers that validate tool-call/response pairing (Together); other
-	// providers silently accept it, so the failure only shows up depending on
-	// which model the router picks. It must run before maybeCompact/routing so
-	// every dispatch attempt this turn sees a wire-valid history.
+	// Sanitize after command extraction: a skill can encode its command as a
+	// plain user string after an assistant tool_use, and sanitizing first would
+	// erase the provenance. Must also run before maybeCompact/routing so every
+	// dispatch sees a wire-valid history (dangling tool_use 400s on Together).
 	if sanitized := env.SanitizeOrphanedToolCalls(); sanitized > 0 {
 		log.Info("Sanitized orphaned tool calls before dispatch", "sanitized", sanitized)
 		requestBodyChanged = true
@@ -5110,14 +5106,10 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		return nil
 	}
 
-	// Sanitize only after command extraction. A client-side skill can encode
-	// its output as a plain user string following an assistant tool_use; doing
-	// this first would erase the provenance needed to avoid executing it.
-	// A dangling tool_use left by a prior mid-stream failure 400s permanently
-	// on providers that validate tool-call/response pairing (Together); other
-	// providers silently accept it, so the failure only shows up depending on
-	// which model the router picks. It must run before maybeCompact/routing so
-	// every dispatch attempt this turn sees a wire-valid history.
+	// Sanitize after command extraction: a skill can encode its command as a
+	// plain user string after an assistant tool_use, and sanitizing first would
+	// erase the provenance. Must also run before maybeCompact/routing so every
+	// dispatch sees a wire-valid history (dangling tool_use 400s on Together).
 	if sanitized := env.SanitizeOrphanedToolCalls(); sanitized > 0 {
 		log.Info("Sanitized orphaned tool calls before dispatch", "sanitized", sanitized)
 		requestBodyChanged = true

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2606,8 +2606,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	// Sanitize after command extraction: a skill can encode its command as a
 	// plain user string after an assistant tool_use, and sanitizing first would
-	// erase the provenance. Must also run before maybeCompact/routing so every
-	// dispatch sees a wire-valid history (dangling tool_use 400s on Together).
+	// erase the provenance and leave a dangling tool_use that 400s on Together.
 	if sanitized := env.SanitizeOrphanedToolCalls(); sanitized > 0 {
 		log.Info("Sanitized orphaned tool calls before dispatch", "sanitized", sanitized)
 		requestBodyChanged = true
@@ -5108,8 +5107,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	// Sanitize after command extraction: a skill can encode its command as a
 	// plain user string after an assistant tool_use, and sanitizing first would
-	// erase the provenance. Must also run before maybeCompact/routing so every
-	// dispatch sees a wire-valid history (dangling tool_use 400s on Together).
+	// erase the provenance and leave a dangling tool_use that 400s on Together.
 	if sanitized := env.SanitizeOrphanedToolCalls(); sanitized > 0 {
 		log.Info("Sanitized orphaned tool calls before dispatch", "sanitized", sanitized)
 		requestBodyChanged = true

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2549,14 +2549,6 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	if removed := env.StripRouterFeedbackArtifacts(); removed > 0 {
 		log.Info("Stripped router-feedback artifacts from Anthropic history", "removed_messages", removed)
 	}
-	// A dangling tool_use left by a prior mid-stream failure 400s permanently
-	// on providers that validate tool-call/response pairing (Together); other
-	// providers silently accept it, so the failure only shows up depending on
-	// which model the router picks. Must run before maybeCompact/routing so
-	// every dispatch attempt this turn sees a wire-valid history.
-	if sanitized := env.SanitizeOrphanedToolCalls(); sanitized > 0 {
-		log.Info("Sanitized orphaned tool calls before dispatch", "sanitized", sanitized)
-	}
 
 	embedFlag := s.ResolveEmbedOnlyUserMessage(ctx)
 	feats := env.RoutingFeatures(embedFlag)
@@ -2580,14 +2572,25 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// env.body so the upstream never sees it). Session key is derived before
 	// extraction: DeriveSessionKey can fall back to prompt text, and deriving
 	// after the strip would mismatch subsequent turns with the unstripped message.
+	agentForceModel := ""
+	requestBodyChanged := false
 	if !agentShadowMode && s.pinStore != nil {
 		if cmd, hasCmd := env.ExtractForceModelCommand(); hasCmd {
 			log.Info("ProxyMessages force-model command", "force_model_cmd", cmd)
-			if err := s.handleForceModelCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens); err != nil {
-				return err
+			if cmd.FromToolResult {
+				var err error
+				agentForceModel, _, err = s.applyForceModelCommand(ctx, env, cmd, installationID, sessionKey)
+				if err != nil {
+					return err
+				}
+				requestBodyChanged = true
+			} else {
+				if err := s.handleForceModelCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens); err != nil {
+					return err
+				}
+				s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
+				return nil
 			}
-			s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
-			return nil
 		}
 	}
 	if !agentShadowMode {
@@ -2601,16 +2604,40 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		}
 	}
 
+	// Sanitize only after command extraction. A client-side skill can encode
+	// its output as a plain user string following an assistant tool_use; doing
+	// this first would erase the provenance needed to avoid executing it.
+	// A dangling tool_use left by a prior mid-stream failure 400s permanently
+	// on providers that validate tool-call/response pairing (Together); other
+	// providers silently accept it, so the failure only shows up depending on
+	// which model the router picks. It must run before maybeCompact/routing so
+	// every dispatch attempt this turn sees a wire-valid history.
+	if sanitized := env.SanitizeOrphanedToolCalls(); sanitized > 0 {
+		log.Info("Sanitized orphaned tool calls before dispatch", "sanitized", sanitized)
+		requestBodyChanged = true
+	}
+	if requestBodyChanged {
+		feats = env.RoutingFeatures(embedFlag)
+		promptText = feats.PromptText
+		embedInput = "concatenated_stream"
+		if embedFlag && feats.OnlyUserMessageText != "" {
+			promptText = feats.OnlyUserMessageText
+			embedInput = "only_user_message"
+		}
+	}
+
 	// Honor the x-weave-force-model header (headless equivalent of /force-model).
 	// Writes the user-forced pin and falls through to normal routing, which picks
 	// the pin up and serves the requested model on this same turn.
-	forceModel := ""
+	forceModel := agentForceModel
 	forceCluster := ""
 	if !agentShadowMode {
-		var forceErr error
-		forceModel, forceErr = s.applyForceModelHeader(ctx, r, env, installationID, sessionKey)
+		headerForceModel, forceErr := s.applyForceModelHeader(ctx, r, env, installationID, sessionKey)
 		if forceErr != nil {
 			return forceErr
+		}
+		if headerForceModel != "" {
+			forceModel = headerForceModel
 		}
 		forceCluster, forceErr = applyForceClusterHeader(ctx, r)
 		if forceErr != nil {
@@ -5029,14 +5056,6 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	if removed := env.StripRouterFeedbackArtifacts(); removed > 0 {
 		log.Info("Stripped router-feedback artifacts from OpenAI history", "removed_messages", removed)
 	}
-	// A dangling tool_use left by a prior mid-stream failure 400s permanently
-	// on providers that validate tool-call/response pairing (Together); other
-	// providers silently accept it, so the failure only shows up depending on
-	// which model the router picks. Must run before maybeCompact/routing so
-	// every dispatch attempt this turn sees a wire-valid history.
-	if sanitized := env.SanitizeOrphanedToolCalls(); sanitized > 0 {
-		log.Info("Sanitized orphaned tool calls before dispatch", "sanitized", sanitized)
-	}
 	embedFlag := s.ResolveEmbedOnlyUserMessage(ctx)
 	feats := env.RoutingFeatures(embedFlag)
 	promptText := feats.PromptText
@@ -5061,14 +5080,25 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// env.body so the upstream never sees it). Session key is derived before
 	// extraction: DeriveSessionKey can fall back to prompt text, and deriving
 	// after the strip would mismatch subsequent turns with the unstripped message.
+	agentForceModel := ""
+	requestBodyChanged := false
 	if s.pinStore != nil {
 		if cmd, hasCmd := env.ExtractForceModelCommand(); hasCmd {
 			log.Info("ProxyOpenAIChatCompletion force-model command", "force_model_cmd", cmd)
-			if err := s.handleForceModelCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens); err != nil {
-				return err
+			if cmd.FromToolResult {
+				var err error
+				agentForceModel, _, err = s.applyForceModelCommand(ctx, env, cmd, installationID, sessionKey)
+				if err != nil {
+					return err
+				}
+				requestBodyChanged = true
+			} else {
+				if err := s.handleForceModelCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens); err != nil {
+					return err
+				}
+				s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
+				return nil
 			}
-			s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
-			return nil
 		}
 	}
 	if cmd, hasCmd := env.ExtractRouterFeedbackCommand(); hasCmd {
@@ -5080,12 +5110,38 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		return nil
 	}
 
+	// Sanitize only after command extraction. A client-side skill can encode
+	// its output as a plain user string following an assistant tool_use; doing
+	// this first would erase the provenance needed to avoid executing it.
+	// A dangling tool_use left by a prior mid-stream failure 400s permanently
+	// on providers that validate tool-call/response pairing (Together); other
+	// providers silently accept it, so the failure only shows up depending on
+	// which model the router picks. It must run before maybeCompact/routing so
+	// every dispatch attempt this turn sees a wire-valid history.
+	if sanitized := env.SanitizeOrphanedToolCalls(); sanitized > 0 {
+		log.Info("Sanitized orphaned tool calls before dispatch", "sanitized", sanitized)
+		requestBodyChanged = true
+	}
+	if requestBodyChanged {
+		feats = env.RoutingFeatures(embedFlag)
+		promptText = feats.PromptText
+		embedInput = "concatenated_stream"
+		if embedFlag && feats.OnlyUserMessageText != "" {
+			promptText = feats.OnlyUserMessageText
+			embedInput = "only_user_message"
+		}
+	}
+
 	// Honor the x-weave-force-model header (headless equivalent of /force-model).
 	// Writes the user-forced pin and falls through to normal routing, which picks
 	// the pin up and serves the requested model on this same turn.
-	forceModel, forceErr := s.applyForceModelHeader(ctx, r, env, installationID, sessionKey)
+	forceModel := agentForceModel
+	headerForceModel, forceErr := s.applyForceModelHeader(ctx, r, env, installationID, sessionKey)
 	if forceErr != nil {
 		return forceErr
+	}
+	if headerForceModel != "" {
+		forceModel = headerForceModel
 	}
 	forceCluster, forceErr := applyForceClusterHeader(ctx, r)
 	if forceErr != nil {

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -1050,6 +1050,41 @@ func TestService_SessionPin_AgentForceModelCommandContinuesOnForcedModel(t *test
 	assert.Equal(t, translate.ReasonUserForceModel, store.upserts[0].Reason)
 }
 
+func TestService_SessionPin_OpenAI_AgentForceModelCommandContinuesOnForcedModel(t *testing.T) {
+	const body = `{
+		"model":"gpt-4o",
+		"messages":[
+			{"role":"user","content":"analyze usage"},
+			{"role":"assistant","tool_calls":[{
+				"id":"call_skill","type":"function",
+				"function":{"name":"Skill","arguments":"{\"skill\":\"fm\"}"}
+			}]},
+			{"role":"tool","tool_call_id":"call_skill","content":"/force-model gpt-5"}
+		]
+	}`
+	store := newFakePinStore()
+	store.persistUpserts = true
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider: providers.ProviderOpenAI, Model: "gpt-4o", Reason: "cluster:v0.2",
+		PinnedUntil: time.Now().Add(time.Hour),
+	}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-5", Reason: translate.ReasonUserForceModel}}
+	svc := newOpenAIPinSvc(fr, store)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+	require.NoError(t, svc.ProxyOpenAIChatCompletion(ctx, []byte(body), rec, httpReq))
+
+	assert.Equal(t, 0, fr.routeCalls, "the newly forced pin must bypass automatic routing")
+	assert.Equal(t, "gpt-5", rec.Header().Get(proxy.HeaderRouterModel))
+	assert.NotContains(t, rec.Body.String(), "force-model applied", "only a user-issued command gets a synthetic acknowledgment")
+	require.NotEmpty(t, store.upserts)
+	assert.Equal(t, "gpt-5", store.upserts[0].Model)
+	assert.Equal(t, translate.ReasonUserForceModel, store.upserts[0].Reason)
+}
+
 func TestService_SessionPin_OpenAI_ForceModelCommandSetsPin(t *testing.T) {
 	const forceBody = `{
 		"model":"gpt-4o",

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -46,6 +46,7 @@ type fakePinStore struct {
 	overloadResetCalls     int
 	disabledProviders      []string
 	commandContinuations   map[string]sessionpin.Pin
+	persistUpserts         bool
 }
 
 func newFakePinStore() *fakePinStore {
@@ -95,6 +96,9 @@ func (f *fakePinStore) Upsert(ctx context.Context, p sessionpin.Pin) error {
 	f.upserts = append(f.upserts, p)
 	if strings.HasSuffix(p.Role, "_cmd_next") {
 		f.commandContinuations[p.Role] = p
+	} else if f.persistUpserts {
+		f.pin = p
+		f.hasPin = p.PinnedUntil.After(time.Now()) && p.Model != "" && p.Provider != ""
 	}
 	f.mu.Unlock()
 	select {
@@ -1007,6 +1011,43 @@ func TestService_SessionPin_OpenAI_FreshRouteCreatesPin(t *testing.T) {
 	require.Len(t, store.upserts, 1)
 	assert.Equal(t, providers.ProviderOpenAI, store.upserts[0].Provider)
 	assert.Equal(t, "gpt-4o", store.upserts[0].Model)
+}
+
+func TestService_SessionPin_AgentForceModelCommandContinuesOnForcedModel(t *testing.T) {
+	const body = `{
+		"model":"claude-opus-4-7",
+		"messages":[
+			{"role":"user","content":"analyze usage"},
+			{"role":"assistant","content":[
+				{"type":"tool_use","id":"toolu_skill","name":"Skill","input":{"skill":"fm","args":"opus"}}
+			]},
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"toolu_skill","content":"Launching skill: fm"},
+				{"type":"text","text":"/force-model opus"}
+			]}
+		]
+	}`
+	store := newFakePinStore()
+	store.persistUpserts = true
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider: providers.ProviderOpenAI, Model: "gpt-5.5", Reason: "cluster:v0.2",
+		PinnedUntil: time.Now().Add(time.Hour),
+	}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-opus-5", Reason: translate.ReasonUserForceModel}}
+	svc := newOpenAIPinSvc(fr, store)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(body), rec, httpReq))
+
+	assert.Equal(t, 0, fr.routeCalls, "the newly forced pin must bypass automatic routing")
+	assert.Equal(t, "claude-opus-5", rec.Header().Get(proxy.HeaderRouterModel))
+	assert.NotContains(t, rec.Body.String(), "force-model applied", "only a user-issued command gets a synthetic acknowledgment")
+	require.NotEmpty(t, store.upserts)
+	assert.Equal(t, "claude-opus-5", store.upserts[0].Model)
+	assert.Equal(t, translate.ReasonUserForceModel, store.upserts[0].Reason)
 }
 
 func TestService_SessionPin_OpenAI_ForceModelCommandSetsPin(t *testing.T) {

--- a/internal/translate/force_model.go
+++ b/internal/translate/force_model.go
@@ -32,7 +32,8 @@ type ForceModelResult struct {
 	FromToolResult bool
 }
 
-// ExtractForceModelCommand scans the trailing user message in env for a
+// ExtractForceModelCommand scans the trailing user or tool-result message in
+// env for a
 // /force-model <model> or /unforce-model directive, stripping it from
 // env.body. FromToolResult distinguishes agent-issued commands from commands
 // typed by the user. Returns (zero, false) when no command is present.
@@ -49,8 +50,8 @@ func (env *RequestEnvelope) ExtractForceModelCommand() (ForceModelResult, bool) 
 	return res, found
 }
 
-// extractLeadingCommand scans the trailing user message (Anthropic/OpenAI
-// shapes only) for a directive recognized by parse.
+// extractLeadingCommand scans the trailing user or tool-result message
+// (Anthropic/OpenAI shapes only) for a directive recognized by parse.
 func (env *RequestEnvelope) extractLeadingCommand(parse func(text string) (found bool, stripped string)) bool {
 	originalBody := env.body
 	found, fromToolResult := env.extractLeadingCommandWithSource(parse)
@@ -82,11 +83,14 @@ func (env *RequestEnvelope) extractLeadingCommandWithSource(parse func(text stri
 
 	all := msgs.Array()
 	lastIdx := -1
+	lastRole := ""
 	var lastContent gjson.Result
 	for i := len(all) - 1; i >= 0; i-- {
-		if all[i].Get("role").String() == "user" {
-			lastIdx = i
-			lastContent = all[i].Get("content")
+		switch role := all[i].Get("role").String(); role {
+		case "user", "tool":
+			lastIdx, lastRole, lastContent = i, role, all[i].Get("content")
+		}
+		if lastIdx >= 0 {
 			break
 		}
 	}
@@ -103,12 +107,23 @@ func (env *RequestEnvelope) extractLeadingCommandWithSource(parse func(text stri
 	}
 
 	idxPath := "messages." + strconv.Itoa(lastIdx) + ".content"
-	fromToolResult := followsAssistantToolUse(all, lastIdx)
+	// OpenAI carries a tool result as its own role:"tool" message instead of a
+	// content block, so provenance comes from the role. Such a message is only
+	// ever blanked, never dropped: deleting it would orphan the assistant
+	// tool_calls entry it answers.
+	isToolMessage := lastRole == "tool"
+	fromToolResult := isToolMessage || followsAssistantToolUse(all, lastIdx)
+	dropPathFor := func(path string) string {
+		if isToolMessage {
+			return ""
+		}
+		return path
+	}
 	var candidates []commandTextCandidate
 	switch {
 	case lastContent.Type == gjson.String:
 		candidates = append(candidates, commandTextCandidate{
-			path: idxPath, dropPath: "messages." + strconv.Itoa(lastIdx), text: lastContent.String(),
+			path: idxPath, dropPath: dropPathFor("messages." + strconv.Itoa(lastIdx)), text: lastContent.String(),
 		})
 	case lastContent.IsArray():
 		lastContent.ForEach(func(key, block gjson.Result) bool {
@@ -116,7 +131,7 @@ func (env *RequestEnvelope) extractLeadingCommandWithSource(parse func(text stri
 			switch block.Get("type").String() {
 			case "text":
 				candidates = append(candidates, commandTextCandidate{
-					path: blockPath + ".text", dropPath: blockPath, text: block.Get("text").String(),
+					path: blockPath + ".text", dropPath: dropPathFor(blockPath), text: block.Get("text").String(),
 				})
 			case "tool_result":
 				fromToolResult = true

--- a/internal/translate/force_model.go
+++ b/internal/translate/force_model.go
@@ -93,11 +93,9 @@ func (env *RequestEnvelope) extractLeadingCommandWithSource(parse func(text stri
 	if lastIdx < 0 {
 		return false, false
 	}
-	// Commands belong only to the request's trailing turn; historical commands
-	// must not be replayed after an assistant turn. Trailing non-conversational
-	// messages don't end the turn: Claude Code appends a role:"system" notice
-	// after the user turn, and treating that as a newer turn would disable the
-	// command entirely.
+	// Commands belong only to the trailing turn; skip if a conversational turn
+	// follows. Non-conversational role:"system" notices (Claude Code deferred
+	// tools) don't count as a newer turn.
 	for i := lastIdx + 1; i < len(all); i++ {
 		if isConversationTurn(all[i].Get("role").String()) {
 			return false, false
@@ -136,15 +134,38 @@ func (env *RequestEnvelope) extractLeadingCommandWithSource(parse func(text stri
 			continue
 		}
 		if fromToolResult && stripped == "" && candidate.dropPath != "" {
-			if newBody, err := sjson.DeleteBytes(env.body, candidate.dropPath); err == nil {
+			if newBody, ok := dropCommandBlock(env.body, candidate.dropPath, lastIdx); ok {
 				env.body = newBody
+				return true, fromToolResult
 			}
-		} else if newBody, err := sjson.SetBytes(env.body, candidate.path, stripped); err == nil {
+		}
+		if newBody, err := sjson.SetBytes(env.body, candidate.path, stripped); err == nil {
 			env.body = newBody
 		}
 		return true, fromToolResult
 	}
 	return false, false
+}
+
+// dropCommandBlock deletes the command-bearing block at dropPath, cascading to
+// the whole message when that empties its content array. Reports false when the
+// drop would leave no messages: providers reject an empty content array or an
+// empty history, so the caller falls back to blanking the command text instead.
+func dropCommandBlock(body []byte, dropPath string, msgIdx int) ([]byte, bool) {
+	out, err := sjson.DeleteBytes(body, dropPath)
+	if err != nil {
+		return nil, false
+	}
+	msgPath := "messages." + strconv.Itoa(msgIdx)
+	if dropPath != msgPath && gjson.GetBytes(out, msgPath+".content").Get("#").Int() == 0 {
+		if out, err = sjson.DeleteBytes(out, msgPath); err != nil {
+			return nil, false
+		}
+	}
+	if gjson.GetBytes(out, "messages").Get("#").Int() == 0 {
+		return nil, false
+	}
+	return out, true
 }
 
 func toolResultCommandCandidates(blockPath string, content gjson.Result) []commandTextCandidate {

--- a/internal/translate/force_model.go
+++ b/internal/translate/force_model.go
@@ -32,11 +32,10 @@ type ForceModelResult struct {
 	FromToolResult bool
 }
 
-// ExtractForceModelCommand scans the trailing user or tool-result message in
-// env for a
-// /force-model <model> or /unforce-model directive, stripping it from
-// env.body. FromToolResult distinguishes agent-issued commands from commands
-// typed by the user. Returns (zero, false) when no command is present.
+// ExtractForceModelCommand scans the trailing user or tool-result message in env for a
+// /force-model <model> or /unforce-model directive, stripping it from env.body.
+// FromToolResult distinguishes agent-issued commands from user-typed ones.
+// Returns (zero, false) when no command is present.
 func (env *RequestEnvelope) ExtractForceModelCommand() (ForceModelResult, bool) {
 	var res ForceModelResult
 	found, fromToolResult := env.extractLeadingCommandWithSource(func(text string) (bool, string) {
@@ -107,10 +106,8 @@ func (env *RequestEnvelope) extractLeadingCommandWithSource(parse func(text stri
 	}
 
 	idxPath := "messages." + strconv.Itoa(lastIdx) + ".content"
-	// OpenAI carries a tool result as its own role:"tool" message instead of a
-	// content block, so provenance comes from the role. Such a message is only
-	// ever blanked, never dropped: deleting it would orphan the assistant
-	// tool_calls entry it answers.
+	// OpenAI marks tool-result provenance with role:"tool", not a content block.
+	// Preserve that message when stripping the command so tool_calls stays paired.
 	isToolMessage := lastRole == "tool"
 	fromToolResult := isToolMessage || followsAssistantToolUse(all, lastIdx)
 	dropPathFor := func(path string) string {

--- a/internal/translate/force_model.go
+++ b/internal/translate/force_model.go
@@ -162,10 +162,9 @@ func (env *RequestEnvelope) extractLeadingCommandWithSource(parse func(text stri
 	return false, false
 }
 
-// dropCommandBlock deletes the command-bearing block at dropPath, cascading to
-// the whole message when that empties its content array. Reports false when the
-// drop would leave no messages: providers reject an empty content array or an
-// empty history, so the caller falls back to blanking the command text instead.
+// dropCommandBlock deletes the block at dropPath, cascading to the whole
+// message when that empties its content array, and reports false when the
+// result would be an empty history (providers reject empty content arrays).
 func dropCommandBlock(body []byte, dropPath string, msgIdx int) ([]byte, bool) {
 	out, err := sjson.DeleteBytes(body, dropPath)
 	if err != nil {

--- a/internal/translate/force_model.go
+++ b/internal/translate/force_model.go
@@ -28,95 +28,179 @@ type ForceModelResult struct {
 	Model string
 	// Clear is true for /unforce-model.
 	Clear bool
+	// FromToolResult is true when an agent invoked the command through a tool.
+	FromToolResult bool
 }
 
-// ExtractForceModelCommand scans the last user-role message in env for a
+// ExtractForceModelCommand scans the trailing user message in env for a
 // /force-model <model> or /unforce-model directive, stripping it from
-// env.body. Returns (zero, false) when no command is present.
+// env.body. FromToolResult distinguishes agent-issued commands from commands
+// typed by the user. Returns (zero, false) when no command is present.
 func (env *RequestEnvelope) ExtractForceModelCommand() (ForceModelResult, bool) {
 	var res ForceModelResult
-	found := env.extractLeadingCommand(func(text string) (bool, string) {
+	found, fromToolResult := env.extractLeadingCommandWithSource(func(text string) (bool, string) {
 		r, ok, stripped := parseForceModelCommand(text)
 		if ok {
 			res = r
 		}
 		return ok, stripped
 	})
+	res.FromToolResult = found && fromToolResult
 	return res, found
 }
 
-// extractLeadingCommand scans the last user-role message (Anthropic/OpenAI
-// shapes only) for a directive recognized by parse, which receives candidate
-// text and returns (found, strippedText). On a match, the matched content is
-// replaced in env.body with the stripped remainder.
+// extractLeadingCommand scans the trailing user message (Anthropic/OpenAI
+// shapes only) for a directive recognized by parse.
 func (env *RequestEnvelope) extractLeadingCommand(parse func(text string) (found bool, stripped string)) bool {
+	originalBody := env.body
+	found, fromToolResult := env.extractLeadingCommandWithSource(parse)
+	if fromToolResult {
+		env.body = originalBody
+		return false
+	}
+	return found
+}
+
+type commandTextCandidate struct {
+	path     string
+	dropPath string
+	text     string
+}
+
+// extractLeadingCommandWithSource returns whether the command came from a
+// tool-result turn as well as whether it matched.
+func (env *RequestEnvelope) extractLeadingCommandWithSource(parse func(text string) (found bool, stripped string)) (bool, bool) {
 	switch env.format {
 	case FormatAnthropic, FormatOpenAI:
 	default:
-		return false
+		return false, false
 	}
 	msgs := gjson.GetBytes(env.body, "messages")
 	if !msgs.IsArray() {
-		return false
+		return false, false
 	}
 
+	all := msgs.Array()
 	lastIdx := -1
 	var lastContent gjson.Result
-	msgs.ForEach(func(key, msg gjson.Result) bool {
-		if msg.Get("role").String() == "user" {
-			lastIdx = int(key.Int())
-			lastContent = msg.Get("content")
+	for i := len(all) - 1; i >= 0; i-- {
+		if all[i].Get("role").String() == "user" {
+			lastIdx = i
+			lastContent = all[i].Get("content")
+			break
 		}
-		return true
-	})
+	}
 	if lastIdx < 0 {
-		return false
+		return false, false
+	}
+	// Commands belong only to the request's trailing turn; historical commands
+	// must not be replayed after an assistant turn. Trailing non-conversational
+	// messages don't end the turn: Claude Code appends a role:"system" notice
+	// after the user turn, and treating that as a newer turn would disable the
+	// command entirely.
+	for i := lastIdx + 1; i < len(all); i++ {
+		if isConversationTurn(all[i].Get("role").String()) {
+			return false, false
+		}
 	}
 
-	idxStr := strconv.Itoa(lastIdx)
-
+	idxPath := "messages." + strconv.Itoa(lastIdx) + ".content"
+	fromToolResult := followsAssistantToolUse(all, lastIdx)
+	var candidates []commandTextCandidate
 	switch {
 	case lastContent.Type == gjson.String:
-		found, stripped := parse(lastContent.String())
-		if !found {
-			return false
-		}
-		if newBody, err := sjson.SetBytes(env.body, "messages."+idxStr+".content", stripped); err == nil {
-			env.body = newBody
-		}
-		return true
-
-	case lastContent.Type == gjson.JSON && lastContent.IsArray():
-		// Scan every text block: Claude Code sometimes splits the user turn
-		// into multiple parts (injected tags in one, typed directive in
-		// another), so checking only the first block could miss it.
-		type textBlock struct {
-			idx  int
-			text string
-		}
-		var blocks []textBlock
+		candidates = append(candidates, commandTextCandidate{
+			path: idxPath, dropPath: "messages." + strconv.Itoa(lastIdx), text: lastContent.String(),
+		})
+	case lastContent.IsArray():
 		lastContent.ForEach(func(key, block gjson.Result) bool {
-			if block.Get("type").String() == "text" {
-				blocks = append(blocks, textBlock{idx: int(key.Int()), text: block.Get("text").String()})
+			blockPath := idxPath + "." + strconv.Itoa(int(key.Int()))
+			switch block.Get("type").String() {
+			case "text":
+				candidates = append(candidates, commandTextCandidate{
+					path: blockPath + ".text", dropPath: blockPath, text: block.Get("text").String(),
+				})
+			case "tool_result":
+				fromToolResult = true
+				candidates = append(candidates, toolResultCommandCandidates(blockPath, block.Get("content"))...)
 			}
 			return true
 		})
-		for _, b := range blocks {
-			found, stripped := parse(b.text)
-			if !found {
-				continue
-			}
-			blockPath := "messages." + idxStr + ".content." + strconv.Itoa(b.idx) + ".text"
-			if newBody, err := sjson.SetBytes(env.body, blockPath, stripped); err == nil {
+	default:
+		return false, false
+	}
+
+	for _, candidate := range candidates {
+		found, stripped := parse(candidate.text)
+		if !found {
+			continue
+		}
+		if fromToolResult && stripped == "" && candidate.dropPath != "" {
+			if newBody, err := sjson.DeleteBytes(env.body, candidate.dropPath); err == nil {
 				env.body = newBody
 			}
-			return true
+		} else if newBody, err := sjson.SetBytes(env.body, candidate.path, stripped); err == nil {
+			env.body = newBody
 		}
-		return false
+		return true, fromToolResult
+	}
+	return false, false
+}
 
-	default:
+func toolResultCommandCandidates(blockPath string, content gjson.Result) []commandTextCandidate {
+	if content.Type == gjson.String {
+		return []commandTextCandidate{{path: blockPath + ".content", text: content.String()}}
+	}
+	if !content.IsArray() {
+		return nil
+	}
+	var candidates []commandTextCandidate
+	content.ForEach(func(key, part gjson.Result) bool {
+		if part.Get("type").String() == "text" {
+			candidates = append(candidates, commandTextCandidate{
+				path: blockPath + ".content." + strconv.Itoa(int(key.Int())) + ".text",
+				text: part.Get("text").String(),
+			})
+		}
+		return true
+	})
+	return candidates
+}
+
+// isConversationTurn reports whether role is part of the user/assistant
+// exchange, as opposed to an out-of-band notice the client interleaves.
+func isConversationTurn(role string) bool {
+	switch role {
+	case "user", "assistant", "tool":
+		return true
+	}
+	return false
+}
+
+func followsAssistantToolUse(messages []gjson.Result, userIdx int) bool {
+	prev := -1
+	for i := userIdx - 1; i >= 0; i-- {
+		if isConversationTurn(messages[i].Get("role").String()) {
+			prev = i
+			break
+		}
+	}
+	if prev < 0 || messages[prev].Get("role").String() != "assistant" {
 		return false
 	}
+	assistant := messages[prev]
+	if toolCalls := assistant.Get("tool_calls"); toolCalls.IsArray() && len(toolCalls.Array()) > 0 {
+		return true
+	}
+	content := assistant.Get("content")
+	if content.IsArray() {
+		for _, block := range content.Array() {
+			if block.Get("type").String() == "tool_use" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // parseForceModelCommand scans text for a /force-model (alias /fm) or

--- a/internal/translate/force_model_test.go
+++ b/internal/translate/force_model_test.go
@@ -309,6 +309,78 @@ func TestExtractForceModelCommand_AgentToolResultBlock(t *testing.T) {
 	assert.True(t, cmd.FromToolResult)
 }
 
+func TestExtractForceModelCommand_AgentSoleTextBlockDropsWholeMessage(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "analyze usage"},
+			map[string]any{
+				"role": "assistant",
+				"content": []any{map[string]any{
+					"type": "tool_use", "id": "toolu_skill", "name": "Skill", "input": map[string]any{"skill": "fm"},
+				}},
+			},
+			map[string]any{
+				"role":    "user",
+				"content": []any{map[string]any{"type": "text", "text": "/force-model opus"}},
+			},
+		},
+		"max_tokens": 1024,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	cmd, found := env.ExtractForceModelCommand()
+	require.True(t, found)
+	assert.Equal(t, "opus", cmd.Model)
+	assert.True(t, cmd.FromToolResult)
+
+	msgs := anthropicMessages(t, env)
+	require.Len(t, msgs, 2, "the command-only user message must be dropped, not left with empty content")
+	for _, msg := range msgs {
+		if blocks, ok := msg["content"].([]any); ok {
+			assert.NotEmpty(t, blocks, "no message may be left with an empty content array")
+		}
+	}
+}
+
+func TestExtractForceModelCommand_AgentToolResultSiblingBlockSurvives(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{
+				"role": "assistant",
+				"content": []any{map[string]any{
+					"type": "tool_use", "id": "toolu_skill", "name": "Skill", "input": map[string]any{"skill": "fm"},
+				}},
+			},
+			map[string]any{
+				"role": "user",
+				"content": []any{
+					map[string]any{"type": "tool_result", "tool_use_id": "toolu_skill", "content": "Launching skill: fm"},
+					map[string]any{"type": "text", "text": "/force-model opus"},
+				},
+			},
+		},
+		"max_tokens": 1024,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	cmd, found := env.ExtractForceModelCommand()
+	require.True(t, found)
+	assert.Equal(t, "opus", cmd.Model)
+	assert.True(t, cmd.FromToolResult)
+
+	msgs := anthropicMessages(t, env)
+	require.Len(t, msgs, 2)
+	blocks, ok := msgs[1]["content"].([]any)
+	require.True(t, ok)
+	require.Len(t, blocks, 1, "only the command block is dropped")
+	block, _ := blocks[0].(map[string]any)
+	assert.Equal(t, "tool_result", block["type"], "the tool_result pairing the assistant tool_use must survive")
+}
+
 func TestExtractForceModelCommand_TrailingSystemNoticeAfterUserTurn(t *testing.T) {
 	// Claude Code appends a role:"system" deferred-tools notice after the user
 	// turn; it must not make the user's command look historical.
@@ -467,6 +539,20 @@ func lastUserMessageArrayText(t *testing.T, env *translate.RequestEnvelope) stri
 		}
 	}
 	return ""
+}
+
+func anthropicMessages(t *testing.T, env *translate.RequestEnvelope) []map[string]any {
+	t.Helper()
+	var body map[string]any
+	raw, _ := env.PrepareAnthropic(nil, translate.EmitOptions{TargetModel: "claude-sonnet-4-6"})
+	require.NoError(t, json.Unmarshal(raw.Body, &body))
+	raws, _ := body["messages"].([]any)
+	msgs := make([]map[string]any, 0, len(raws))
+	for _, m := range raws {
+		msg, _ := m.(map[string]any)
+		msgs = append(msgs, msg)
+	}
+	return msgs
 }
 
 func mustMarshalJSON(t *testing.T, v any) []byte {

--- a/internal/translate/force_model_test.go
+++ b/internal/translate/force_model_test.go
@@ -381,6 +381,39 @@ func TestExtractForceModelCommand_AgentToolResultSiblingBlockSurvives(t *testing
 	assert.Equal(t, "tool_result", block["type"], "the tool_result pairing the assistant tool_use must survive")
 }
 
+func TestExtractForceModelCommand_OpenAIToolResult(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "gpt-4o",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "analyze usage"},
+			map[string]any{
+				"role": "assistant",
+				"tool_calls": []any{map[string]any{
+					"id": "call_skill", "type": "function",
+					"function": map[string]any{"name": "Skill", "arguments": `{"skill":"fm"}`},
+				}},
+			},
+			map[string]any{"role": "tool", "tool_call_id": "call_skill", "content": "/force-model gpt-5"},
+		},
+	})
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+
+	cmd, found := env.ExtractForceModelCommand()
+	require.True(t, found)
+	assert.Equal(t, "gpt-5", cmd.Model)
+	assert.True(t, cmd.FromToolResult)
+
+	prep, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "gpt-5"})
+	require.NoError(t, err)
+	var prepared map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &prepared))
+	msgs, _ := prepared["messages"].([]any)
+	require.Len(t, msgs, 3, "the tool message must remain to answer the assistant tool call")
+	tool, _ := msgs[2].(map[string]any)
+	assert.Equal(t, "", tool["content"], "only the command text is stripped")
+}
+
 func TestExtractForceModelCommand_TrailingSystemNoticeAfterUserTurn(t *testing.T) {
 	// Claude Code appends a role:"system" deferred-tools notice after the user
 	// turn; it must not make the user's command look historical.

--- a/internal/translate/force_model_test.go
+++ b/internal/translate/force_model_test.go
@@ -158,6 +158,7 @@ func TestParseForceModelCommand_ForceModel(t *testing.T) {
 			}
 			assert.Equal(t, tt.wantModel, res.Model)
 			assert.False(t, res.Clear)
+			assert.False(t, res.FromToolResult)
 
 			// Verify the command was stripped from env body.
 			stripped := lastUserMessageText(t, env)
@@ -254,6 +255,131 @@ func TestExtractForceModelCommand_ArrayContentMultipleTextBlocks(t *testing.T) {
 	require.Len(t, blocks, 2)
 	second, _ := blocks[1].(map[string]any)
 	assert.Equal(t, "", second["text"], "the directive-bearing text block must be stripped")
+}
+
+func TestExtractForceModelCommand_AgentToolResultString(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{
+				"role": "assistant",
+				"content": []any{map[string]any{
+					"type": "tool_use", "id": "toolu_skill", "name": "Skill", "input": map[string]any{"skill": "fm"},
+				}},
+			},
+			map[string]any{"role": "user", "content": "/force-model opus"},
+		},
+		"max_tokens": 1024,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	cmd, found := env.ExtractForceModelCommand()
+	require.True(t, found)
+	assert.Equal(t, "opus", cmd.Model)
+	assert.True(t, cmd.FromToolResult)
+	assert.Equal(t, "", lastUserMessageText(t, env))
+}
+
+func TestExtractForceModelCommand_AgentToolResultBlock(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{
+				"role": "assistant",
+				"content": []any{map[string]any{
+					"type": "tool_use", "id": "toolu_skill", "name": "Skill", "input": map[string]any{"skill": "fm"},
+				}},
+			},
+			map[string]any{
+				"role": "user",
+				"content": []any{map[string]any{
+					"type": "tool_result", "tool_use_id": "toolu_skill", "content": "/force-model opus",
+				}},
+			},
+		},
+		"max_tokens": 1024,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	cmd, found := env.ExtractForceModelCommand()
+	require.True(t, found)
+	assert.Equal(t, "opus", cmd.Model)
+	assert.True(t, cmd.FromToolResult)
+}
+
+func TestExtractForceModelCommand_TrailingSystemNoticeAfterUserTurn(t *testing.T) {
+	// Claude Code appends a role:"system" deferred-tools notice after the user
+	// turn; it must not make the user's command look historical.
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{
+				"role": "user",
+				"content": []any{
+					map[string]any{"type": "text", "text": "<system-reminder>context</system-reminder>"},
+					map[string]any{"type": "text", "text": "/force-model opus"},
+				},
+			},
+			map[string]any{"role": "system", "content": "The following deferred tools are now available."},
+		},
+		"max_tokens": 1024,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	cmd, found := env.ExtractForceModelCommand()
+	require.True(t, found)
+	assert.Equal(t, "opus", cmd.Model)
+	assert.False(t, cmd.FromToolResult, "a typed command is not agent-issued")
+}
+
+func TestExtractForceModelCommand_AgentToolResultWithTrailingSystemNotice(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "do the thing"},
+			map[string]any{"role": "system", "content": "deferred tools notice"},
+			map[string]any{
+				"role": "assistant",
+				"content": []any{map[string]any{
+					"type": "tool_use", "id": "toolu_skill", "name": "Skill", "input": map[string]any{"skill": "fm"},
+				}},
+			},
+			map[string]any{
+				"role": "user",
+				"content": []any{map[string]any{
+					"type": "tool_result", "tool_use_id": "toolu_skill", "content": "/force-model opus",
+				}},
+			},
+			map[string]any{"role": "system", "content": "deferred tools notice"},
+		},
+		"max_tokens": 1024,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	cmd, found := env.ExtractForceModelCommand()
+	require.True(t, found)
+	assert.Equal(t, "opus", cmd.Model)
+	assert.True(t, cmd.FromToolResult, "an interleaved system notice must not hide tool provenance")
+}
+
+func TestExtractForceModelCommand_IgnoresHistoricalCommand(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "/force-model opus"},
+			map[string]any{"role": "assistant", "content": "Acknowledged."},
+		},
+		"max_tokens": 1024,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	_, found := env.ExtractForceModelCommand()
+	assert.False(t, found, "a command from an earlier turn must not be replayed")
 }
 
 func TestExtractForceModelCommand_NoUserMessage(t *testing.T) {


### PR DESCRIPTION
## Summary

- distinguish user-issued force-model commands from commands returned by an agent tool invocation
- short-circuit user commands while applying agent-issued pins and continuing the same request on the selected model
- prevent historical commands from replaying while preserving Claude Code's trailing system notices
- cover Anthropic and OpenAI ingress paths with regression tests

## Testing

- `go test ./...`
- `go vet ./...`
- local Docker router driven by `claude -p`, including a cross-provider agent pin to `gpt-5.5`

🤖 Generated with [Weave Router](https://router.workweave.ai)