### PR TITLE
feat(admin): expose full catalog via GET /v1/router/models?scope=catalog

### DIFF
--- a/internal/api/admin/allowed_models.go
+++ b/internal/api/admin/allowed_models.go
@@ -23,7 +23,7 @@ type updateAllowedModelsRequest struct {
 // GetAllowedModelsHandler returns deployed models and the installation's
 // positive allowlist. An empty list means no restriction — every deployed
 // model is routable, subject to the separate exclusion list.
-func GetAllowedModelsHandler(authSvc *auth.Service, models DeployedModelsSource) gin.HandlerFunc {
+func GetAllowedModelsHandler(authSvc *auth.Service, _ DeployedModelsSource) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		installation, ok := resolveInstallation(c, authSvc)
 		if !ok {
@@ -34,7 +34,7 @@ func GetAllowedModelsHandler(authSvc *auth.Service, models DeployedModelsSource)
 		sort.Strings(allowed)
 
 		c.JSON(http.StatusOK, allowedModelsResponse{
-			Available: deployedModelsDTO(models),
+			Available: fullCatalogDTO(),
 			Allowed:   allowed,
 		})
 	}
@@ -43,7 +43,7 @@ func GetAllowedModelsHandler(authSvc *auth.Service, models DeployedModelsSource)
 // UpdateAllowedModelsHandler replaces the installation's positive allowlist.
 // 400 on unknown model IDs. Unlike the exclusion list there is no env override
 // to contend with — the allowlist is purely a per-installation control.
-func UpdateAllowedModelsHandler(authSvc *auth.Service, models DeployedModelsSource) gin.HandlerFunc {
+func UpdateAllowedModelsHandler(authSvc *auth.Service, _ DeployedModelsSource) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		log := observability.FromGin(c)
 		installation, ok := resolveInstallation(c, authSvc)
@@ -57,9 +57,8 @@ func UpdateAllowedModelsHandler(authSvc *auth.Service, models DeployedModelsSour
 			return
 		}
 
-		deployed := models.DefaultDeployedModels()
-		allowed := make(map[string]struct{}, len(deployed))
-		for _, e := range deployed {
+		allowed := make(map[string]struct{})
+		for _, e := range fullCatalogDTO() {
 			allowed[e.Model] = struct{}{}
 		}
 
@@ -76,7 +75,7 @@ func UpdateAllowedModelsHandler(authSvc *auth.Service, models DeployedModelsSour
 
 		sort.Strings(stored)
 		c.JSON(http.StatusOK, allowedModelsResponse{
-			Available: deployedModelsDTO(models),
+			Available: fullCatalogDTO(),
 			Allowed:   stored,
 		})
 	}

--- a/internal/api/admin/catalog.go
+++ b/internal/api/admin/catalog.go
@@ -7,6 +7,7 @@ import (
 
 	"workweave/router/internal/observability"
 	"workweave/router/internal/router"
+	"workweave/router/internal/router/catalog"
 	"workweave/router/internal/router/cluster"
 
 	"github.com/gin-gonic/gin"
@@ -34,6 +35,10 @@ type HMMRosterSource interface {
 // RouterArena leaderboard) so there is no leak risk from leaving this open.
 func CatalogModelsHandler(models DeployedModelsSource, hmmModels HMMRosterSource) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if strings.EqualFold(strings.TrimSpace(c.Query("scope")), CatalogScopeCatalog) {
+			c.JSON(http.StatusOK, CatalogModelsResponse{Models: fullCatalogDTO()})
+			return
+		}
 		strategy := router.Strategy(strings.ToLower(strings.TrimSpace(c.Query("strategy"))))
 		if router.IsHMMStrategy(strategy) && hmmModels != nil {
 			entries, err := hmmModels.HMMDeployedModels(c.Request.Context())
@@ -51,4 +56,22 @@ func CatalogModelsHandler(models DeployedModelsSource, hmmModels HMMRosterSource
 		}
 		c.JSON(http.StatusOK, CatalogModelsResponse{Models: deployedModelsDTO(models)})
 	}
+}
+
+// CatalogScopeCatalog is the query value for GET /v1/router/models?scope=catalog.
+// It returns every row in catalog.Models, independent of the serving strategy.
+const CatalogScopeCatalog = "catalog"
+
+// fullCatalogDTO maps catalog.Models to the same {model, provider} DTO as the
+// strategy-scoped lists. Provider is the model's primary binding so grouping
+// in the settings UI stays consistent with the roster view.
+func fullCatalogDTO() []deployedModelDTO {
+	entries := make([]cluster.DeployedEntry, 0, len(catalog.Models))
+	for _, m := range catalog.Models {
+		if m.ID == "" {
+			continue
+		}
+		entries = append(entries, cluster.DeployedEntry{Model: m.ID, Provider: m.PrimaryProvider()})
+	}
+	return entriesToDTO(entries)
 }

--- a/internal/api/admin/catalog_test.go
+++ b/internal/api/admin/catalog_test.go
@@ -151,3 +151,39 @@ func TestCatalogModelsHandler_HMMRosterErrorReturns503(t *testing.T) {
 
 	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }
+
+func TestCatalogModelsHandler_ScopeCatalogReturnsFullCatalog(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	clusterSrc := fakeDeployedModels{entries: []cluster.DeployedEntry{
+		{Model: "gpt-5.5", Provider: providers.ProviderOpenAI},
+	}}
+	hmmSrc := &fakeHMMRoster{entries: []cluster.DeployedEntry{
+		{Model: "gpt-5.6-sol", Provider: providers.ProviderOpenAI},
+	}}
+
+	engine := gin.New()
+	engine.GET("/v1/router/models", admin.CatalogModelsHandler(clusterSrc, hmmSrc))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/router/models?scope=catalog&strategy=hmm", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, 0, hmmSrc.calls, "scope=catalog must not consult the HMM roster")
+
+	var got admin.CatalogModelsResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Greater(t, len(got.Models), 1, "full catalog is larger than the 1-entry cluster fixture")
+
+	seen := map[string]struct{}{}
+	for _, m := range got.Models {
+		require.NotEmpty(t, m.Model)
+		require.NotEmpty(t, m.Provider)
+		_, dup := seen[m.Model]
+		require.False(t, dup, "duplicate catalog id %s", m.Model)
+		seen[m.Model] = struct{}{}
+	}
+	_, hasOpus := seen["claude-opus-5"]
+	require.True(t, hasOpus, "catalog must include a known Models row")
+}

--- a/internal/api/admin/excluded_models.go
+++ b/internal/api/admin/excluded_models.go
@@ -65,14 +65,14 @@ func entriesToDTO(entries []cluster.DeployedEntry) []deployedModelDTO {
 
 // GetExcludedModelsHandler returns deployed models and the installation's
 // exclusion list. `env_override_active` tells the UI to render read-only.
-func GetExcludedModelsHandler(authSvc *auth.Service, models DeployedModelsSource, override ExclusionOverrideSource) gin.HandlerFunc {
+func GetExcludedModelsHandler(authSvc *auth.Service, _ DeployedModelsSource, override ExclusionOverrideSource) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		installation, ok := resolveInstallation(c, authSvc)
 		if !ok {
 			return
 		}
 
-		out := deployedModelsDTO(models)
+		out := fullCatalogDTO()
 
 		envActive := override != nil && override.HasExcludedModelsOverride()
 		var excluded []string
@@ -96,7 +96,7 @@ func GetExcludedModelsHandler(authSvc *auth.Service, models DeployedModelsSource
 
 // UpdateExcludedModelsHandler replaces the installation's exclusion list.
 // 400 on unknown model IDs; 403 if the env override is active.
-func UpdateExcludedModelsHandler(authSvc *auth.Service, models DeployedModelsSource, override ExclusionOverrideSource) gin.HandlerFunc {
+func UpdateExcludedModelsHandler(authSvc *auth.Service, _ DeployedModelsSource, override ExclusionOverrideSource) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		log := observability.FromGin(c)
 		installation, ok := resolveInstallation(c, authSvc)
@@ -116,8 +116,8 @@ func UpdateExcludedModelsHandler(authSvc *auth.Service, models DeployedModelsSou
 			return
 		}
 
-		allowed := make(map[string]struct{}, len(models.DefaultDeployedModels()))
-		for _, e := range models.DefaultDeployedModels() {
+		allowed := make(map[string]struct{})
+		for _, e := range fullCatalogDTO() {
 			allowed[e.Model] = struct{}{}
 		}
 
@@ -134,7 +134,7 @@ func UpdateExcludedModelsHandler(authSvc *auth.Service, models DeployedModelsSou
 
 		sort.Strings(stored)
 		c.JSON(http.StatusOK, excludedModelsResponse{
-			Available: deployedModelsDTO(models),
+			Available: fullCatalogDTO(),
 			Excluded:  stored,
 		})
 	}


### PR DESCRIPTION
## Summary
- `GET /v1/router/models?scope=catalog` returns every `catalog.Models` row as `{model, provider}`. Independent of `?strategy=`.
- Self-hosted allow/exclude available lists and validation use that universe so a non-roster model can be opted in/out for force-model / hard-pin.
- `?strategy=hmm` is unchanged (still the serving roster).

The WorkWeave settings page (`weave_router_deployed_models`) will consume this once the pin is bumped.

## Test plan
- [x] `go test ./internal/api/admin/`
- [x] `wv mr tc` / `wv mr t`

🤖 Generated with [Weave Router](https://router.workweave.ai)