### PR TITLE
Include Codex session ID in logging

### DIFF
--- a/internal/proxy/client_identity.go
+++ b/internal/proxy/client_identity.go
@@ -41,13 +41,30 @@ func ClientIdentityFrom(ctx context.Context) ClientIdentity {
 // anthropic.stashClientIdentity) overlay those after calling this.
 func ClientIdentityFromHeaders(h http.Header) ClientIdentity {
 	return ClientIdentity{
-		SessionID:   NormalizeClientIdentifier(h.Get("X-Claude-Code-Session-Id")),
+		SessionID:   sessionIDFromHeaders(h),
 		Email:       NormalizeEmail(h.Get("X-Weave-User-Email")),
 		DisplayName: NormalizeDisplayName(h.Get("X-Weave-User-Name")),
 		UserAgent:   h.Get("User-Agent"),
 		ClientApp:   NormalizeClientApp(h.Get("X-App"), h.Get("User-Agent")),
 		RolloutID:   NormalizeRolloutID(h.Get(RolloutIDHeader)),
 	}
+}
+
+// sessionIDFromHeaders picks the first usable client session id. Claude Code
+// sends X-Claude-Code-Session-Id; Codex 0.149+ sends Session-Id (and Thread-Id
+// with the same value on the main thread). First match wins so a mixed
+// client cannot have Claude Code's header overwritten by Codex leftovers.
+func sessionIDFromHeaders(h http.Header) string {
+	for _, key := range [...]string{
+		"X-Claude-Code-Session-Id",
+		"Session-Id",
+		"Thread-Id",
+	} {
+		if id := NormalizeClientIdentifier(h.Get(key)); id != "" {
+			return id
+		}
+	}
+	return ""
 }
 
 // ResolveUserFromContext dispatches identity signals from ctx to

--- a/internal/proxy/client_identity_test.go
+++ b/internal/proxy/client_identity_test.go
@@ -3,6 +3,7 @@ package proxy_test
 import (
 	"context"
 	"errors"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -201,4 +202,38 @@ func TestResolveUserFromContext_BothMissingIsNoOp(t *testing.T) {
 	assert.Empty(t, repo.emailUpserts)
 	assert.Empty(t, repo.accountUpserts)
 	assert.Equal(t, "", auth.UserIDFrom(ctx))
+}
+
+func TestClientIdentityFromHeaders_SessionIDSources(t *testing.T) {
+	claude := "4dbee464-ebf7-437f-9f20-db5a6f7fe3b4"
+	codex := "01a03b54-9459-7373-a349-88a59b825211"
+
+	t.Run("claude code header", func(t *testing.T) {
+		h := http.Header{}
+		h.Set("X-Claude-Code-Session-Id", claude)
+		assert.Equal(t, claude, proxy.ClientIdentityFromHeaders(h).SessionID)
+	})
+	t.Run("codex Session-Id", func(t *testing.T) {
+		h := http.Header{}
+		h.Set("Session-Id", codex)
+		h.Set("Thread-Id", codex)
+		h.Set("X-App", "codex")
+		got := proxy.ClientIdentityFromHeaders(h)
+		assert.Equal(t, codex, got.SessionID)
+		assert.Equal(t, proxy.ClientAppCodex, got.ClientApp)
+	})
+	t.Run("codex Thread-Id fallback", func(t *testing.T) {
+		h := http.Header{}
+		h.Set("Thread-Id", codex)
+		assert.Equal(t, codex, proxy.ClientIdentityFromHeaders(h).SessionID)
+	})
+	t.Run("claude header wins over Session-Id", func(t *testing.T) {
+		h := http.Header{}
+		h.Set("X-Claude-Code-Session-Id", claude)
+		h.Set("Session-Id", codex)
+		assert.Equal(t, claude, proxy.ClientIdentityFromHeaders(h).SessionID)
+	})
+	t.Run("no session headers", func(t *testing.T) {
+		assert.Equal(t, "", proxy.ClientIdentityFromHeaders(http.Header{}).SessionID)
+	})
 }

--- a/internal/proxy/session_key.go
+++ b/internal/proxy/session_key.go
@@ -53,12 +53,19 @@ func bindRequestLogger(
 		"api_key_id", apiKeyID,
 		"ingress", ingress,
 	)
-	// The client's own session id (e.g. Claude Code's /status UUID), bound
-	// when present so operators can grep by the id the user actually sees.
+	// The client's own session id, bound when present so operators can grep
+	// by the id the user actually sees. Envelope first (Claude Code packs it
+	// in metadata.user_id); header identity covers Codex, which sends
+	// Session-Id and never a Chat Completions `user` field.
+	cs := ""
 	if env != nil {
-		if cs := env.ClientSessionID(); cs != "" {
-			log = log.With("client_session_id", cs)
-		}
+		cs = env.ClientSessionID()
+	}
+	if cs == "" {
+		cs = ClientIdentityFrom(ctx).SessionID
+	}
+	if cs != "" {
+		log = log.With("client_session_id", cs)
 	}
 	return observability.WithLogger(ctx, log), log, key
 }


### PR DESCRIPTION
## Summary
Codex CLI 0.149+ sends its printed session id as `Session-Id` / `Thread-Id` on `POST /v1/responses`, not `X-Claude-Code-Session-Id`. Identity, slog (`client_session_id`), OTel (`client.session_id`), and telemetry `session_id` now pick those headers up, with Claude Code's header still winning if both are present.

## Test plan
- [x] `go test ./internal/proxy -run TestClientIdentityFromHeaders_SessionIDSources`
- [ ] Confirm a live Codex turn's structured logs include `client_session_id` matching the CLI `session id:` line

🤖 Generated with [Weave Router](https://router.workweave.ai)