### PR TITLE
fix: persist OpenAI GPT-5.6 cache_write_tokens

### DIFF
--- a/internal/observability/otel/usage.go
+++ b/internal/observability/otel/usage.go
@@ -105,8 +105,8 @@ func (u *UsageExtractor) RecordUsage(inputTokens, outputTokens int) {
 	}
 }
 
-// RecordCacheUsage sets cache token counts directly. OpenAI has no cache-creation
-// concept, so callers pass 0 for cacheCreationTokens.
+// RecordCacheUsage sets cache token counts directly. Pass 0 for a field the
+// provider does not emit.
 func (u *UsageExtractor) RecordCacheUsage(cacheCreationTokens, cacheReadTokens int) {
 	if cacheCreationTokens > 0 {
 		u.cacheCreation = cacheCreationTokens
@@ -248,7 +248,7 @@ func (u *UsageExtractor) tryExtractFromJSON() {
 }
 
 // extractUsageGJSON probes usage fields via gjson (no json.Unmarshal/map allocs).
-// OpenAI has no cache-creation field; cacheRead maps from cached_tokens.
+// OpenAI cache-read maps from cached_tokens; GPT-5.6+ cache-write maps from cache_write_tokens.
 // Google's native :generateContent uses usageMetadata; its OpenAI-compat surface
 // uses the OpenAI shape instead.
 func extractUsageGJSON(data []byte, provider string) (input, output, cacheCreation, cacheRead int, found bool) {
@@ -288,15 +288,39 @@ func extractUsageGJSON(data []byte, provider string) (input, output, cacheCreati
 		if pt := usage.Get("prompt_tokens"); pt.Exists() {
 			input = int(pt.Int())
 			output = int(usage.Get("completion_tokens").Int())
-			cacheRead = int(usage.Get("prompt_tokens_details.cached_tokens").Int())
 		} else {
 			input = int(usage.Get("input_tokens").Int())
 			output = int(usage.Get("output_tokens").Int())
-			cacheRead = int(usage.Get("input_tokens_details.cached_tokens").Int())
 		}
+		cacheCreation, cacheRead = openaiCacheTokens(usage)
 	default:
 		return 0, 0, 0, 0, false
 	}
 
 	return input, output, cacheCreation, cacheRead, true
+}
+
+// openaiCacheTokens mirrors translate.OpenAICacheTokens. Duplicated here so
+// otel does not import translate (translate already imports observability).
+func openaiCacheTokens(usage gjson.Result) (cacheWrite, cacheRead int) {
+	if !usage.Exists() {
+		return 0, 0
+	}
+	for _, prefix := range []string{"input_tokens_details", "prompt_tokens_details"} {
+		details := usage.Get(prefix)
+		if !details.Exists() {
+			continue
+		}
+		if cacheRead == 0 {
+			cacheRead = int(details.Get("cached_tokens").Int())
+		}
+		if cacheWrite == 0 {
+			if w := details.Get("cache_write_tokens"); w.Exists() {
+				cacheWrite = int(w.Int())
+			} else {
+				cacheWrite = int(details.Get("cache_creation_tokens").Int())
+			}
+		}
+	}
+	return cacheWrite, cacheRead
 }

--- a/internal/observability/otel/usage_test.go
+++ b/internal/observability/otel/usage_test.go
@@ -97,8 +97,26 @@ func TestUsageExtractor_OpenAIResponsesStreaming(t *testing.T) {
 	in, out := ext.Tokens()
 	assert.Equal(t, 120, in)
 	assert.Equal(t, 34, out)
-	_, cacheRead := ext.CacheTokens()
+	cacheCreation, cacheRead := ext.CacheTokens()
+	assert.Equal(t, 0, cacheCreation)
 	assert.Equal(t, 40, cacheRead, "Responses cached_tokens must map to cache-read for accurate subscription billing")
+}
+
+func TestUsageExtractor_OpenAIResponsesCacheWriteTokens(t *testing.T) {
+	rec := httptest.NewRecorder()
+	ext := otel.NewUsageExtractor(rec, "openai")
+
+	events := []string{
+		"event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"usage\":{\"input_tokens\":1200,\"output_tokens\":34,\"input_tokens_details\":{\"cached_tokens\":800,\"cache_write_tokens\":256}}}}\n\n",
+	}
+	for _, e := range events {
+		_, err := ext.Write([]byte(e))
+		require.NoError(t, err)
+	}
+
+	cacheCreation, cacheRead := ext.CacheTokens()
+	assert.Equal(t, 256, cacheCreation, "GPT-5.6 cache_write_tokens must map to cache-creation for 1.25x billing")
+	assert.Equal(t, 800, cacheRead)
 }
 
 func TestUsageExtractor_OpenAIResponsesNonStreaming(t *testing.T) {
@@ -199,7 +217,7 @@ func TestUsageExtractor_OpenAICacheTokens_NonStreaming(t *testing.T) {
 	ext := otel.NewUsageExtractor(rec, "openai")
 
 	// OpenAI exposes cached prompt tokens via prompt_tokens_details.cached_tokens.
-	// There is no creation analogue, so cache_creation stays at 0.
+	// GPT-5.4 and earlier have no write field, so cache_creation stays at 0.
 	body := `{"id":"chatcmpl-2","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":15,"completion_tokens":8,"total_tokens":23,"prompt_tokens_details":{"cached_tokens":42}}}`
 	_, err := ext.Write([]byte(body))
 	require.NoError(t, err)
@@ -210,6 +228,19 @@ func TestUsageExtractor_OpenAICacheTokens_NonStreaming(t *testing.T) {
 
 	cacheCreation, cacheRead := ext.CacheTokens()
 	assert.Equal(t, 0, cacheCreation)
+	assert.Equal(t, 42, cacheRead)
+}
+
+func TestUsageExtractor_OpenAIChatCompletionsCacheWriteTokens(t *testing.T) {
+	rec := httptest.NewRecorder()
+	ext := otel.NewUsageExtractor(rec, "openai")
+
+	body := `{"id":"chatcmpl-2","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":80,"completion_tokens":8,"prompt_tokens_details":{"cached_tokens":42,"cache_write_tokens":16}}}`
+	_, err := ext.Write([]byte(body))
+	require.NoError(t, err)
+
+	cacheCreation, cacheRead := ext.CacheTokens()
+	assert.Equal(t, 16, cacheCreation)
 	assert.Equal(t, 42, cacheRead)
 }
 

--- a/internal/proxy/testdata/conformance/responses/toolcall_nonstream_client.golden
+++ b/internal/proxy/testdata/conformance/responses/toolcall_nonstream_client.golden
@@ -26,7 +26,6 @@
     "stop_sequence": null,
     "type": "message",
     "usage": {
-      "cache_read_input_tokens": 0,
       "input_tokens": 150,
       "output_tokens": 45
     }

--- a/internal/translate/cache_usage_test.go
+++ b/internal/translate/cache_usage_test.go
@@ -285,3 +285,23 @@ func TestOpenAICacheTokens_FallsBackToCacheCreationTokens(t *testing.T) {
 func gjsonMust(raw string) gjson.Result {
 	return gjson.Parse(raw)
 }
+
+func TestResponsesToAnthropicWriter_NonStreamingSinkKeepsInclusiveInput(t *testing.T) {
+	const fixture = `event: response.completed
+data: {"type":"response.completed","response":{"id":"r","status":"completed","model":"gpt-5.6-sol","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}],"usage":{"input_tokens":1200,"input_tokens_details":{"cached_tokens":800,"cache_write_tokens":256},"output_tokens":340}}}
+
+`
+	rec := httptest.NewRecorder()
+	sink := &fakeUsageSink{}
+	w := translate.NewResponsesToAnthropicWriter(rec, "gpt-5.6-sol", sink)
+	require.NoError(t, w.Prelude(false))
+	_, err := w.Write([]byte(fixture))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	assert.Equal(t, 1200, sink.input, "billing sink must keep OpenAI inclusive input_tokens")
+	assert.Equal(t, 256, sink.cacheCreation)
+	assert.Equal(t, 800, sink.cacheRead)
+	assert.Contains(t, rec.Body.String(), `"input_tokens":144`)
+	assert.Contains(t, rec.Body.String(), `"cache_creation_input_tokens":256`)
+}

--- a/internal/translate/cache_usage_test.go
+++ b/internal/translate/cache_usage_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 
 	"workweave/router/internal/translate"
 )
@@ -218,4 +219,69 @@ func TestSSETranslator_SinkAccumulatesInputAndOutputAcrossStream(t *testing.T) {
 	}
 
 	assert.Equal(t, 17, sink.output, "sink must record output tokens from message_delta")
+}
+
+func TestAnthropicSSETranslator_ForwardsOpenAICacheWriteTokens(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sink := &fakeUsageSink{}
+	translator := translate.NewAnthropicSSETranslator(rec, "gpt-5.6-sol", sink)
+
+	translator.Header().Set("Content-Type", "text/event-stream")
+	translator.WriteHeader(http.StatusOK)
+
+	events := []string{
+		"data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"hi\"},\"finish_reason\":null}]}\n\n",
+		"data: {\"id\":\"chatcmpl-1\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":80,\"completion_tokens\":12,\"prompt_tokens_details\":{\"cached_tokens\":64,\"cache_write_tokens\":16}}}\n\n",
+		"data: [DONE]\n\n",
+	}
+	for _, e := range events {
+		_, err := translator.Write([]byte(e))
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, 16, sink.cacheCreation)
+	assert.Equal(t, 64, sink.cacheRead)
+	assert.Contains(t, rec.Body.String(), `"cache_creation_input_tokens":16`)
+	assert.Contains(t, rec.Body.String(), `"cache_read_input_tokens":64`)
+}
+
+func TestResponsesToAnthropicWriter_ForwardsCacheWriteTokens(t *testing.T) {
+	const fixture = `event: response.completed
+data: {"type":"response.completed","response":{"id":"r","status":"completed","model":"gpt-5.6-sol","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}],"usage":{"input_tokens":1200,"input_tokens_details":{"cached_tokens":800,"cache_write_tokens":256},"output_tokens":340}}}
+
+`
+	rec := httptest.NewRecorder()
+	sink := &fakeUsageSink{}
+	w := translate.NewResponsesToAnthropicWriter(rec, "gpt-5.6-sol", sink)
+	require.NoError(t, w.Prelude(true))
+	_, err := w.Write([]byte(fixture))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	assert.Equal(t, 256, sink.cacheCreation)
+	assert.Equal(t, 800, sink.cacheRead)
+	got := w.Summary()
+	assert.Equal(t, 256, got.CacheCreationTokens)
+	assert.Equal(t, 800, got.CacheReadTokens)
+	body := rec.Body.String()
+	assert.Contains(t, body, `"cache_creation_input_tokens":256`)
+	assert.Contains(t, body, `"cache_read_input_tokens":800`)
+}
+
+func TestOpenAICacheTokens_PrefersCacheWriteTokens(t *testing.T) {
+	usage := gjsonMust(`{"input_tokens_details":{"cached_tokens":10,"cache_write_tokens":4,"cache_creation_tokens":99}}`)
+	w, r := translate.OpenAICacheTokens(usage)
+	assert.Equal(t, 4, w)
+	assert.Equal(t, 10, r)
+}
+
+func TestOpenAICacheTokens_FallsBackToCacheCreationTokens(t *testing.T) {
+	usage := gjsonMust(`{"prompt_tokens_details":{"cached_tokens":7,"cache_creation_tokens":3}}`)
+	w, r := translate.OpenAICacheTokens(usage)
+	assert.Equal(t, 3, w)
+	assert.Equal(t, 7, r)
+}
+
+func gjsonMust(raw string) gjson.Result {
+	return gjson.Parse(raw)
 }

--- a/internal/translate/openai_cache_usage.go
+++ b/internal/translate/openai_cache_usage.go
@@ -3,10 +3,8 @@ package translate
 import "github.com/tidwall/gjson"
 
 // OpenAICacheTokens extracts cache-write and cache-read counts from an OpenAI
-// usage object. GPT-5.6+ reports writes as cache_write_tokens (Responses:
-// input_tokens_details; Chat Completions: prompt_tokens_details). Older
-// shapes only have cached_tokens. cache_creation_tokens is accepted as a
-// fallback for OpenAI-compat hosts that already emit our internal name.
+// usage object. GPT-5.6+ reports cache_write_tokens; cache_creation_tokens is
+// a compat fallback for hosts that already emit our internal name.
 func OpenAICacheTokens(usage gjson.Result) (cacheWrite, cacheRead int) {
 	if !usage.Exists() {
 		return 0, 0

--- a/internal/translate/openai_cache_usage.go
+++ b/internal/translate/openai_cache_usage.go
@@ -1,0 +1,31 @@
+package translate
+
+import "github.com/tidwall/gjson"
+
+// OpenAICacheTokens extracts cache-write and cache-read counts from an OpenAI
+// usage object. GPT-5.6+ reports writes as cache_write_tokens (Responses:
+// input_tokens_details; Chat Completions: prompt_tokens_details). Older
+// shapes only have cached_tokens. cache_creation_tokens is accepted as a
+// fallback for OpenAI-compat hosts that already emit our internal name.
+func OpenAICacheTokens(usage gjson.Result) (cacheWrite, cacheRead int) {
+	if !usage.Exists() {
+		return 0, 0
+	}
+	for _, prefix := range []string{"input_tokens_details", "prompt_tokens_details"} {
+		details := usage.Get(prefix)
+		if !details.Exists() {
+			continue
+		}
+		if cacheRead == 0 {
+			cacheRead = int(details.Get("cached_tokens").Int())
+		}
+		if cacheWrite == 0 {
+			if w := details.Get("cache_write_tokens"); w.Exists() {
+				cacheWrite = int(w.Int())
+			} else {
+				cacheWrite = int(details.Get("cache_creation_tokens").Int())
+			}
+		}
+	}
+	return cacheWrite, cacheRead
+}

--- a/internal/translate/responses_outbound_test.go
+++ b/internal/translate/responses_outbound_test.go
@@ -377,7 +377,7 @@ func TestResponsesToAnthropicResponse(t *testing.T) {
 	input, _ := b2["input"].(map[string]any)
 	assert.Equal(t, "go test", input["command"], "arguments string parsed back to an input object")
 	usage, _ := msg["usage"].(map[string]any)
-	assert.EqualValues(t, 1200, usage["input_tokens"])
+	assert.EqualValues(t, 144, usage["input_tokens"], "Anthropic input_tokens is fresh-only")
 	assert.EqualValues(t, 340, usage["output_tokens"])
 	assert.EqualValues(t, 800, usage["cache_read_input_tokens"])
 	assert.EqualValues(t, 256, usage["cache_creation_input_tokens"])

--- a/internal/translate/responses_outbound_test.go
+++ b/internal/translate/responses_outbound_test.go
@@ -343,7 +343,7 @@ func TestResponsesToAnthropicResponse(t *testing.T) {
         {"type":"message","id":"m1","role":"assistant","content":[{"type":"output_text","text":"here is the fix"}]},
         {"type":"function_call","id":"fc1","call_id":"call_9","name":"bash","arguments":"{\"command\":\"go test\"}"}
       ],
-      "usage":{"input_tokens":1200,"output_tokens":340,"output_tokens_details":{"reasoning_tokens":256},"input_tokens_details":{"cached_tokens":800}}
+      "usage":{"input_tokens":1200,"output_tokens":340,"output_tokens_details":{"reasoning_tokens":256},"input_tokens_details":{"cached_tokens":800,"cache_write_tokens":256}}
     }`)
 	out, err := translate.ResponsesToAnthropicResponse(body, "gpt-5.5")
 	require.NoError(t, err)
@@ -380,6 +380,7 @@ func TestResponsesToAnthropicResponse(t *testing.T) {
 	assert.EqualValues(t, 1200, usage["input_tokens"])
 	assert.EqualValues(t, 340, usage["output_tokens"])
 	assert.EqualValues(t, 800, usage["cache_read_input_tokens"])
+	assert.EqualValues(t, 256, usage["cache_creation_input_tokens"])
 }
 
 func TestResponsesToAnthropicResponse_StopReasons(t *testing.T) {

--- a/internal/translate/responses_response.go
+++ b/internal/translate/responses_response.go
@@ -143,9 +143,14 @@ func responsesToAnthropicResponse(body []byte, requestModel string, toolValidato
 	jw.Int(usage.Get("input_tokens").Int())
 	jw.Key("output_tokens")
 	jw.Int(usage.Get("output_tokens").Int())
-	if cached := usage.Get("input_tokens_details.cached_tokens"); cached.Exists() {
+	cacheWrite, cacheRead := OpenAICacheTokens(usage)
+	if cacheWrite > 0 {
+		jw.Key("cache_creation_input_tokens")
+		jw.Int(int64(cacheWrite))
+	}
+	if cacheRead > 0 {
 		jw.Key("cache_read_input_tokens")
-		jw.Int(cached.Int())
+		jw.Int(int64(cacheRead))
 	}
 	jw.EndObj()
 

--- a/internal/translate/responses_response.go
+++ b/internal/translate/responses_response.go
@@ -137,13 +137,17 @@ func responsesToAnthropicResponse(body []byte, requestModel string, toolValidato
 	jw.Null()
 
 	usage := root.Get("usage")
+	cacheWrite, cacheRead := OpenAICacheTokens(usage)
+	freshInput := usage.Get("input_tokens").Int() - int64(cacheWrite) - int64(cacheRead)
+	if freshInput < 0 {
+		freshInput = 0
+	}
 	jw.Key("usage")
 	jw.Obj()
 	jw.Key("input_tokens")
-	jw.Int(usage.Get("input_tokens").Int())
+	jw.Int(freshInput)
 	jw.Key("output_tokens")
 	jw.Int(usage.Get("output_tokens").Int())
-	cacheWrite, cacheRead := OpenAICacheTokens(usage)
 	if cacheWrite > 0 {
 		jw.Key("cache_creation_input_tokens")
 		jw.Int(int64(cacheWrite))

--- a/internal/translate/responses_to_anthropic_writer.go
+++ b/internal/translate/responses_to_anthropic_writer.go
@@ -663,9 +663,11 @@ func (t *ResponsesToAnthropicWriter) finalizeBuffered() error {
 		return t.finalizeError()
 	}
 	root := gjson.ParseBytes(anthropic)
-	t.recordBufferedUsage(root.Get("usage"))
+	// Record the original OpenAI usage (cache-inclusive input). The
+	// Anthropic body below is fresh-only for the client/statusline;
+	// EffectiveInputCost subtracts cache from the sink's inclusive count.
+	t.recordOpenAIUsage(resp.Get("usage"))
 	t.emittedStopReason = root.Get("stop_reason").String()
-	t.captureBufferedUsage(root.Get("usage"))
 	root.Get("content").ForEach(func(_, block gjson.Result) bool {
 		if block.Get("type").String() == "tool_use" {
 			t.toolUseCount++
@@ -680,26 +682,18 @@ func (t *ResponsesToAnthropicWriter) finalizeBuffered() error {
 	return err
 }
 
-func (t *ResponsesToAnthropicWriter) captureBufferedUsage(usage gjson.Result) {
+func (t *ResponsesToAnthropicWriter) recordOpenAIUsage(usage gjson.Result) {
 	if !usage.Exists() {
 		return
 	}
 	t.hasUsage = true
 	t.usageInput = int(usage.Get("input_tokens").Int())
 	t.usageOutput = int(usage.Get("output_tokens").Int())
-	t.usageCacheRead = int(usage.Get("cache_read_input_tokens").Int())
-	t.usageCacheCreation = int(usage.Get("cache_creation_input_tokens").Int())
-}
-
-func (t *ResponsesToAnthropicWriter) recordBufferedUsage(usage gjson.Result) {
-	if t.usageSink == nil || !usage.Exists() {
-		return
+	t.usageCacheCreation, t.usageCacheRead = OpenAICacheTokens(usage)
+	if t.usageSink != nil {
+		t.usageSink.RecordUsage(t.usageInput, t.usageOutput)
+		t.usageSink.RecordCacheUsage(t.usageCacheCreation, t.usageCacheRead)
 	}
-	t.usageSink.RecordUsage(int(usage.Get("input_tokens").Int()), int(usage.Get("output_tokens").Int()))
-	t.usageSink.RecordCacheUsage(
-		int(usage.Get("cache_creation_input_tokens").Int()),
-		int(usage.Get("cache_read_input_tokens").Int()),
-	)
 }
 
 // finalizeError renders a one-shot Anthropic error body. Streaming errors are

--- a/internal/translate/responses_to_anthropic_writer.go
+++ b/internal/translate/responses_to_anthropic_writer.go
@@ -663,9 +663,8 @@ func (t *ResponsesToAnthropicWriter) finalizeBuffered() error {
 		return t.finalizeError()
 	}
 	root := gjson.ParseBytes(anthropic)
-	// Record the original OpenAI usage (cache-inclusive input). The
-	// Anthropic body below is fresh-only for the client/statusline;
-	// EffectiveInputCost subtracts cache from the sink's inclusive count.
+	// Anthropic body is fresh-only for the client; sink keeps OpenAI's cache-inclusive
+	// count so EffectiveInputCost can apply the correct multipliers.
 	t.recordOpenAIUsage(resp.Get("usage"))
 	t.emittedStopReason = root.Get("stop_reason").String()
 	root.Get("content").ForEach(func(_, block gjson.Result) bool {

--- a/internal/translate/responses_to_anthropic_writer.go
+++ b/internal/translate/responses_to_anthropic_writer.go
@@ -82,11 +82,12 @@ type ResponsesToAnthropicWriter struct {
 	toolCallIssues []toolcheck.Issue
 
 	// Captured from the terminal response.completed/.failed/.incomplete event.
-	finalStopReason string
-	hasUsage        bool
-	usageInput      int
-	usageOutput     int
-	usageCacheRead  int
+	finalStopReason    string
+	hasUsage           bool
+	usageInput         int
+	usageOutput        int
+	usageCacheRead     int
+	usageCacheCreation int
 
 	// Summary fields.
 	toolUseCount      int
@@ -238,12 +239,13 @@ func (t *ResponsesToAnthropicWriter) Finalize() error {
 
 func (t *ResponsesToAnthropicWriter) Summary() ResponseSummary {
 	return ResponseSummary{
-		StopReason:      t.emittedStopReason,
-		ToolUseBlocks:   t.toolUseCount,
-		ToolCallIssues:  t.toolCallIssues,
-		OutputTokens:    t.usageOutput,
-		InputTokens:     t.usageInput,
-		CacheReadTokens: t.usageCacheRead,
+		StopReason:          t.emittedStopReason,
+		ToolUseBlocks:       t.toolUseCount,
+		ToolCallIssues:      t.toolCallIssues,
+		OutputTokens:        t.usageOutput,
+		InputTokens:         t.usageInput,
+		CacheReadTokens:     t.usageCacheRead,
+		CacheCreationTokens: t.usageCacheCreation,
 	}
 }
 
@@ -574,10 +576,10 @@ func (t *ResponsesToAnthropicWriter) captureFinalResponse(data []byte) {
 		t.hasUsage = true
 		t.usageInput = int(usage.Get("input_tokens").Int())
 		t.usageOutput = int(usage.Get("output_tokens").Int())
-		t.usageCacheRead = int(usage.Get("input_tokens_details.cached_tokens").Int())
+		t.usageCacheCreation, t.usageCacheRead = OpenAICacheTokens(usage)
 		if t.usageSink != nil {
 			t.usageSink.RecordUsage(t.usageInput, t.usageOutput)
-			t.usageSink.RecordCacheUsage(0, t.usageCacheRead)
+			t.usageSink.RecordCacheUsage(t.usageCacheCreation, t.usageCacheRead)
 		}
 	}
 }
@@ -686,6 +688,7 @@ func (t *ResponsesToAnthropicWriter) captureBufferedUsage(usage gjson.Result) {
 	t.usageInput = int(usage.Get("input_tokens").Int())
 	t.usageOutput = int(usage.Get("output_tokens").Int())
 	t.usageCacheRead = int(usage.Get("cache_read_input_tokens").Int())
+	t.usageCacheCreation = int(usage.Get("cache_creation_input_tokens").Int())
 }
 
 func (t *ResponsesToAnthropicWriter) recordBufferedUsage(usage gjson.Result) {
@@ -693,7 +696,10 @@ func (t *ResponsesToAnthropicWriter) recordBufferedUsage(usage gjson.Result) {
 		return
 	}
 	t.usageSink.RecordUsage(int(usage.Get("input_tokens").Int()), int(usage.Get("output_tokens").Int()))
-	t.usageSink.RecordCacheUsage(0, int(usage.Get("cache_read_input_tokens").Int()))
+	t.usageSink.RecordCacheUsage(
+		int(usage.Get("cache_creation_input_tokens").Int()),
+		int(usage.Get("cache_read_input_tokens").Int()),
+	)
 }
 
 // finalizeError renders a one-shot Anthropic error body. Streaming errors are
@@ -998,13 +1004,17 @@ func (t *ResponsesToAnthropicWriter) emitMessageDelta(stopReason string) error {
 	sse.WriteJSONString(t.bw, stopReason)
 	t.bw.WriteString(",\"stop_sequence\":null},\"usage\":{")
 	if t.hasUsage {
-		// Anthropic's input_tokens is fresh-only; subtract cached reads so the
+		// Anthropic's input_tokens is fresh-only; subtract cache so the
 		// statusline formula doesn't double-count.
-		freshInput := max(0, t.usageInput-t.usageCacheRead)
+		freshInput := max(0, t.usageInput-t.usageCacheCreation-t.usageCacheRead)
 		t.bw.WriteString("\"input_tokens\":")
 		sse.WriteJSONInt(t.bw, int64(freshInput))
 		t.bw.WriteString(",\"output_tokens\":")
 		sse.WriteJSONInt(t.bw, int64(t.usageOutput))
+		if t.usageCacheCreation > 0 {
+			t.bw.WriteString(",\"cache_creation_input_tokens\":")
+			sse.WriteJSONInt(t.bw, int64(t.usageCacheCreation))
+		}
 		if t.usageCacheRead > 0 {
 			t.bw.WriteString(",\"cache_read_input_tokens\":")
 			sse.WriteJSONInt(t.bw, int64(t.usageCacheRead))

--- a/internal/translate/responses_to_anthropic_writer_stream_test.go
+++ b/internal/translate/responses_to_anthropic_writer_stream_test.go
@@ -216,6 +216,7 @@ data: {"type":"response.completed","response":{"id":"r","status":"completed","mo
 	assert.Equal(t, 1200, got.InputTokens)
 	assert.Equal(t, 340, got.OutputTokens)
 	assert.Equal(t, 800, got.CacheReadTokens)
+	assert.Equal(t, 0, got.CacheCreationTokens)
 }
 
 // No delta events: falls back to item.arguments on output_item.done, not {}.

--- a/internal/translate/responses_to_anthropic_writer_stream_test.go
+++ b/internal/translate/responses_to_anthropic_writer_stream_test.go
@@ -213,7 +213,7 @@ data: {"type":"response.completed","response":{"id":"r","status":"completed","mo
 	require.NoError(t, w.Finalize())
 
 	got := w.Summary()
-	assert.Equal(t, 1200, got.InputTokens)
+	assert.Equal(t, 400, got.InputTokens, "non-streaming Anthropic usage is fresh-only")
 	assert.Equal(t, 340, got.OutputTokens)
 	assert.Equal(t, 800, got.CacheReadTokens)
 	assert.Equal(t, 0, got.CacheCreationTokens)

--- a/internal/translate/responses_to_anthropic_writer_stream_test.go
+++ b/internal/translate/responses_to_anthropic_writer_stream_test.go
@@ -213,7 +213,7 @@ data: {"type":"response.completed","response":{"id":"r","status":"completed","mo
 	require.NoError(t, w.Finalize())
 
 	got := w.Summary()
-	assert.Equal(t, 400, got.InputTokens, "non-streaming Anthropic usage is fresh-only")
+	assert.Equal(t, 1200, got.InputTokens, "summary keeps OpenAI inclusive input for billing")
 	assert.Equal(t, 340, got.OutputTokens)
 	assert.Equal(t, 800, got.CacheReadTokens)
 	assert.Equal(t, 0, got.CacheCreationTokens)

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -653,6 +653,9 @@ type ResponseSummary struct {
 	// CacheReadTokens is cache_read_input_tokens (Anthropic) or cached_tokens
 	// (OpenAI), when reported.
 	CacheReadTokens int
+	// CacheCreationTokens is cache_creation_input_tokens (Anthropic) or
+	// cache_write_tokens (OpenAI GPT-5.6+), when reported.
+	CacheCreationTokens int
 }
 
 // Summary returns the response summary for observability. Call after Finalize;
@@ -671,6 +674,7 @@ func (t *AnthropicSSETranslator) Summary() ResponseSummary {
 		OutputTokens:          t.usageOutputTokens,
 		InputTokens:           t.usageInputTokens,
 		CacheReadTokens:       t.usageCacheReadTokens,
+		CacheCreationTokens:   t.usageCacheCreationTokens,
 	}
 }
 
@@ -815,10 +819,8 @@ func (t *AnthropicSSETranslator) Finalize() error {
 				int(usage.Get("prompt_tokens").Int()),
 				int(usage.Get("completion_tokens").Int()),
 			)
-			t.usageSink.RecordCacheUsage(
-				int(usage.Get("prompt_tokens_details.cache_creation_tokens").Int()),
-				int(usage.Get("prompt_tokens_details.cached_tokens").Int()),
-			)
+			cw, cr := OpenAICacheTokens(usage)
+			t.usageSink.RecordCacheUsage(cw, cr)
 		}
 	}
 
@@ -943,16 +945,15 @@ func (t *AnthropicSSETranslator) extractAndForwardUsage(data []byte) {
 	}
 	prompt := usage.Get("prompt_tokens").Int()
 	completion := usage.Get("completion_tokens").Int()
-	cachedRead := usage.Get("prompt_tokens_details.cached_tokens").Int()
+	cacheCreation, cachedRead := OpenAICacheTokens(usage)
 	t.usageInputTokens = int(prompt)
 	t.usageOutputTokens = int(completion)
-	cacheCreation := usage.Get("prompt_tokens_details.cache_creation_tokens").Int()
-	t.usageCacheCreationTokens = int(cacheCreation)
-	t.usageCacheReadTokens = int(cachedRead)
+	t.usageCacheCreationTokens = cacheCreation
+	t.usageCacheReadTokens = cachedRead
 	t.hasUsage = true
 	if t.usageSink != nil {
 		t.usageSink.RecordUsage(int(prompt), int(completion))
-		t.usageSink.RecordCacheUsage(int(cacheCreation), int(cachedRead))
+		t.usageSink.RecordCacheUsage(cacheCreation, cachedRead)
 	}
 }
 

--- a/internal/translate/translate.go
+++ b/internal/translate/translate.go
@@ -358,8 +358,9 @@ func openAIFinishToAnthropicStopReason(s string) string {
 func writeAnthropicUsageFromOpenAI(jw *jsonWriter, usage gjson.Result) {
 	prompt := usage.Get("prompt_tokens").Int()
 	completion := usage.Get("completion_tokens").Int()
-	cacheRead := usage.Get("prompt_tokens_details.cached_tokens").Int()
-	cacheCreation := usage.Get("prompt_tokens_details.cache_creation_tokens").Int()
+	cacheWrite, cacheReadN := OpenAICacheTokens(usage)
+	cacheCreation := int64(cacheWrite)
+	cacheRead := int64(cacheReadN)
 
 	freshInput := prompt - cacheCreation - cacheRead
 	if freshInput < 0 {


### PR DESCRIPTION
GPT-5.6 Responses reports cache writes as `input_tokens_details.cache_write_tokens` (billed at 1.25×). We only parsed `cached_tokens` and hardcoded write=0, so telemetry, cost, and the Claude Code statusline showed **0 cache write** on every GPT turn even when cache was working (~97% read hit on the sessions that prompted this).

## What changed
- Shared `OpenAICacheTokens` helper reads `cache_write_tokens` (preferred) or `cache_creation_tokens` (compat fallback) from both Responses `input_tokens_details` and Chat Completions `prompt_tokens_details`.
- Responses → Anthropic streaming/non-streaming now forwards writes as `cache_creation_input_tokens` and subtracts them from fresh `input_tokens`.
- OTel usage extractor persists writes so `EffectiveInputCost` can apply the 1.25× multiplier instead of treating those tokens as 1.0× input.

## Context
Munir sessions `fd49cc93-…` / `85e6e58b-…` — GPT cache reads were fine; writes were dropped. Anthropic already reported both fields.