### PR TITLE
fix(admin): reject allowlists that empty the routed pool

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -945,7 +945,7 @@ func main() {
 		WithSummarizer(summarizer).
 		WithWebSearchExecutor(cortexWebSearch(logger)).
 		WithCompaction(compactionSz, compactionPct).
-		WithAvailableModels(routingTargets).
+		WithAvailableModels(proxyRoutableModels(routingTargets, availableProviders, hmmRouter != nil)).
 		WithDefaultBaselineModel(resolveDefaultBaselineModel()).
 		WithBillingService(billingSvc)
 	for _, spec := range configuredPolicySpecs {
@@ -1433,6 +1433,23 @@ func parseEnvInt(key string, fallback int) int {
 // parseEnvFloat reads an env var as a float64, falling back on unset/empty/
 // unparseable. Zero and negative values are valid — e.g. operators set
 // ROUTER_SWITCH_EV_THRESHOLD_USD <= 0 to force aggressive planner switching.
+// proxyRoutableModels is the allowlist desugaring universe. Generic
+// RoutingTargetSet plus HMM-only rows when an HMM sidecar is wired, so an
+// HMM-only allowlist is not rejected as emptying the pool.
+func proxyRoutableModels(generic, providers map[string]struct{}, hmmWired bool) map[string]struct{} {
+	if !hmmWired {
+		return generic
+	}
+	out := catalog.HMMRoutingTargetSet(providers)
+	if len(generic) == 0 {
+		return out
+	}
+	for m := range generic {
+		out[m] = struct{}{}
+	}
+	return out
+}
+
 func parseEnvFloat(key string, fallback float64) float64 {
 	raw := config.GetOr(key, "")
 	if raw == "" {

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -1433,9 +1433,7 @@ func parseEnvInt(key string, fallback int) int {
 // parseEnvFloat reads an env var as a float64, falling back on unset/empty/
 // unparseable. Zero and negative values are valid — e.g. operators set
 // ROUTER_SWITCH_EV_THRESHOLD_USD <= 0 to force aggressive planner switching.
-// proxyRoutableModels is the allowlist desugaring universe. Generic
-// RoutingTargetSet plus HMM-only rows when an HMM sidecar is wired, so an
-// HMM-only allowlist is not rejected as emptying the pool.
+// proxyRoutableModels is RoutingTargetSet plus HMM-only rows when HMM is wired.
 func proxyRoutableModels(generic, providers map[string]struct{}, hmmWired bool) map[string]struct{} {
 	if !hmmWired {
 		return generic

--- a/cmd/router/routable_models_test.go
+++ b/cmd/router/routable_models_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+
+	"workweave/router/internal/router/catalog"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProxyRoutableModels_WithoutHMMLeavesGenericSet(t *testing.T) {
+	generic := map[string]struct{}{"claude-opus-4-7": {}}
+	got := proxyRoutableModels(generic, map[string]struct{}{"anthropic": {}}, false)
+	assert.Equal(t, generic, got)
+}
+
+func TestProxyRoutableModels_WithHMMUnionsHMMOnlyTargets(t *testing.T) {
+	providers := map[string]struct{}{}
+	for _, m := range catalog.Models {
+		for _, b := range m.Providers {
+			providers[b.Provider] = struct{}{}
+		}
+	}
+	generic := catalog.RoutingTargetSet(providers)
+	hmm := catalog.HMMRoutingTargetSet(providers)
+	require.Greater(t, len(hmm), len(generic), "catalog must have HMM-only rows or this test is vacuous")
+
+	got := proxyRoutableModels(generic, providers, true)
+	assert.Equal(t, len(hmm), len(got))
+	for id := range hmm {
+		assert.Contains(t, got, id)
+	}
+}

--- a/internal/api/admin/allowed_models.go
+++ b/internal/api/admin/allowed_models.go
@@ -7,9 +7,17 @@ import (
 
 	"workweave/router/internal/auth"
 	"workweave/router/internal/observability"
+	"workweave/router/internal/proxy"
 
 	"github.com/gin-gonic/gin"
 )
+
+// RoutableModelsSource reports the models this deployment can actually route:
+// catalog rows with a known tier and a binding to an available provider.
+// Implemented by *proxy.Service; nil skips the intersection guard.
+type RoutableModelsSource interface {
+	RoutableModels() map[string]struct{}
+}
 
 type allowedModelsResponse struct {
 	Available []deployedModelDTO `json:"available"`
@@ -41,9 +49,10 @@ func GetAllowedModelsHandler(authSvc *auth.Service, _ DeployedModelsSource) gin.
 }
 
 // UpdateAllowedModelsHandler replaces the installation's positive allowlist.
-// 400 on unknown model IDs. Unlike the exclusion list there is no env override
-// to contend with — the allowlist is purely a per-installation control.
-func UpdateAllowedModelsHandler(authSvc *auth.Service, _ DeployedModelsSource) gin.HandlerFunc {
+// 400 on unknown model IDs, and on an allowlist with no routable member.
+// Unlike the exclusion list there is no env override to contend with — the
+// allowlist is purely a per-installation control.
+func UpdateAllowedModelsHandler(authSvc *auth.Service, _ DeployedModelsSource, routable RoutableModelsSource) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		log := observability.FromGin(c)
 		installation, ok := resolveInstallation(c, authSvc)
@@ -57,9 +66,23 @@ func UpdateAllowedModelsHandler(authSvc *auth.Service, _ DeployedModelsSource) g
 			return
 		}
 
+		// Membership is catalog-wide, not roster-scoped: force-model and
+		// hard-pin reach rows the router never scores, so an admin must be able
+		// to opt those in.
 		allowed := make(map[string]struct{})
 		for _, e := range fullCatalogDTO() {
 			allowed[e.Model] = struct{}{}
+		}
+
+		// ...but the allowlist is enforced by excluding its complement over the
+		// routable set, so a list naming only non-routable catalog rows (an
+		// unbound provider, or a passthrough-only row with no tier) empties the
+		// candidate pool and 400s every routed request. Require one survivor.
+		if allowlistLosesRoutability(req.Allowed, allowed, routable) {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+				"error": "Allowlist selects no model this deployment can route. Add at least one routable model; the rest are reachable only via force-model or passthrough.",
+			})
+			return
 		}
 
 		stored, err := authSvc.SetInstallationAllowedModels(c.Request.Context(), installation.ExternalID, installation.ID, req.Allowed, allowed)
@@ -80,3 +103,32 @@ func UpdateAllowedModelsHandler(authSvc *auth.Service, _ DeployedModelsSource) g
 		})
 	}
 }
+
+// allowlistLosesRoutability reports whether saving models would leave the
+// routed candidate pool empty.
+//
+// It returns false — no objection — in three cases. An empty allowlist clears
+// the restriction, and an org that has locked itself out must always be able to
+// do that. An unknown ID defers to SetInstallationAllowedModels, which names it
+// precisely instead of blaming routability for a typo. And an unknown routable
+// universe fails open, so a router wired without a proxy stays editable.
+func allowlistLosesRoutability(models []string, catalogIDs map[string]struct{}, routable RoutableModelsSource) bool {
+	if len(models) == 0 || routable == nil {
+		return false
+	}
+	universe := routable.RoutableModels()
+	if len(universe) == 0 {
+		return false
+	}
+	for _, m := range models {
+		if _, known := catalogIDs[m]; !known {
+			return false
+		}
+		if _, ok := universe[m]; ok {
+			return false
+		}
+	}
+	return true
+}
+
+var _ RoutableModelsSource = (*proxy.Service)(nil)

--- a/internal/api/admin/allowed_models.go
+++ b/internal/api/admin/allowed_models.go
@@ -74,10 +74,8 @@ func UpdateAllowedModelsHandler(authSvc *auth.Service, _ DeployedModelsSource, r
 			allowed[e.Model] = struct{}{}
 		}
 
-		// ...but the allowlist is enforced by excluding its complement over the
-		// routable set, so a list naming only non-routable catalog rows (an
-		// unbound provider, or a passthrough-only row with no tier) empties the
-		// candidate pool and 400s every routed request. Require one survivor.
+		// A list naming only non-routable rows empties the candidate pool;
+		// require at least one routable survivor.
 		if allowlistLosesRoutability(req.Allowed, allowed, routable) {
 			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
 				"error": "Allowlist selects no model this deployment can route. Add at least one routable model; the rest are reachable only via force-model or passthrough.",

--- a/internal/api/admin/allowed_models.go
+++ b/internal/api/admin/allowed_models.go
@@ -12,9 +12,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// RoutableModelsSource reports the models this deployment can actually route:
-// catalog rows with a known tier and a binding to an available provider.
-// Implemented by *proxy.Service; nil skips the intersection guard.
+// RoutableModelsSource reports the models this deployment can route;
+// nil skips the intersection guard.
 type RoutableModelsSource interface {
 	RoutableModels() map[string]struct{}
 }
@@ -50,8 +49,7 @@ func GetAllowedModelsHandler(authSvc *auth.Service, _ DeployedModelsSource) gin.
 
 // UpdateAllowedModelsHandler replaces the installation's positive allowlist.
 // 400 on unknown model IDs, and on an allowlist with no routable member.
-// Unlike the exclusion list there is no env override to contend with — the
-// allowlist is purely a per-installation control.
+// Unlike the exclusion list there is no env override to contend with.
 func UpdateAllowedModelsHandler(authSvc *auth.Service, _ DeployedModelsSource, routable RoutableModelsSource) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		log := observability.FromGin(c)

--- a/internal/api/admin/allowed_models.go
+++ b/internal/api/admin/allowed_models.go
@@ -66,9 +66,7 @@ func UpdateAllowedModelsHandler(authSvc *auth.Service, _ DeployedModelsSource, r
 			return
 		}
 
-		// Membership is catalog-wide, not roster-scoped: force-model and
-		// hard-pin reach rows the router never scores, so an admin must be able
-		// to opt those in.
+		// Membership is catalog-wide so force-model can name non-roster rows.
 		allowed := make(map[string]struct{})
 		for _, e := range fullCatalogDTO() {
 			allowed[e.Model] = struct{}{}

--- a/internal/api/admin/allowed_models.go
+++ b/internal/api/admin/allowed_models.go
@@ -104,14 +104,9 @@ func UpdateAllowedModelsHandler(authSvc *auth.Service, _ DeployedModelsSource, r
 	}
 }
 
-// allowlistLosesRoutability reports whether saving models would leave the
-// routed candidate pool empty.
-//
-// It returns false — no objection — in three cases. An empty allowlist clears
-// the restriction, and an org that has locked itself out must always be able to
-// do that. An unknown ID defers to SetInstallationAllowedModels, which names it
-// precisely instead of blaming routability for a typo. And an unknown routable
-// universe fails open, so a router wired without a proxy stays editable.
+// allowlistLosesRoutability reports whether saving models would leave
+// the routed candidate pool empty. Returns false (no objection) when
+// the list is empty, any ID is unknown, or the routable universe is nil.
 func allowlistLosesRoutability(models []string, catalogIDs map[string]struct{}, routable RoutableModelsSource) bool {
 	if len(models) == 0 || routable == nil {
 		return false

--- a/internal/api/admin/allowed_models_internal_test.go
+++ b/internal/api/admin/allowed_models_internal_test.go
@@ -32,22 +32,19 @@ func known(ids ...string) map[string]struct{} {
 	return out
 }
 
-// Clearing the restriction must never be blocked — an org that has locked
-// itself out needs the empty list to keep working.
+// An empty allowlist clears the restriction and must never be blocked.
 func TestAllowlistLosesRoutability_EmptyAllowlistAlwaysPasses(t *testing.T) {
 	assert.False(t, allowlistLosesRoutability(nil, known("a"), routable("a")))
 	assert.False(t, allowlistLosesRoutability([]string{}, known("a"), routable("a")))
 }
 
-// One routable survivor is enough; the rest may be force-model-only rows.
+// One routable survivor is enough; the rest may be force-model-only.
 func TestAllowlistLosesRoutability_PartialOverlapPasses(t *testing.T) {
 	assert.False(t, allowlistLosesRoutability(
 		[]string{"passthrough-only", "a"}, known("passthrough-only", "a"), routable("a", "b")))
 }
 
-// The regression this guard exists for: a catalog-valid but wholly non-routable
-// allowlist desugars into "exclude every routable model", so every routed
-// request 400s with ErrAllowlistEmptiesPool until an admin widens the list.
+// A wholly non-routable allowlist would 400 every routed request.
 func TestAllowlistLosesRoutability_DisjointAllowlistFails(t *testing.T) {
 	assert.True(t, allowlistLosesRoutability(
 		[]string{"claude-opus-4-8"}, known("claude-opus-4-8", "claude-opus-4-7"), routable("claude-opus-4-7")))
@@ -55,22 +52,19 @@ func TestAllowlistLosesRoutability_DisjointAllowlistFails(t *testing.T) {
 		[]string{"x", "y"}, known("x", "y", "a"), routable("a", "b")))
 }
 
-// An unknown ID belongs to SetInstallationAllowedModels' error, not this one.
+// Unknown IDs defer to SetInstallationAllowedModels, not this guard.
 func TestAllowlistLosesRoutability_UnknownIDDefersToMembershipCheck(t *testing.T) {
 	assert.False(t, allowlistLosesRoutability(
 		[]string{"typo"}, known("a", "b"), routable("a")))
 }
 
-// Fail open when the deployment's routable set is unknown: a router wired
-// without a proxy must still be able to edit its allowlist.
+// Unknown universe fails open so a proxy-less router stays editable.
 func TestAllowlistLosesRoutability_UnknownUniverseFailsOpen(t *testing.T) {
 	assert.False(t, allowlistLosesRoutability([]string{"anything"}, known("anything"), nil))
 	assert.False(t, allowlistLosesRoutability([]string{"anything"}, known("anything"), routable()))
 }
 
-// The two universes are deliberately different sizes: membership validation is
-// catalog-wide, the guard is routable-only. If they ever coincided the guard
-// would be dead code, so assert the gap is real.
+// Catalog membership is wider than the routable set; otherwise this guard is dead.
 func TestFullCatalogExceedsRoutableUniverse(t *testing.T) {
 	catalogIDs := fullCatalogDTO()
 	require.NotEmpty(t, catalogIDs)

--- a/internal/api/admin/allowed_models_internal_test.go
+++ b/internal/api/admin/allowed_models_internal_test.go
@@ -1,0 +1,91 @@
+package admin
+
+import (
+	"testing"
+
+	"workweave/router/internal/router/catalog"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRoutableModels struct {
+	models map[string]struct{}
+}
+
+func (f fakeRoutableModels) RoutableModels() map[string]struct{} { return f.models }
+
+func routable(ids ...string) fakeRoutableModels {
+	out := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		out[id] = struct{}{}
+	}
+	return fakeRoutableModels{models: out}
+}
+
+// known builds the catalog-membership set the guard checks IDs against.
+func known(ids ...string) map[string]struct{} {
+	out := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		out[id] = struct{}{}
+	}
+	return out
+}
+
+// Clearing the restriction must never be blocked — an org that has locked
+// itself out needs the empty list to keep working.
+func TestAllowlistLosesRoutability_EmptyAllowlistAlwaysPasses(t *testing.T) {
+	assert.False(t, allowlistLosesRoutability(nil, known("a"), routable("a")))
+	assert.False(t, allowlistLosesRoutability([]string{}, known("a"), routable("a")))
+}
+
+// One routable survivor is enough; the rest may be force-model-only rows.
+func TestAllowlistLosesRoutability_PartialOverlapPasses(t *testing.T) {
+	assert.False(t, allowlistLosesRoutability(
+		[]string{"passthrough-only", "a"}, known("passthrough-only", "a"), routable("a", "b")))
+}
+
+// The regression this guard exists for: a catalog-valid but wholly non-routable
+// allowlist desugars into "exclude every routable model", so every routed
+// request 400s with ErrAllowlistEmptiesPool until an admin widens the list.
+func TestAllowlistLosesRoutability_DisjointAllowlistFails(t *testing.T) {
+	assert.True(t, allowlistLosesRoutability(
+		[]string{"claude-opus-4-8"}, known("claude-opus-4-8", "claude-opus-4-7"), routable("claude-opus-4-7")))
+	assert.True(t, allowlistLosesRoutability(
+		[]string{"x", "y"}, known("x", "y", "a"), routable("a", "b")))
+}
+
+// An unknown ID belongs to SetInstallationAllowedModels' error, not this one.
+func TestAllowlistLosesRoutability_UnknownIDDefersToMembershipCheck(t *testing.T) {
+	assert.False(t, allowlistLosesRoutability(
+		[]string{"typo"}, known("a", "b"), routable("a")))
+}
+
+// Fail open when the deployment's routable set is unknown: a router wired
+// without a proxy must still be able to edit its allowlist.
+func TestAllowlistLosesRoutability_UnknownUniverseFailsOpen(t *testing.T) {
+	assert.False(t, allowlistLosesRoutability([]string{"anything"}, known("anything"), nil))
+	assert.False(t, allowlistLosesRoutability([]string{"anything"}, known("anything"), routable()))
+}
+
+// The two universes are deliberately different sizes: membership validation is
+// catalog-wide, the guard is routable-only. If they ever coincided the guard
+// would be dead code, so assert the gap is real.
+func TestFullCatalogExceedsRoutableUniverse(t *testing.T) {
+	catalogIDs := fullCatalogDTO()
+	require.NotEmpty(t, catalogIDs)
+
+	// Every provider bound: still narrower than the catalog, because
+	// passthrough-only rows carry no tier and are never scored.
+	all := make(map[string]struct{})
+	for _, m := range catalog.Models {
+		for _, b := range m.Providers {
+			all[b.Provider] = struct{}{}
+		}
+	}
+	targets := catalog.RoutingTargetSet(all)
+
+	require.NotEmpty(t, targets)
+	assert.Less(t, len(targets), len(catalogIDs),
+		"expected catalog rows that no deployment can route; guard would be dead code otherwise")
+}

--- a/internal/api/admin/allowed_models_test.go
+++ b/internal/api/admin/allowed_models_test.go
@@ -1,0 +1,74 @@
+package admin_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"workweave/router/internal/api/admin"
+	"workweave/router/internal/auth"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubRoutableModels struct {
+	models map[string]struct{}
+}
+
+func (s stubRoutableModels) RoutableModels() map[string]struct{} { return s.models }
+
+// putAllowedModels drives the handler behind a middleware that injects an
+// already-authed installation, so the request reaches the validation guards
+// without a real auth flow. authSvc is nil: every case here must be rejected
+// before the handler touches it.
+func putAllowedModels(t *testing.T, routable admin.RoutableModelsSource, allowed []string) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.PUT("/admin/v1/allowed-models", func(c *gin.Context) {
+		c.Set("router_installation", &auth.Installation{ID: "inst-1"})
+	}, admin.UpdateAllowedModelsHandler(nil, nil, routable))
+
+	body, err := json.Marshal(map[string][]string{"allowed": allowed})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPut, "/admin/v1/allowed-models", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+	return rec
+}
+
+// claude-opus-4-8 is a real catalog row with no tier, so it passes catalog
+// membership yet can never be routed. Saving it alone would desugar into
+// "exclude every routable model" and 400 every routed request.
+func TestUpdateAllowedModelsHandler_RejectsAllowlistWithNoRoutableMember(t *testing.T) {
+	rec := putAllowedModels(t,
+		stubRoutableModels{models: map[string]struct{}{"claude-opus-4-7": {}}},
+		[]string{"claude-opus-4-8"},
+	)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Contains(t, body["error"], "no model this deployment can route")
+}
+
+// Membership validation still runs and still reports unknown IDs distinctly,
+// so a typo does not get reported as a routability problem.
+func TestUpdateAllowedModelsHandler_RejectsUnknownModelBeforeRoutabilityCheck(t *testing.T) {
+	rec := putAllowedModels(t,
+		stubRoutableModels{models: map[string]struct{}{"claude-opus-4-7": {}}},
+		[]string{"not-a-real-model"},
+	)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.NotContains(t, body["error"], "no model this deployment can route")
+}

--- a/internal/api/admin/allowed_models_test.go
+++ b/internal/api/admin/allowed_models_test.go
@@ -21,10 +21,8 @@ type stubRoutableModels struct {
 
 func (s stubRoutableModels) RoutableModels() map[string]struct{} { return s.models }
 
-// putAllowedModels drives the handler behind a middleware that injects an
-// already-authed installation, so the request reaches the validation guards
-// without a real auth flow. authSvc is nil: every case here must be rejected
-// before the handler touches it.
+// putAllowedModels drives the handler with an already-authed installation
+// injected, bypassing the real auth flow.
 func putAllowedModels(t *testing.T, routable admin.RoutableModelsSource, allowed []string) *httptest.ResponseRecorder {
 	t.Helper()
 	gin.SetMode(gin.TestMode)

--- a/internal/api/admin/allowed_models_test.go
+++ b/internal/api/admin/allowed_models_test.go
@@ -40,9 +40,7 @@ func putAllowedModels(t *testing.T, routable admin.RoutableModelsSource, allowed
 	return rec
 }
 
-// claude-opus-4-8 is a real catalog row with no tier, so it passes catalog
-// membership yet can never be routed. Saving it alone would desugar into
-// "exclude every routable model" and 400 every routed request.
+// A catalog-valid but unroutable-only list must 400 before it is saved.
 func TestUpdateAllowedModelsHandler_RejectsAllowlistWithNoRoutableMember(t *testing.T) {
 	rec := putAllowedModels(t,
 		stubRoutableModels{models: map[string]struct{}{"claude-opus-4-7": {}}},
@@ -56,8 +54,7 @@ func TestUpdateAllowedModelsHandler_RejectsAllowlistWithNoRoutableMember(t *test
 	assert.Contains(t, body["error"], "no model this deployment can route")
 }
 
-// Membership validation still runs and still reports unknown IDs distinctly,
-// so a typo does not get reported as a routability problem.
+// Unknown IDs must not be reported as a routability problem.
 func TestUpdateAllowedModelsHandler_RejectsUnknownModelBeforeRoutabilityCheck(t *testing.T) {
 	rec := putAllowedModels(t,
 		stubRoutableModels{models: map[string]struct{}{"claude-opus-4-7": {}}},

--- a/internal/proxy/AGENTS.md
+++ b/internal/proxy/AGENTS.md
@@ -68,9 +68,9 @@ therefore excludes the entire pool and 400s every routed request with
 `ErrAllowlistEmptiesPool`. The handler calls `Service.RoutableModels()` and
 refuses to save such a list, deferring to the unknown-model error first so a
 typo is not reported as a routability problem. Keep that accessor and the
-desugaring reading the same universe: validating against a narrower roster
-(the cluster artifact's `DefaultDeployedModels`) is what this replaced, and it
-wrongly rejected arms a non-cluster strategy can serve.
+desugaring reading the same universe. `availableModels` is the generic
+`RoutingTargetSet` plus `HMMRoutingTargetSet` when an HMM sidecar is wired,
+so an HMM-only allowlist is not rejected as emptying the pool.
 
 **The fail-open/fail-closed asymmetry is load-bearing.** An org allowlist is a
 compliance control (a breach is worse than an outage); a user's per-cluster

--- a/internal/proxy/AGENTS.md
+++ b/internal/proxy/AGENTS.md
@@ -59,6 +59,19 @@ set, so all six existing enforcement sites honor it with no new filter loops.
 `router.Request.AllowedModels` exists only so errors and diagnostics can name
 the allowlist instead of dumping the desugared exclusion list.
 
+**A wholly non-routable allowlist is rejected at the admin API.** Membership
+validation for `PUT /admin/v1/allowed-models` is catalog-wide on purpose —
+force-model and hard-pin reach rows the router never scores — but the
+desugaring only excludes over `routableUniverse()`. A list naming *only*
+non-routable rows (an unbound provider, or a tierless passthrough-only row)
+therefore excludes the entire pool and 400s every routed request with
+`ErrAllowlistEmptiesPool`. The handler calls `Service.RoutableModels()` and
+refuses to save such a list, deferring to the unknown-model error first so a
+typo is not reported as a routability problem. Keep that accessor and the
+desugaring reading the same universe: validating against a narrower roster
+(the cluster artifact's `DefaultDeployedModels`) is what this replaced, and it
+wrongly rejected arms a non-cluster strategy can serve.
+
 **The fail-open/fail-closed asymmetry is load-bearing.** An org allowlist is a
 compliance control (a breach is worse than an outage); a user's per-cluster
 selection is a preference (hard-failing a turn because a personal pick went

--- a/internal/proxy/CLAUDE.md
+++ b/internal/proxy/CLAUDE.md
@@ -68,9 +68,9 @@ therefore excludes the entire pool and 400s every routed request with
 `ErrAllowlistEmptiesPool`. The handler calls `Service.RoutableModels()` and
 refuses to save such a list, deferring to the unknown-model error first so a
 typo is not reported as a routability problem. Keep that accessor and the
-desugaring reading the same universe: validating against a narrower roster
-(the cluster artifact's `DefaultDeployedModels`) is what this replaced, and it
-wrongly rejected arms a non-cluster strategy can serve.
+desugaring reading the same universe. `availableModels` is the generic
+`RoutingTargetSet` plus `HMMRoutingTargetSet` when an HMM sidecar is wired,
+so an HMM-only allowlist is not rejected as emptying the pool.
 
 **The fail-open/fail-closed asymmetry is load-bearing.** An org allowlist is a
 compliance control (a breach is worse than an outage); a user's per-cluster

--- a/internal/proxy/CLAUDE.md
+++ b/internal/proxy/CLAUDE.md
@@ -59,6 +59,19 @@ set, so all six existing enforcement sites honor it with no new filter loops.
 `router.Request.AllowedModels` exists only so errors and diagnostics can name
 the allowlist instead of dumping the desugared exclusion list.
 
+**A wholly non-routable allowlist is rejected at the admin API.** Membership
+validation for `PUT /admin/v1/allowed-models` is catalog-wide on purpose —
+force-model and hard-pin reach rows the router never scores — but the
+desugaring only excludes over `routableUniverse()`. A list naming *only*
+non-routable rows (an unbound provider, or a tierless passthrough-only row)
+therefore excludes the entire pool and 400s every routed request with
+`ErrAllowlistEmptiesPool`. The handler calls `Service.RoutableModels()` and
+refuses to save such a list, deferring to the unknown-model error first so a
+typo is not reported as a routability problem. Keep that accessor and the
+desugaring reading the same universe: validating against a narrower roster
+(the cluster artifact's `DefaultDeployedModels`) is what this replaced, and it
+wrongly rejected arms a non-cluster strategy can serve.
+
 **The fail-open/fail-closed asymmetry is load-bearing.** An org allowlist is a
 compliance control (a breach is worse than an outage); a user's per-cluster
 selection is a preference (hard-failing a turn because a personal pick went

--- a/internal/proxy/allowlist_internal_test.go
+++ b/internal/proxy/allowlist_internal_test.go
@@ -85,6 +85,45 @@ func TestExcludedModelsForRequest_UndeployedAllowlistEntryIgnored(t *testing.T) 
 	assert.NotContains(t, got, "retired-model")
 }
 
+// The failure mode the admin allowlist guard exists to prevent: when NO entry
+// is routable, the desugaring excludes the entire pool and the scorer returns
+// ErrAllowlistEmptiesPool (400) for every routed request. Membership validation
+// is catalog-wide, so a tierless row like claude-opus-4-8 clears it.
+func TestExcludedModelsForRequest_WhollyUnroutableAllowlistEmptiesThePool(t *testing.T) {
+	s := &Service{availableModels: map[string]struct{}{"a": {}, "b": {}}}
+
+	got := s.excludedModelsForRequest(ctxWithAllowedModels("not-routable-1", "not-routable-2"))
+
+	assert.Equal(t, s.availableModels, got, "every routable model must be excluded")
+}
+
+// RoutableModels backs the admin guard, so it must agree with the desugaring's
+// universe exactly — a narrower view would let a pool-emptying list through.
+func TestRoutableModels_MatchesDesugaringUniverse(t *testing.T) {
+	s := &Service{availableModels: map[string]struct{}{"a": {}, "b": {}}}
+
+	assert.Equal(t, s.routableUniverse(), s.RoutableModels())
+}
+
+// The accessor hands its map to an HTTP handler; sharing the internal map would
+// let a caller mutate what every subsequent request routes against.
+func TestRoutableModels_ReturnsACopy(t *testing.T) {
+	s := &Service{availableModels: map[string]struct{}{"a": {}}}
+
+	got := s.RoutableModels()
+	got["injected"] = struct{}{}
+
+	assert.NotContains(t, s.availableModels, "injected")
+}
+
+// server.Register mounts the admin routes with a nil *Service in self-hosted
+// tests, which reaches the guard as a typed-nil interface.
+func TestRoutableModels_NilServiceReportsUnknownUniverse(t *testing.T) {
+	var s *Service
+
+	assert.Nil(t, s.RoutableModels())
+}
+
 // The env override is a deliberate operator escape hatch: an operator debugging
 // a deployment is not silently constrained by one org's allowlist.
 func TestExcludedModelsForRequest_EnvOverrideBypassesAllowlist(t *testing.T) {

--- a/internal/proxy/allowlist_internal_test.go
+++ b/internal/proxy/allowlist_internal_test.go
@@ -85,10 +85,8 @@ func TestExcludedModelsForRequest_UndeployedAllowlistEntryIgnored(t *testing.T) 
 	assert.NotContains(t, got, "retired-model")
 }
 
-// The failure mode the admin allowlist guard exists to prevent: when NO entry
-// is routable, the desugaring excludes the entire pool and the scorer returns
-// ErrAllowlistEmptiesPool (400) for every routed request. Membership validation
-// is catalog-wide, so a tierless row like claude-opus-4-8 clears it.
+// WhollyUnroutableAllowlistEmptiesThePool: no routable entry means the
+// desugaring excludes the entire pool, so every routed request 400s.
 func TestExcludedModelsForRequest_WhollyUnroutableAllowlistEmptiesThePool(t *testing.T) {
 	s := &Service{availableModels: map[string]struct{}{"a": {}, "b": {}}}
 
@@ -97,16 +95,14 @@ func TestExcludedModelsForRequest_WhollyUnroutableAllowlistEmptiesThePool(t *tes
 	assert.Equal(t, s.availableModels, got, "every routable model must be excluded")
 }
 
-// RoutableModels backs the admin guard, so it must agree with the desugaring's
-// universe exactly — a narrower view would let a pool-emptying list through.
+// RoutableModels must match the desugaring universe exactly.
 func TestRoutableModels_MatchesDesugaringUniverse(t *testing.T) {
 	s := &Service{availableModels: map[string]struct{}{"a": {}, "b": {}}}
 
 	assert.Equal(t, s.routableUniverse(), s.RoutableModels())
 }
 
-// The accessor hands its map to an HTTP handler; sharing the internal map would
-// let a caller mutate what every subsequent request routes against.
+// The accessor must return a copy so callers cannot mutate routing state.
 func TestRoutableModels_ReturnsACopy(t *testing.T) {
 	s := &Service{availableModels: map[string]struct{}{"a": {}}}
 
@@ -116,8 +112,7 @@ func TestRoutableModels_ReturnsACopy(t *testing.T) {
 	assert.NotContains(t, s.availableModels, "injected")
 }
 
-// server.Register mounts the admin routes with a nil *Service in self-hosted
-// tests, which reaches the guard as a typed-nil interface.
+// A typed-nil *Service from server.Register must not panic.
 func TestRoutableModels_NilServiceReportsUnknownUniverse(t *testing.T) {
 	var s *Service
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1687,9 +1687,8 @@ func (s *Service) HasExcludedModelsOverride() bool {
 // route, so the admin guard and request-time desugaring share one definition
 // and cannot drift.
 func (s *Service) RoutableModels() map[string]struct{} {
-	// A nil Service reaches here as a typed-nil interface from server.Register
-	// (self-hosted tests wire the admin routes without a proxy); report an
-	// unknown universe rather than panicking.
+	// A nil Service arrives as a typed-nil interface from server.Register;
+	// return nil rather than panicking.
 	if s == nil {
 		return nil
 	}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1684,10 +1684,8 @@ func (s *Service) HasExcludedModelsOverride() bool {
 }
 
 // RoutableModels returns a copy of the set of models this deployment can
-// route. Exported so the admin allowlist guard and the request-time allowlist
-// desugaring share one definition of "routable" and cannot drift: the
-// allowlist is enforced by excluding its complement over this set, so a list
-// that misses it entirely empties the candidate pool.
+// route, so the admin guard and request-time desugaring share one definition
+// and cannot drift.
 func (s *Service) RoutableModels() map[string]struct{} {
 	// A nil Service reaches here as a typed-nil interface from server.Register
 	// (self-hosted tests wire the admin routes without a proxy); report an

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1683,6 +1683,26 @@ func (s *Service) HasExcludedModelsOverride() bool {
 	return s.excludedModelsOverride != nil
 }
 
+// RoutableModels returns a copy of the set of models this deployment can
+// route. Exported so the admin allowlist guard and the request-time allowlist
+// desugaring share one definition of "routable" and cannot drift: the
+// allowlist is enforced by excluding its complement over this set, so a list
+// that misses it entirely empties the candidate pool.
+func (s *Service) RoutableModels() map[string]struct{} {
+	// A nil Service reaches here as a typed-nil interface from server.Register
+	// (self-hosted tests wire the admin routes without a proxy); report an
+	// unknown universe rather than panicking.
+	if s == nil {
+		return nil
+	}
+	universe := s.routableUniverse()
+	out := make(map[string]struct{}, len(universe))
+	for m := range universe {
+		out[m] = struct{}{}
+	}
+	return out
+}
+
 // ExcludedModelsOverride returns a sorted copy of the override list.
 func (s *Service) ExcludedModelsOverride() []string {
 	if s.excludedModelsOverride == nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -181,7 +181,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 			mgmt.GET("/excluded-models", admin.GetExcludedModelsHandler(authSvc, deployedModels, proxySvc))
 			mgmt.PUT("/excluded-models", admin.UpdateExcludedModelsHandler(authSvc, deployedModels, proxySvc))
 			mgmt.GET("/allowed-models", admin.GetAllowedModelsHandler(authSvc, deployedModels))
-			mgmt.PUT("/allowed-models", admin.UpdateAllowedModelsHandler(authSvc, deployedModels))
+			mgmt.PUT("/allowed-models", admin.UpdateAllowedModelsHandler(authSvc, deployedModels, proxySvc))
 			mgmt.GET("/excluded-providers", admin.GetExcludedProvidersHandler(authSvc, deployedModels, proxySvc))
 			mgmt.PUT("/excluded-providers", admin.UpdateExcludedProvidersHandler(authSvc, deployedModels, proxySvc))
 		}


### PR DESCRIPTION
## Summary
- Greptile was right: after #1041, `PUT /admin/v1/allowed-models` accepts any catalog ID. A non-empty allowlist is desugared as “exclude every model in `routableUniverse()` that isn’t listed,” so a list with no routable member (e.g. only `claude-opus-4-8` on a box that serves `claude-opus-4-7`) empties the candidate pool and every routed request 400s with `ErrAllowlistEmptiesPool`.
- Membership stays catalog-wide so force-model / hard-pin can still name non-roster rows. The new guard requires at least one ID in `proxy.Service.RoutableModels()` (the same set the desugaring uses). Empty list still clears the restriction. Unknown IDs still surface as `ErrUnknownModel` first.

## Test plan
- [x] `go test ./internal/api/admin/` (guard + HTTP 400)
- [x] `go test ./internal/proxy/` (wholly-unroutable allowlist empties the pool; `RoutableModels` matches the desugaring universe)
- [x] `wv mr tc` / `wv mr t`

🤖 Generated with [Weave Router](https://router.workweave.ai)