### PR TITLE
feat(install): reuse the installed router key for Codex, opencode, and pi

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -249,12 +249,12 @@ env or disk only, refreshes the managed config and assets in place, and errors
 ```bash
 npx @workweave/router update --claude                    # user scope
 npx @workweave/router update --claude --scope project    # in the repo
+npx @workweave/router update --codex                     # Codex / opencode / pi too
 ```
 
 A rejected key is an error for `update` (exit 1), not a warning, so a scheduled
-run surfaces a revoked key instead of logging past it. `update` currently
-supports `--claude`; for the other targets re-run the installer normally — it
-reuses your installed key the same way.
+run surfaces a revoked key instead of logging past it. `update` works for every
+target; a plain re-run of the installer reuses your installed key the same way.
 
 **Claude Code also refreshes itself.** `cc-statusline.sh` checks
 `raw.githubusercontent.com` for a newer copy of itself at most once every

--- a/install/install.sh
+++ b/install/install.sh
@@ -49,10 +49,11 @@
 #   npx @workweave/router --uninstall                      # remove a previous install (delegates to uninstall.sh)
 #
 # Re-running the installer reuses the key already on disk, so you only paste it
-# once. `update` is the scriptable form of that: it never prompts, refreshes the
-# managed config + assets in place, and errors (rather than asking) when no key
-# can be found:
+# once — for every client, not just Claude Code. `update` is the scriptable form
+# of that: it never prompts, refreshes the managed config + assets in place, and
+# errors (rather than asking) when no key can be found:
 #   npx @workweave/router update --claude                  # refresh the Claude Code install in place
+#   npx @workweave/router update --codex                   # same for Codex / opencode / pi
 #
 # Toggle an existing install on/off without losing the router config (so
 # switching back is instant). These never prompt for a key and require an
@@ -1157,12 +1158,13 @@ if [ "$mode" != "install" ] && [ "$mode" != "update" ]; then
   fi
 fi
 
-# Only Claude Code's settings are read back for a key today (read_installed_key),
-# so `models` can't authenticate as any other client. Fail fast here rather than
-# falling through to the toggle dispatch, which would flip config nobody asked
-# to change.
+# `models` resolves the endpoint and the trust decision out of Claude Code's
+# settings files specifically (resolve_installed_base_url +
+# models_endpoint_is_trusted), so it can't yet address another client's install.
+# Fail fast here rather than falling through to the toggle dispatch, which would
+# flip config nobody asked to change.
 if [ "$mode" = "models" ] && [ "$target" != "claude" ]; then
-  err "'models' currently supports --claude only (it reads the router key from Claude Code's settings)."
+  err "'models' currently supports --claude only (it resolves the router endpoint from Claude Code's settings)."
   exit 2
 fi
 
@@ -1183,10 +1185,6 @@ if [ "$mode" = "update" ]; then
   non_interactive="true"
   if [ "$rotate_key" = "true" ]; then
     err "--rotate-key needs a prompt, which 'update' never issues. Re-run the installer without 'update'."
-    exit 2
-  fi
-  if [ "$target" != "claude" ]; then
-    err "'update' currently supports --claude only. Re-run the installer for $target (it reuses your installed key)."
     exit 2
   fi
 fi
@@ -1664,14 +1662,81 @@ claude_key_present() {
   [ -n "$(read_claude_key "$1")" ]
 }
 
-# read_installed_key prints the router key this install already has on disk, or
-# nothing. Only Claude Code is supported today; the other targets still prompt.
-# Defined up here rather than with the rest of token handling because `models`
-# dispatches (and needs a key) before that section runs.
+# key_source_is_own returns 0 when a config file is safe to read a router key
+# back out of. Codex, opencode, and pi all embed the key in a file that lives
+# INSIDE the project in project scope, and the installer gitignores each one —
+# so a file git tracks is by definition not this user's own install. A hostile
+# checkout could commit one carrying an attacker's rk_ key, and adopting it
+# would bill the developer's traffic to whoever wrote the repo. Same tracked-file
+# test models_endpoint_is_trusted applies to a planted endpoint.
 #
-# models_key_file_order echoes the precedence this uses, so a caller that needs
-# to know *which* file the key came from can walk the same list (a command
-# substitution around this function would discard any global it set).
+# Claude Code deliberately does NOT go through this: read_installed_key is
+# documented to pick up a committed header from an older install, which is a
+# supported case there.
+key_source_is_own() {
+  local f="$1"
+  [ -f "$f" ] || return 1
+  [ -L "$f" ] && return 1
+  # Only project-scoped installs put the file somewhere a repo can reach.
+  [ "$scope" = "project" ] && [ -z "$install_dir" ] || return 0
+  command -v git >/dev/null 2>&1 || return 1
+  git -C "$(dirname "$f")" ls-files --error-unmatch -- "$f" >/dev/null 2>&1 && return 1
+  return 0
+}
+
+# read_codex_key prints the router key out of Codex's config.toml, or nothing.
+# Scoped to the managed block so a key-shaped string the user wrote elsewhere in
+# the file is never adopted. awk rather than jq on purpose: the Codex path is the
+# one target that doesn't require jq (see the require_cmd block above).
+read_codex_key() {
+  local f="$1"
+  key_source_is_own "$f" || return 0
+  awk -v begin="$WEAVE_CODEX_BEGIN_MARKER" -v end="$WEAVE_CODEX_END_MARKER" '
+    $0 == begin { inblk = 1; next }
+    $0 == end   { inblk = 0; next }
+    inblk && match($0, /"X-Weave-Router-Key"[[:space:]]*=[[:space:]]*"[^"]*"/) {
+      hdr = substr($0, RSTART, RLENGTH)
+      sub(/^.*=[[:space:]]*"/, "", hdr)
+      sub(/"$/, "", hdr)
+      print hdr
+      exit
+    }
+  ' "$f" 2>/dev/null || true
+}
+
+# read_opencode_key prints the router key out of opencode.json's managed
+# provider, or nothing. The header is the authoritative copy — options.apiKey is
+# only a parse-time placeholder for the @ai-sdk/openai provider.
+read_opencode_key() {
+  local f="$1"
+  key_source_is_own "$f" || return 0
+  json_get "$f" '.provider.weave.options.headers["X-Weave-Router-Key"]'
+}
+
+# read_pi_key prints the router key this pi install already has. The dedicated
+# key file comes first — it is what the @workweave/router extension itself reads
+# at runtime — and models.json is the fallback for an install whose key file was
+# removed by hand.
+read_pi_key() {
+  local key=""
+  if key_source_is_own "$pi_key_file"; then
+    key="$(tr -d '[:space:]' <"$pi_key_file" 2>/dev/null || true)"
+  fi
+  if [ -z "$key" ] && key_source_is_own "$pi_models_file"; then
+    key="$(json_get "$pi_models_file" '.providers.weave.headers["X-Weave-Router-Key"]')"
+  fi
+  printf '%s' "$key"
+}
+
+# read_installed_key prints the router key this install already has on disk, or
+# nothing, for whichever client is being installed. Reading it back is what makes
+# a re-run painless — see the token-handling section below. Defined up here
+# rather than with the rest of token handling because `models` dispatches (and
+# needs a key) before that section runs.
+#
+# models_key_file_order echoes the precedence the Claude reader uses, so a caller
+# that needs to know *which* file the key came from can walk the same list (a
+# command substitution around this function would discard any global it set).
 models_key_file_order() {
   if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
     printf '%s\n%s\n%s\n' "$local_settings_file" "$settings_file" "$settings_dir/.weave-parked.json"
@@ -1680,8 +1745,7 @@ models_key_file_order() {
   fi
 }
 
-read_installed_key() {
-  [ "$target" = "claude" ] || return 0
+read_claude_installed_key() {
   local key="" candidate
   # Mirror where the install path writes the key: project scope (no --dir) puts
   # it in the gitignored settings.local.json, everything else inlines it into
@@ -1697,6 +1761,15 @@ read_installed_key() {
     [ -n "$key" ] && break
   done <<<"$(models_key_file_order)"
   printf '%s' "$key"
+}
+
+read_installed_key() {
+  case "$target" in
+    claude)   read_claude_installed_key ;;
+    codex)    read_codex_key "$codex_config_file" ;;
+    opencode) read_opencode_key "$opencode_config_file" ;;
+    pi)       read_pi_key ;;
+  esac
 }
 
 # resolve_installed_base_url prints the router endpoint this Claude Code install
@@ -1722,6 +1795,54 @@ resolve_installed_base_url() {
     fi
   done <<<"$(models_base_file_order)"
   printf ''
+}
+
+# resolve_installed_endpoint prints the router endpoint this install already
+# points at, for whichever client is being installed, or nothing. `update` uses
+# it so a refresh never silently retargets a self-hosted install at the hosted
+# default.
+#
+# The stored shapes differ by client and are normalized back to the root the
+# installer takes on the command line: Codex and opencode hold an OpenAI-style
+# base ending in /v1, while pi holds the bare root (its Anthropic SDK appends
+# /v1/messages itself). Same tracked-file gate as the key readers — a config the
+# repo supplied is not this user's install, whichever field is being read.
+resolve_installed_endpoint() {
+  local found=""
+  case "$target" in
+    claude)
+      resolve_installed_base_url
+      return 0
+      ;;
+    codex)
+      if key_source_is_own "$codex_config_file"; then
+        found="$(awk -v begin="$WEAVE_CODEX_BEGIN_MARKER" -v end="$WEAVE_CODEX_END_MARKER" '
+          $0 == begin { inblk = 1; next }
+          $0 == end   { inblk = 0; next }
+          inblk && match($0, /^[[:space:]]*base_url[[:space:]]*=[[:space:]]*"[^"]*"/) {
+            line = substr($0, RSTART, RLENGTH)
+            sub(/^.*=[[:space:]]*"/, "", line)
+            sub(/"$/, "", line)
+            print line
+            exit
+          }
+        ' "$codex_config_file" 2>/dev/null || true)"
+      fi
+      found="${found%/v1}"
+      ;;
+    opencode)
+      if key_source_is_own "$opencode_config_file"; then
+        found="$(json_get "$opencode_config_file" '.provider.weave.options.baseURL')"
+      fi
+      found="${found%/v1}"
+      ;;
+    pi)
+      if key_source_is_own "$pi_models_file"; then
+        found="$(json_get "$pi_models_file" '.providers.weave.baseUrl')"
+      fi
+      ;;
+  esac
+  printf '%s' "${found%/}"
 }
 
 # models_endpoint_is_trusted returns 0 when it is safe to send the router key
@@ -2472,8 +2593,8 @@ fi
 # `off` parks the router URL and points Claude Code at Anthropic, so the parked
 # sidecar is the authority while toggled off — reading the live file there would
 # pin the install to api.anthropic.com.
-if [ "$mode" = "update" ] && [ "$base_url_explicit" != "true" ] && [ "$target" = "claude" ]; then
-  installed_base="$(resolve_installed_base_url)"
+if [ "$mode" = "update" ] && [ "$base_url_explicit" != "true" ]; then
+  installed_base="$(resolve_installed_endpoint)"
   if [ -n "$installed_base" ]; then
     base_url="${installed_base%/}"
   fi
@@ -2830,6 +2951,98 @@ $(weave_registry_skill_names codex)
 EOF
 }
 
+# ---------- post-install verification (shared by every target) ----------
+#
+# Every client gets the same two probes — reach the router, then prove the key
+# it was just handed actually authenticates — so a working install produces the
+# same green checks regardless of which one was installed.
+
+# validate_key asks the router whether $api_key is live. The key goes over stdin
+# (`@-`) rather than a -H argument so it never appears in the process arg list,
+# where `ps` / /proc would expose it to other local users on a shared machine.
+# Wrapped in a function so the spinner's exec form sees a single command argv.
+validate_key() {
+  printf '%s: %s\n' "$router_key_header" "$api_key" \
+    | curl -fsS --max-time 5 --header @- "$base_url/validate"
+}
+
+# rewrite_installed_key rewrites this target's managed config with the key in $1.
+# Used by the rejected-key fallback below to swap in a replacement without
+# re-running the whole install.
+rewrite_installed_key() {
+  local key="$1"
+  case "$target" in
+    claude)   write_claude_settings "$key" ;;
+    codex)    write_codex_config "$codex_config_file" "$base_url" "$key" "$user_email" "$user_name" ;;
+    opencode) write_opencode_config "$opencode_config_file" "$base_url" "$key" "$user_email" "$user_name" ;;
+    pi)
+      write_pi_models_config "$pi_models_file" "$base_url" "$key" "$user_email" "$user_name"
+      printf '%s\n' "$key" >"$pi_key_file"
+      chmod 600 "$pi_key_file"
+      ;;
+  esac
+}
+
+verify_install() {
+  if [ "$quiet" != "true" ]; then
+    if ! spin "Pinging $base_url/health" curl -fsS --max-time 5 "$base_url/health"; then
+      warn "Could not reach $base_url/health within 5s. Settings are written; verify the router is running."
+    fi
+  fi
+
+  [ -n "$api_key" ] || return 0
+
+  spin "Validating API key" validate_key && return 0
+
+  # A key we read back off disk can have been revoked or rotated since it was
+  # installed, and reusing it silently would leave a broken install behind
+  # exactly where the old behavior (always prompt) would have fixed it. Ask
+  # once, then rewrite the config with whatever the user pastes. Anywhere a
+  # prompt isn't available — non-interactive, update, --quiet, no tty, or a
+  # key that didn't come from disk — keep the historical warn-and-continue.
+  if [ "$api_key_source" = "disk" ] && [ "$non_interactive" != "true" ] \
+     && [ "$quiet" != "true" ] && [ -r /dev/tty ]; then
+    warn "The router key already installed was rejected (revoked or rotated)."
+    prompt_for_key
+    rewrite_installed_key "$api_key"
+    if ! spin "Validating API key" validate_key; then
+      warn "Router rejected the API key (check it matches the dashboard at $base_url)."
+    fi
+    return 0
+  fi
+
+  if [ "$mode" = "update" ]; then
+    # update is meant for cron/scripting: a rejected key is a real failure,
+    # not a note in the log. --quiet callers opted out of the noise, not out
+    # of the nonzero exit — a scheduled run that reports success here would
+    # hide a revoked key indefinitely.
+    if [ "$quiet" = "true" ]; then
+      warn "Router rejected the installed API key. Re-run the installer to set a new one."
+    else
+      err "Router rejected the installed API key. Re-run the installer to set a new one."
+    fi
+    exit 1
+  fi
+
+  warn "Router rejected the API key (check it matches the dashboard at $base_url)."
+}
+
+# announce_done prints the closing line for the client named in $1. `update`
+# refreshed an existing install rather than creating one, so it says so and
+# skips the uninstall hint — that run was never the user's first contact with
+# the installer.
+announce_done() {
+  printf "\n"
+  if [ "$mode" = "update" ]; then
+    printf "%s✓%s %s%sWeave Router config refreshed for %s.%s\n" \
+      "$C_GREEN" "$C_RESET" "$C_BOLD" "$C_BRAND" "$1" "$C_RESET"
+    return 0
+  fi
+  printf "%s✓%s %s%sWeave Router installed for %s.%s\n" \
+    "$C_GREEN" "$C_RESET" "$C_BOLD" "$C_BRAND" "$1" "$C_RESET"
+}
+
+# ---------- codex install path (dispatch + exit before the Claude-only writes) ----------
 
 if [ "$target" = "codex" ]; then
   write_codex_config "$codex_config_file" "$base_url" "$api_key" "$user_email" "$user_name"
@@ -2856,35 +3069,15 @@ if [ "$target" = "codex" ]; then
     ok "Updated $gitignore (ignored .codex/config.toml)"
   fi
 
-  # Post-install verification: same probes the Claude path runs so a working
-  # install gives the same green checks regardless of target.
-  if [ "$quiet" != "true" ]; then
-    if ! spin "Pinging $base_url/health" curl -fsS --max-time 5 "$base_url/health"; then
-      warn "Could not reach $base_url/health within 5s. Settings are written; verify the router is running."
-    fi
-  fi
+  verify_install
 
-  if [ -n "$api_key" ]; then
-    # Pass the router key via stdin (`@-`) instead of -H so it never lands in
-    # the process arg list. Mirrors the Claude-path validate logic.
-    validate_codex_key() {
-      printf '%s: %s\n' "$router_key_header" "$api_key" \
-        | curl -fsS --max-time 5 --header @- "$base_url/validate"
-    }
-    if ! spin "Validating API key" validate_codex_key; then
-      warn "Router rejected the API key (check it matches the dashboard at $base_url/ui/)."
-    fi
-  fi
-
-  printf "\n"
-  printf "%s✓%s %s%sWeave Router installed for Codex.%s\n" \
-    "$C_GREEN" "$C_RESET" "$C_BOLD" "$C_BRAND" "$C_RESET"
+  announce_done "Codex"
   if [ "$scope" = "project" ] || [ -n "$install_dir" ]; then
     # Codex auto-discovers ~/.codex; for non-user installs the caller has to
     # point CODEX_HOME at the directory we wrote so Codex finds our config.
     info "Run Codex with CODEX_HOME=$codex_dir codex so it picks up this config."
   fi
-  print_uninstall_hint
+  [ "$mode" = "update" ] || print_uninstall_hint
   exit 0
 fi
 
@@ -2932,26 +3125,9 @@ if [ "$target" = "opencode" ]; then
     info "opencode restart required for commands to take effect."
   fi
 
-  # Post-install verification: same probes the Claude/Codex paths run.
-  if [ "$quiet" != "true" ]; then
-    if ! spin "Pinging $base_url/health" curl -fsS --max-time 5 "$base_url/health"; then
-      warn "Could not reach $base_url/health within 5s. Settings are written; verify the router is running."
-    fi
-  fi
+  verify_install
 
-  if [ -n "$api_key" ]; then
-    validate_opencode_key() {
-      printf '%s: %s\n' "$router_key_header" "$api_key" \
-        | curl -fsS --max-time 5 --header @- "$base_url/validate"
-    }
-    if ! spin "Validating API key" validate_opencode_key; then
-      warn "Router rejected the API key (check it matches the dashboard at $base_url/ui/)."
-    fi
-  fi
-
-  printf "\n"
-  printf "%s✓%s %s%sWeave Router installed for opencode.%s\n" \
-    "$C_GREEN" "$C_RESET" "$C_BOLD" "$C_BRAND" "$C_RESET"
+  announce_done "opencode"
   # Surface the optional subscription-routing path only when this run actually
   # registered the weave-claude login provider (which is written together with
   # the plugin). Gate on its presence in the written config (authoritative)
@@ -2966,7 +3142,7 @@ if [ "$target" = "opencode" ]; then
     # has to point opencode at the file explicitly.
     info "Run opencode with OPENCODE_CONFIG=$opencode_config_file opencode."
   fi
-  print_uninstall_hint
+  [ "$mode" = "update" ] || print_uninstall_hint
   exit 0
 fi
 
@@ -3007,30 +3183,13 @@ if [ "$target" = "pi" ]; then
     ok "Updated $gitignore (ignored repo-local .pi router config)"
   fi
 
-  # Post-install verification: same probes the Claude/Codex/opencode paths run.
-  if [ "$quiet" != "true" ]; then
-    if ! spin "Pinging $base_url/health" curl -fsS --max-time 5 "$base_url/health"; then
-      warn "Could not reach $base_url/health within 5s. Settings are written; verify the router is running."
-    fi
-  fi
-
-  if [ -n "$api_key" ]; then
-    validate_pi_key() {
-      printf '%s: %s\n' "$router_key_header" "$api_key" \
-        | curl -fsS --max-time 5 --header @- "$base_url/validate"
-    }
-    if ! spin "Validating API key" validate_pi_key; then
-      warn "Router rejected the API key (check it matches the dashboard at $base_url/ui/)."
-    fi
-  fi
+  verify_install
 
   if [ -n "$lsp_langs" ]; then
     install_lsp_servers "$lsp_langs"
   fi
 
-  printf "\n"
-  printf "%s✓%s %s%sWeave Router installed for pi.%s\n" \
-    "$C_GREEN" "$C_RESET" "$C_BOLD" "$C_BRAND" "$C_RESET"
+  announce_done "pi"
   # Billing note: pi normally draws on a Claude subscription (OAuth); routing
   # through the router switches to per-token billing on the router deployment
   # key (or BYOK). Surface it at install so the change isn't a surprise.
@@ -3038,7 +3197,7 @@ if [ "$target" = "pi" ]; then
   if [ "$scope" = "project" ] || [ -n "$install_dir" ]; then
     info "Run pi with PI_CODING_AGENT_DIR=$pi_dir pi so it picks up this config."
   fi
-  print_uninstall_hint
+  [ "$mode" = "update" ] || print_uninstall_hint
   exit 0
 fi
 
@@ -4053,61 +4212,9 @@ fi
 
 # ---------- post-install verification ----------
 
-if [ "$quiet" != "true" ]; then
-  if ! spin "Pinging $base_url/health" curl -fsS --max-time 5 "$base_url/health"; then
-    warn "Could not reach $base_url/health within 5s. Settings are written; verify the router is running."
-  fi
-fi
-
-if [ -n "$api_key" ]; then
-  # Pass the router key via stdin (`@-`) instead of a -H argument so the key
-  # never appears in the process arg list (visible via `ps` / /proc to other
-  # local users on shared machines). We feed stdin via a small wrapper so the
-  # spinner's exec form sees a single command argv.
-  validate_key() {
-    printf '%s: %s\n' "$router_key_header" "$api_key" \
-      | curl -fsS --max-time 5 --header @- "$base_url/validate"
-  }
-  if ! spin "Validating API key" validate_key; then
-    # A key we read back off disk can have been revoked or rotated since it was
-    # installed, and reusing it silently would leave a broken install behind
-    # exactly where the old behavior (always prompt) would have fixed it. Ask
-    # once, then rewrite the settings with whatever the user pastes. Anywhere a
-    # prompt isn't available — non-interactive, update, --quiet, no tty, or a
-    # key that didn't come from disk — keep the historical warn-and-continue.
-    if [ "$api_key_source" = "disk" ] && [ "$non_interactive" != "true" ] \
-       && [ "$quiet" != "true" ] && [ -r /dev/tty ]; then
-      warn "The router key already installed was rejected (revoked or rotated)."
-      prompt_for_key
-      write_claude_settings "$api_key"
-      if ! spin "Validating API key" validate_key; then
-        warn "Router rejected the API key (check it matches the dashboard at $base_url)."
-      fi
-    elif [ "$mode" = "update" ]; then
-      # update is meant for cron/scripting: a rejected key is a real failure,
-      # not a note in the log. --quiet callers opted out of the noise, not out
-      # of the nonzero exit — a scheduled run that reports success here would
-      # hide a revoked key indefinitely.
-      if [ "$quiet" = "true" ]; then
-        warn "Router rejected the installed API key. Re-run the installer to set a new one."
-      else
-        err "Router rejected the installed API key. Re-run the installer to set a new one."
-      fi
-      exit 1
-    else
-      warn "Router rejected the API key (check it matches the dashboard at $base_url)."
-    fi
-  fi
-fi
+verify_install
 
 # ---------- done ----------
 
-printf "\n"
-if [ "$mode" = "update" ]; then
-  printf "%s✓%s %s%sWeave Router config refreshed for Claude Code.%s\n" \
-    "$C_GREEN" "$C_RESET" "$C_BOLD" "$C_BRAND" "$C_RESET"
-  exit 0
-fi
-printf "%s✓%s %s%sWeave Router installed for Claude Code.%s\n" \
-  "$C_GREEN" "$C_RESET" "$C_BOLD" "$C_BRAND" "$C_RESET"
-print_uninstall_hint
+announce_done "Claude Code"
+[ "$mode" = "update" ] || print_uninstall_hint

--- a/install/install.sh
+++ b/install/install.sh
@@ -1191,8 +1191,10 @@ fi
 
 # Toggle verbs (off/on/status) aren't implemented for pi — its config is a
 # structural models.json/settings.json merge, reversed by the uninstaller
-# rather than a single env/key line we can park and restore.
-if [ "$mode" != "install" ] && [ "$target" = "pi" ]; then
+# rather than a single env/key line we can park and restore. `update` is not a
+# toggle: it rewrites that same structural config in place, exactly as install
+# does, so it belongs with install here.
+if [ "$mode" != "install" ] && [ "$mode" != "update" ] && [ "$target" = "pi" ]; then
   err "Toggle verbs (off/on/status) aren't supported for --pi. Use 'npx @workweave/router --uninstall --pi' to remove, or re-run the installer to refresh."
   exit 2
 fi

--- a/install/npm/README.md
+++ b/install/npm/README.md
@@ -15,11 +15,13 @@ npx @workweave/router --non-interactive     # reads $WEAVE_ROUTER_KEY, no prompt
 ```
 
 Re-running the installer to pick up changes reuses the key already on disk, so
-you paste it once and never again. `update` is the never-prompting form of that
-(safe for cron; errors instead of asking when no key can be found):
+you paste it once and never again — for every client, not just Claude Code.
+`update` is the never-prompting form of that (safe for cron; errors instead of
+asking when no key can be found):
 
 ```bash
 npx @workweave/router --claude                # reuses the installed key
+npx @workweave/router --codex                 # same for Codex, opencode, and pi
 npx @workweave/router --claude --rotate-key   # ignore it and prompt for a new one
 npx @workweave/router update --claude         # non-interactive refresh in place
 ```
@@ -28,7 +30,7 @@ For Claude Code the installed statusline and `/force-model`, `/router-*` slash
 commands also refresh themselves in the background about once a week (never
 overwriting a wrapper you edited). Opt out with `WEAVE_STATUSLINE_UPDATE=0`, or
 just the commands with `WEAVE_COMMANDS_UPDATE=0`. Codex, opencode, and pi have
-no per-turn hook to refresh from — re-run the installer for those.
+no per-turn hook to refresh from — re-run the installer (or `update`) for those.
 
 Version-pin for reproducible setups:
 

--- a/install/tests/key_reuse_test.sh
+++ b/install/tests/key_reuse_test.sh
@@ -50,6 +50,25 @@ installed_key() { # installed_key <settings_file>
     | sed -n 's/^X-Weave-Router-Key: //p'
 }
 
+# Per-target readers for the same key, each pulling from where that client's
+# install actually stores it. Deliberately independent of install.sh's own
+# parsers: a test that reused them would pass even if both sides were wrong.
+codex_key() { # codex_key <config.toml>
+  sed -n 's/.*"X-Weave-Router-Key"[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$1" 2>/dev/null | head -n 1
+}
+
+opencode_key() { # opencode_key <opencode.json>
+  jq -r '.provider.weave.options.headers["X-Weave-Router-Key"] // ""' "$1" 2>/dev/null
+}
+
+pi_key() { # pi_key <models.json>
+  jq -r '.providers.weave.headers["X-Weave-Router-Key"] // ""' "$1" 2>/dev/null
+}
+
+codex_base() { # codex_base <config.toml>
+  sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$1" 2>/dev/null | head -n 1
+}
+
 echo "install.sh key reuse"
 
 # ---------- user scope ----------
@@ -150,10 +169,10 @@ check "quiet update still exits nonzero on rejection" "$?" 1
 run "$upd_home" -- update --claude --rotate-key
 check "update rejects --rotate-key" "$?" 2
 
-# Only Claude Code is wired up; the other targets must say so rather than
-# half-running an install path that still expects a prompt.
+# update reaches every target now, so an unconfigured one must fail on the
+# missing key (1) rather than on the target itself (2, the old gate).
 run "$upd_home" -- update --codex
-check "update rejects an unsupported target" "$?" 2
+check "update on an uninstalled target errors on the key" "$?" 1
 
 # ---------- command baseline seeding ----------
 #
@@ -253,6 +272,151 @@ check "update while off (project scope) drops the direct-to-Anthropic override" 
   "$(jq -r '.env.ANTHROPIC_BASE_URL // ""' "$proj_off_local")" ""
 check "update while off (project scope) leaves the router URL live in settings.json" \
   "$(jq -r '.env.ANTHROPIC_BASE_URL // ""' "$proj_off_settings")" "https://router.workweave.ai"
+
+# ---------- codex / opencode / pi: the same read-back Claude Code has ----------
+#
+# These three used to demand the key on every re-run — the installer only ever
+# read a key back out of Claude Code's settings. Each stores it somewhere
+# different (TOML header block, opencode.json provider, pi's key file), so each
+# needs its own case rather than one loop over the target flag.
+#
+# Every run here uses --dir: a self-contained sandbox, so no case can reach the
+# fixture $HOME's Claude install and pass on the wrong client's key.
+
+echo
+echo "install.sh key reuse — codex / opencode / pi"
+
+# run_dir <home> <dir> [env-key] -- <installer args...>
+# Same shape as `run`, plus the --dir sandbox each of these targets installs into.
+run_dir() {
+  local home="$1" dir="$2"; shift 2
+  local key=""
+  if [ "${1:-}" != "--" ]; then key="$1"; shift; fi
+  [ "${1:-}" = "--" ] && shift
+  HOME="$home" XDG_CACHE_HOME="$home/.cache" PATH="$test_path" NO_COLOR=1 \
+    WEAVE_ROUTER_KEY="$key" \
+    bash "$installer" "$@" --dir "$dir" --base-url http://127.0.0.1:9 </dev/null >/dev/null 2>&1
+}
+
+# check_target_reuse <label> <flag> <key-file-path-suffix> <reader>
+# Runs the four cases every target shares. The key file is resolved under the
+# sandbox dir, and <reader> is the extractor for that client's config format.
+check_target_reuse() { # <label> <flag> <relative key file> <reader fn>
+  local label="$1" flag="$2" rel="$3" reader="$4"
+  local home dir f
+  home="$work/$label-home"; dir="$work/$label-dir"
+  mkdir -p "$home" "$dir"
+  f="$dir/$rel"
+
+  run_dir "$home" "$dir" rk_${label}_first -- "$flag" --quiet --non-interactive
+  check "$label: first install stores the env key" "$("$reader" "$f")" "rk_${label}_first"
+
+  # The whole point: a re-run with nothing in the environment must not demand
+  # the key again. Without read-back this is a hard exit 1.
+  run_dir "$home" "$dir" -- "$flag" --quiet --non-interactive
+  check "$label: re-run with no env var succeeds" "$?" 0
+  check "$label: re-run keeps the installed key" "$("$reader" "$f")" "rk_${label}_first"
+
+  # Env stays highest precedence — a key the user just rotated cannot lose to
+  # the stale one on disk.
+  run_dir "$home" "$dir" rk_${label}_second -- "$flag" --quiet --non-interactive
+  check "$label: env key overwrites the installed key" "$("$reader" "$f")" "rk_${label}_second"
+
+  # --rotate-key skips read-back deliberately, so with no env and no tty there
+  # is nothing to rotate to: fail rather than silently reuse.
+  run_dir "$home" "$dir" -- "$flag" --quiet --non-interactive --rotate-key
+  check "$label: --rotate-key with no key source fails" "$?" 1
+  check "$label: --rotate-key failure leaves the key intact" "$("$reader" "$f")" "rk_${label}_second"
+
+  # update is no longer Claude-only, and must refresh in place off the same key.
+  run_dir "$home" "$dir" -- update "$flag" --quiet
+  check "$label: update reuses the installed key" "$("$reader" "$f")" "rk_${label}_second"
+}
+
+check_target_reuse codex    --codex    ".codex/config.toml" codex_key
+check_target_reuse opencode --opencode "opencode.json"      opencode_key
+check_target_reuse pi       --pi       ".pi/models.json"    pi_key
+
+# pi keeps a second copy in a dedicated key file, which is what its runtime
+# extension actually reads. Read-back has to keep both in step.
+check "pi: key file matches the config copy" \
+  "$(tr -d '[:space:]' <"$work/pi-dir/.pi/.weave_router_key" 2>/dev/null)" "rk_pi_second"
+
+# ---------- update must not retarget a custom endpoint ----------
+#
+# Claude Code already carried its endpoint across an update; the other three
+# were excluded along with everything else. A refresh that silently moved a
+# self-hosted install to the hosted default would be a much worse bug than the
+# re-prompt this change removes. Note the stored shapes differ — codex and
+# opencode append /v1, pi keeps the bare root — so each must round-trip.
+
+ep_home="$work/endpoint-home"; ep_dir="$work/endpoint-dir"
+mkdir -p "$ep_home" "$ep_dir"
+custom_ep="http://custom-router.internal:9999"
+
+# Direct invocation, not run_dir — that helper always appends its own
+# --base-url, which would set base_url_explicit and defeat the carry-over.
+HOME="$ep_home" XDG_CACHE_HOME="$ep_home/.cache" PATH="$test_path" NO_COLOR=1 \
+  WEAVE_ROUTER_KEY="rk_endpoint" \
+  bash "$installer" --codex --dir "$ep_dir" --quiet --non-interactive \
+    --base-url "$custom_ep" </dev/null >/dev/null 2>&1
+HOME="$ep_home" XDG_CACHE_HOME="$ep_home/.cache" PATH="$test_path" NO_COLOR=1 \
+  bash "$installer" update --codex --dir "$ep_dir" --quiet </dev/null >/dev/null 2>&1
+check "codex: update preserves a custom base URL, not the hosted default" \
+  "$(codex_base "$ep_dir/.codex/config.toml")" "$custom_ep/v1"
+
+# ---------- a repo-supplied key is never adopted ----------
+#
+# In project scope these configs live INSIDE the repo, and the installer
+# gitignores each one. A file git tracks therefore isn't this user's install —
+# it is what a hostile checkout would commit to have the installer adopt an
+# attacker's key and bill the developer's traffic to them. Reading it back must
+# refuse and fall through to the prompt (exit 1 here, with no tty).
+
+hostile_home="$work/hostile-home"; hostile="$work/hostile-repo"
+mkdir -p "$hostile_home" "$hostile/.codex"
+git -C "$hostile" init -q .
+git -C "$hostile" config user.email test@example.com
+git -C "$hostile" config user.name test
+cat >"$hostile/.codex/config.toml" <<'HOSTILE'
+# >>> weave-router managed (do not edit between markers) >>>
+model_provider = "weave"
+
+[model_providers.weave]
+name = "Weave Router"
+base_url = "http://127.0.0.1:9/v1"
+wire_api = "responses"
+requires_openai_auth = true
+http_headers = { "X-Weave-Router-Key" = "rk_attacker_planted", "X-App" = "codex" }
+# <<< weave-router managed <<<
+HOSTILE
+git -C "$hostile" add -f .codex/config.toml
+git -C "$hostile" commit -qm "planted router config"
+
+( cd "$hostile" && HOME="$hostile_home" XDG_CACHE_HOME="$hostile_home/.cache" \
+    PATH="$test_path" NO_COLOR=1 WEAVE_ROUTER_KEY="" \
+    bash "$installer" --codex --scope project --quiet --non-interactive \
+      --base-url http://127.0.0.1:9 </dev/null >/dev/null 2>&1 )
+check "codex: a git-tracked config's key is not adopted" "$?" 1
+
+# ---------- uninstall must not leave a key to resurrect ----------
+#
+# Read-back turns a leftover key into a silently-reused one, so uninstall has to
+# clear every copy. pi is the case that matters: it writes two.
+
+gone_home="$work/gone-home"; gone_dir="$work/gone-dir"
+mkdir -p "$gone_home" "$gone_dir"
+run_dir "$gone_home" "$gone_dir" rk_gone -- --pi --quiet --non-interactive
+HOME="$gone_home" PATH="$test_path" NO_COLOR=1 \
+  bash "$uninstaller" --pi --dir "$gone_dir" </dev/null >/dev/null 2>&1
+check "pi: uninstall removes the models.json key" \
+  "$(pi_key "$gone_dir/.pi/models.json")" ""
+[ ! -f "$gone_dir/.pi/.weave_router_key" ] && ok "pi: uninstall removes the key file" \
+  || no "pi: uninstall removes the key file" "file removed" "file still present"
+# With both copies gone there is nothing to read back, so a prompt-less re-run
+# has to fail rather than quietly resurrect the old key.
+run_dir "$gone_home" "$gone_dir" -- --pi --quiet --non-interactive
+check "pi: re-run after uninstall finds no key to reuse" "$?" 1
 
 echo
 echo "$pass passed, $fail failed"

--- a/install/tests/key_reuse_test.sh
+++ b/install/tests/key_reuse_test.sh
@@ -329,7 +329,13 @@ check_target_reuse() { # <label> <flag> <relative key file> <reader fn>
   check "$label: --rotate-key failure leaves the key intact" "$("$reader" "$f")" "rk_${label}_second"
 
   # update is no longer Claude-only, and must refresh in place off the same key.
+  # Assert the exit code, not just the key: a gate that rejects the target exits
+  # before writing anything, which leaves the key untouched and would make a
+  # key-only assertion pass on a target update never reached. The fake curl
+  # fails /validate, and update treats that as fatal, so 1 here means the run
+  # got all the way to the post-write probe.
   run_dir "$home" "$dir" -- update "$flag" --quiet
+  check "$label: update runs instead of rejecting the target" "$?" 1
   check "$label: update reuses the installed key" "$("$reader" "$f")" "rk_${label}_second"
 }
 
@@ -362,6 +368,7 @@ HOME="$ep_home" XDG_CACHE_HOME="$ep_home/.cache" PATH="$test_path" NO_COLOR=1 \
     --base-url "$custom_ep" </dev/null >/dev/null 2>&1
 HOME="$ep_home" XDG_CACHE_HOME="$ep_home/.cache" PATH="$test_path" NO_COLOR=1 \
   bash "$installer" update --codex --dir "$ep_dir" --quiet </dev/null >/dev/null 2>&1
+check "codex: update reaches the write path" "$?" 1
 check "codex: update preserves a custom base URL, not the hosted default" \
   "$(codex_base "$ep_dir/.codex/config.toml")" "$custom_ep/v1"
 


### PR DESCRIPTION
## What

Re-running the installer only ever read a key back off disk for Claude Code — `read_installed_key` opened with `[ "$target" = "claude" ] || return 0`. The other three clients demanded the key on every re-run, which is friction given the installer refreshes assets and config shape often enough that people re-run it routinely.

Each client now gets a reader for wherever it already stores the key:

| target | source |
|---|---|
| codex | `X-Weave-Router-Key` in the managed block of `.codex/config.toml` (awk — that path deliberately doesn't require jq) |
| opencode | `.provider.weave.options.headers` in `opencode.json` |
| pi | `.weave_router_key`, falling back to `.providers.weave.headers` in `models.json` |

Resolution order is unchanged and still shared: `WEAVE_ROUTER_KEY` → installed key → prompt, with `--rotate-key` skipping the read-back.

## Security: a repo-supplied key is never adopted

In project scope all three configs live **inside the repo**, and the installer gitignores each one. So a file git tracks is by definition not the user's own install — it is exactly what a hostile checkout would commit to have the installer adopt an attacker's `rk_` key and bill the developer's traffic to them. Read-back refuses a tracked (or symlinked) file and falls through to the prompt, reusing the same `git ls-files` test `models_endpoint_is_trusted` already applies to a planted endpoint.

**Claude Code deliberately keeps its current behavior** — `read_installed_key` is documented to accept "a committed header from an older install," so adding the guard there would regress a supported case. Flagging the asymmetry rather than silently closing it; happy to revisit separately.

## `update` is no longer Claude-only

Since the read-back it was gated on now exists everywhere, the `--claude`-only rejection is gone. Its endpoint carry-over is generalized with it — a refresh must not silently retarget a self-hosted install at the hosted default. Stored shapes differ (codex/opencode append `/v1`, pi keeps the bare root) and normalize back to the installer's own `--base-url` form.

`models` stays `--claude` only. Its blocker was never key read-back but the endpoint-resolution + trust machinery, which is Claude-settings-shaped; only the stale justification comment is corrected.

## Consolidation

The four copies of the health-ping + `/validate` tail collapse into one `verify_install`. That also gives every client the two behaviors only Claude had: the re-prompt when a disk key turns out to be revoked, and `update`'s nonzero exit on rejection so a cron run can't hide a dead key. Net ~40 lines removed from the duplicated tails.

## Testing

`make test-install` — 62 passed in `key_reuse_test.sh` (was 35), 79 in `models_test.sh`, codex + statusline suites green.

Per target: first install, prompt-less re-run, env precedence, `--rotate-key`, and `update`; plus a repo-planted key being refused, a custom base URL surviving `update`, and no key surviving uninstall for pi to resurrect.

Both new behaviors were verified to be non-tautological by reverting them in place — restoring the `claude`-only gate fails exactly the three "re-run with no env var succeeds" cases, and neutering the tracked-file check fails exactly the hostile-repo case.

Also driven end-to-end against a `--dir` sandbox for all three targets (install → re-run → `update` → uninstall).