### PR TITLE
feat(hmm-roster): publish roster-native arm IDs alongside catalog models

### DIFF
--- a/internal/api/admin/hmm_roster.go
+++ b/internal/api/admin/hmm_roster.go
@@ -12,10 +12,13 @@ import (
 )
 
 // hmmClusterDTO is one classifier cluster with its ordered default catalog
-// model IDs (index 0 = highest serving priority).
+// roster arms and catalog model IDs (index 0 = highest serving priority).
 type hmmClusterDTO struct {
-	Cluster string   `json:"cluster"`
-	Models  []string `json:"models"`
+	Cluster string `json:"cluster"`
+	// Arms are the roster-native IDs, including provider prefixes and effort
+	// suffixes. Models is the catalog-facing projection used by settings.
+	Arms   []string `json:"arms"`
+	Models []string `json:"models"`
 }
 
 type hmmRosterResponse struct {
@@ -39,7 +42,11 @@ func HMMRosterHandler(source policy.RosterSource) gin.HandlerFunc {
 			for _, arm := range arms {
 				models = append(models, hmm.CatalogIDForRoster(arm))
 			}
-			clusters = append(clusters, hmmClusterDTO{Cluster: cluster, Models: models})
+			clusters = append(clusters, hmmClusterDTO{
+				Arms:    append([]string(nil), arms...),
+				Cluster: cluster,
+				Models:  models,
+			})
 		}
 		sort.SliceStable(clusters, func(i, j int) bool {
 			return clusters[i].Cluster < clusters[j].Cluster

--- a/internal/api/admin/hmm_roster_test.go
+++ b/internal/api/admin/hmm_roster_test.go
@@ -1,0 +1,61 @@
+package admin_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"workweave/router/internal/api/admin"
+	"workweave/router/internal/router/policy"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRosterSource struct {
+	snapshot policy.RosterSnapshot
+}
+
+func (f fakeRosterSource) ClusterRoster(context.Context) (policy.RosterSnapshot, error) {
+	return f.snapshot, nil
+}
+
+func TestHMMRosterHandler_PreservesRosterArmsAndCatalogModels(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	engine := gin.New()
+	engine.GET("/v1/router/hmm-roster", admin.HMMRosterHandler(fakeRosterSource{
+		snapshot: policy.RosterSnapshot{
+			RosterSHA256: "sha-1",
+			Clusters: map[string][]string{
+				"high": {
+					"anthropic/claude-opus-5:xhigh",
+					"x-ai/grok-4.6",
+				},
+			},
+		},
+	}))
+
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/router/hmm-roster", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body struct {
+		Clusters []struct {
+			Arms   []string `json:"arms"`
+			Models []string `json:"models"`
+		} `json:"clusters"`
+		RosterSHA256 string `json:"roster_sha256"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Clusters, 1)
+	assert.Equal(t, "sha-1", body.RosterSHA256)
+	assert.Equal(t, []string{
+		"anthropic/claude-opus-5:xhigh",
+		"x-ai/grok-4.6",
+	}, body.Clusters[0].Arms)
+	assert.Equal(t, []string{"claude-opus-5", "grok-4.6"}, body.Clusters[0].Models)
+}


### PR DESCRIPTION
## Problem

`GET /v1/router/hmm-roster` returns only `hmm.CatalogIDForRoster(arm)`, which is lossy in two ways:

1. `SplitEffort` drops `:effort` — `openai/gpt-5.6-luna:{xhigh,high,medium,low}` and the bare arm all collapse to one `gpt-5.6-luna`.
2. First-party vendor prefixes are stripped — `anthropic/claude-opus-5` → `claude-opus-5`, `x-ai/grok-4.6` → `grok-4.6`. Gateway-hosted models (`deepseek/…`, `minimax/…`, `moonshotai/…`) keep the slash form because that *is* their catalog ID.

That projection is right for the customer settings page — a catalog ID is what a customer routes to — but it is not the roster's own key. Roster artifacts (`rosters/frozen/roster_<sha16>.json`) and AA analysis data are keyed by arm ID, so a consumer joining against this endpoint matches only the gateway-hosted arms.

Replaying the pinned prod roster `5fff31fc…` through the mapping: **3 of 11 names join, 8 miss**, and each 10-arm cluster returns only 5–6 unique IDs, so a positional rank map built from the response is last-write-wins rather than serving priority. This is live on the Weave admin roster dashboard today — Anthropic, OpenAI, Google and xAI arms render with no data.

## Change

The handler already has the arm IDs; it discarded them one line before serializing. Emit them as `arms` and leave `models` untouched, so the settings path is byte-identical and consumers that need the roster-native key can join correctly.

## Test

`internal/api/admin/hmm_roster_test.go` — new; the endpoint had no coverage. Asserts both projections from one snapshot: `arms` preserves `anthropic/claude-opus-5:xhigh` and `x-ai/grok-4.6` verbatim, `models` still yields `claude-opus-5` / `grok-4.6`.

`go test ./internal/api/admin ./internal/router/hmm` and `go vet ./internal/api/... ./internal/router/hmm/...` pass.

Consumed by a WorkWeave PR that joins the admin roster dashboard on `arms`; that one bumps the gitlink after this merges.

🤖 Generated with [Weave Router](https://router.workweave.ai)