### PR TITLE
fix(openaicompat): surface the real gateway error after a version probe

### DIFF
--- a/internal/providers/openaicompat/client.go
+++ b/internal/providers/openaicompat/client.go
@@ -235,15 +235,17 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	baseURL := proxy.EffectiveBaseURL(ctx, c.baseURL)
 
 	// 404s are buffered before reaching w, so a missing "/v1" segment can be retried.
-	// firstErr is returned on double-miss so the probe's 404 doesn't mask the original.
+	// A non-404 on the versioned path is the real error and is memoized; only a
+	// second 404 falls back to the probe so a genuine model-not-found is preserved.
 	urls := c.versionMemo.URLs(baseURL, "/chat/completions")
 	firstErr := c.proxyTo(ctx, cancel, urls[0], baseURL, body, decision, prep, w, r)
 	if len(urls) == 1 || !providers.IsUpstreamModelNotFound(firstErr) {
 		return firstErr
 	}
-	if err := c.proxyTo(ctx, cancel, urls[1], baseURL, body, decision, prep, w, r); err == nil {
+	err := c.proxyTo(ctx, cancel, urls[1], baseURL, body, decision, prep, w, r)
+	if err == nil || !providers.IsUpstreamModelNotFound(err) {
 		c.versionMemo.Learn(baseURL)
-		return nil
+		return err
 	}
 	return firstErr
 }

--- a/internal/providers/openaicompat/cortex_inference_test.go
+++ b/internal/providers/openaicompat/cortex_inference_test.go
@@ -2,6 +2,7 @@ package openaicompat_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -55,6 +56,38 @@ func TestProxy_GatewayBaseURLMissingVersionSegment(t *testing.T) {
 
 	paths = nil
 	require.NoError(t, c.Proxy(context.Background(), router.Decision{Model: "claude-sonnet-4-5"}, prep, httptest.NewRecorder(), clientReq))
+	assert.Equal(t, []string{"/api/v2/cortex/v1/chat/completions"}, paths)
+}
+
+// A real error on the versioned path must win over the unversioned probe 404,
+// and the working path must be memoized so the next call skips the probe.
+func TestProxy_GatewayVersionProbeSurfacesRealError(t *testing.T) {
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if r.URL.Path != "/api/v2/cortex/v1/chat/completions" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"invalid request parameters: Function tools with reasoning_effort are not supported"}`))
+	}))
+	defer srv.Close()
+
+	c := openaicompat.NewGatewayClient("tok", srv.URL+"/api/v2/cortex")
+	prep, clientReq := chatRequest()
+	err := c.Proxy(context.Background(), router.Decision{Model: "gpt-5.6-luna"}, prep, httptest.NewRecorder(), clientReq)
+
+	require.Error(t, err)
+	var upstream *providers.UpstreamErrorResponse
+	require.True(t, errors.As(err, &upstream))
+	assert.Equal(t, http.StatusBadRequest, upstream.Status)
+	assert.Contains(t, string(upstream.Body), "reasoning_effort")
+	assert.Equal(t, []string{"/api/v2/cortex/chat/completions", "/api/v2/cortex/v1/chat/completions"}, paths)
+
+	paths = nil
+	_ = c.Proxy(context.Background(), router.Decision{Model: "gpt-5.6-luna"}, prep, httptest.NewRecorder(), clientReq)
 	assert.Equal(t, []string{"/api/v2/cortex/v1/chat/completions"}, paths)
 }
 


### PR DESCRIPTION
## Summary

#1050 already drops leftover inbound `reasoning_effort` on OpenAI-format chat/completions emit. That is necessary but not sufficient for serving `gpt-5.6-luna` on an unversioned Cortex `openai_gateway` base (`…/api/v2/cortex`).

Every Cortex request first probes `{base}/chat/completions` (404, empty body), then hits `{base}/v1/chat/completions`. On a real 400 the adapter returned the **probe** 404, so Claude Code reported:

> There's an issue with the selected model (claude-opus-5[1m]). It may not exist or you may not have access to it.

while the useful Cortex body (`Function tools with reasoning_effort are not supported` / `unknown model "openai-1p-gpt-5.6-luna"`) never left the router.

This PR:

- returns the versioned-path error whenever it is not a 404
- memoizes that path so the next call skips the wasted probe

Anthropic-ingress emit already omits `reasoning_effort` for catalog `gpt-5*` (`TargetModel` stays `gpt-5.6-luna`; the Cortex alias is applied after emit). Combined with #1050, a luna turn on Cortex should now either succeed (no effort field) or fail with Cortex's real 400 instead of a fake model-not-found.

## Test plan

- [x] `go test ./internal/providers/openaicompat ./internal/providers`
- [ ] After merge + router pin bump: `sf ai claude -p "hi"` on the Cortex-backed key should not 404 as a missing `claude-opus-5[1m]`

🤖 Generated with [Weave Router](https://router.workweave.ai)