### PR TITLE
fix(observability): tag every log line with service + request correlation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,7 +180,7 @@ If new helper doesn't fit, justify new package in code comment before creating.
 - All exported symbols carry godoc starting with symbol name (`Foo does X` or `// Foo is …`).
 - Errors flow up. Don't swallow; don't log-and-continue on request path. The one documented exception is a **best-effort, off-request-path fire-and-forget** — always wrapped in [`observability.SafeGo`](internal/observability/safego.go) (bounded timeout, panic-recovering, logs its own failure), never a raw `go func(){}()`. Current call sites: `fireMarkUsed` ([auth/service.go](internal/auth/service.go)), `fireTelemetry` + `reportHMMOutcome` ([proxy/service.go](internal/proxy/service.go)), `NotifyInstallationChanged` + `NotifyRechargeNeeded` ([pubsub](internal/pubsub)).
 - Use `errors.Is` / `errors.As`, never `==` or `!=` on errors. For no-rows checks: `errors.Is(err, sql.ErrNoRows)`.
-- Use `slog` (via `observability.Get` / `observability.FromGin`), not `fmt.Println` or `log.Print*`.
+- Use `slog`, not `fmt.Println` or `log.Print*`. **On the request path, acquire the logger from the context** — `observability.FromContext(ctx)`, or `observability.FromGin(c)` in a handler. Both inherit the correlation fields `observability.Middleware` binds at first touch (`request_id`, plus `session_key` / `client_session_id` once `bindRequestLogger` runs), which is what makes one session's logs filterable end to end. `observability.Get()` returns the global logger with **no** request correlation, so a request-path line emitted through it cannot be found when filtering by session — reserve it for genuinely off-request-path code (startup, background listeners, `SafeGo` fire-and-forget). Enforced by `TestGlobalLoggerBudget`; fix a failure by threading ctx, not by raising the budget.
 - Sentinel errors typed (`var ErrFoo = errors.New(...)`) + live in same package as function that returns them. HTTP layer maps to status codes; do not export HTTP semantics from inner-ring packages.
 - Constructor injection over package-level singletons. Inject clock (`auth.Clock = func() time.Time`), logger, HTTP client, etc.
 
@@ -201,6 +201,19 @@ If new helper doesn't fit, justify new package in code comment before creating.
 - snake_case for log attribute keys (`api_key_id`, not `apiKeyID`).
 - Log `Debug` for routine ops (auth checks, repo calls); `Info` for major business events (server start, key issuance). Reserve `Error` for genuine failures needing on-call attention; auth-401 is `Debug`, not `Error`.
 - Never log raw bearer tokens or hashes. 8-char prefix + 4-char suffix (`KeyPrefix`/`KeySuffix` columns on `auth.APIKey`) are safe; full token is not.
+
+**Every line must be findable.** Correlation tags are what let an operator pull one session's full log trail; a line without them is effectively lost even though it was written. The tags are attached in two layers, and both are automatic — inherit them, never re-add by hand:
+
+| Field | Bound by | Present from |
+|---|---|---|
+| `name` | `initLogger` (from `NAME`, else `OTEL_SERVICE_NAME`, else `router`) | process start — every line |
+| `request_id` | `observability.Middleware` | first touch, before the body is read |
+| `session_key`, `api_key_id`, `ingress` | `bindRequestLogger` | after the envelope parses |
+| `client_session_id` | `bindRequestLogger` | after the envelope parses, when the client sent one |
+
+`request_id` is bound before parsing on purpose: pre-parse failures ("Failed to parse Anthropic request") used to be untagged, which made exactly the errors you go hunting for the ones you could not find. It is echoed as the `X-Request-Id` response header. An inbound `X-Request-Id` is **not** adopted — it lands in `upstream_request_id` (sanitized, length-bounded) instead, so one client reusing a value can't make `request_id` stop identifying a single request.
+
+A helper that logs on the request path takes `ctx` and calls `observability.FromContext(ctx)`. Do not add a `msg`-only log helper that reaches for `observability.Get()` internally — that silently drops every tag (this is what made upstream 4xx/5xx error bodies unfindable by session; see `httputil.LogUpstreamStatus`, which now takes `ctx` for that reason).
 
 ## Things to NEVER do
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,8 @@ If new helper doesn't fit, justify new package in code comment before creating.
 
 A helper that logs on the request path takes `ctx` and calls `observability.FromContext(ctx)`. Do not add a `msg`-only log helper that reaches for `observability.Get()` internally — that silently drops every tag (this is what made upstream 4xx/5xx error bodies unfindable by session; see `httputil.LogUpstreamStatus`, which now takes `ctx` for that reason).
 
+**Never pass a bound key as a call-site attribute.** `slog` does not dedupe: re-passing `request_id`, `session_key`, `client_session_id`, `api_key_id`, `ingress`, or `name` emits the key twice and JSON consumers keep the **last** value, overwriting the bound one — so the line goes missing from exactly the search that should find it. A different-meaning value gets a distinct key (`upstream_request_id`, `rated_request_id`, `tool_name`); an identical value is simply dropped. Enforced by `TestNoReservedLogKeyShadowing`.
+
 ## Things to NEVER do
 
 - **Never put customer/company/org names or private identifiers in anything committed here.** This repo is public — commit messages, branch names, PR titles/descriptions, code comments, tests, and fixtures are world-readable. This holds even when a change is motivated by one customer's investigation (e.g. a loop-break or spiral fix found from a specific org's agentic session): describe the trigger generically ("a customer", "a large agentic session", "an org's monorepo"). No org names, org IDs, account emails, internal ticket/Linear links, or verbatim private Slack/support excerpts — those stay in the private WorkWeave repo + Linear.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ If new helper doesn't fit, justify new package in code comment before creating.
 - All exported symbols carry godoc starting with symbol name (`Foo does X` or `// Foo is …`).
 - Errors flow up. Don't swallow; don't log-and-continue on request path. The one documented exception is a **best-effort, off-request-path fire-and-forget** — always wrapped in [`observability.SafeGo`](internal/observability/safego.go) (bounded timeout, panic-recovering, logs its own failure), never a raw `go func(){}()`. Current call sites: `fireMarkUsed` ([auth/service.go](internal/auth/service.go)), `fireTelemetry` + `reportHMMOutcome` ([proxy/service.go](internal/proxy/service.go)), `NotifyInstallationChanged` + `NotifyRechargeNeeded` ([pubsub](internal/pubsub)).
 - Use `errors.Is` / `errors.As`, never `==` or `!=` on errors. For no-rows checks: `errors.Is(err, sql.ErrNoRows)`.
-- Use `slog` (via `observability.Get` / `observability.FromGin`), not `fmt.Println` or `log.Print*`.
+- Use `slog`, not `fmt.Println` or `log.Print*`. **On the request path, acquire the logger from the context** — `observability.FromContext(ctx)`, or `observability.FromGin(c)` in a handler. Both inherit the correlation fields `observability.Middleware` binds at first touch (`request_id`, plus `session_key` / `client_session_id` once `bindRequestLogger` runs), which is what makes one session's logs filterable end to end. `observability.Get()` returns the global logger with **no** request correlation, so a request-path line emitted through it cannot be found when filtering by session — reserve it for genuinely off-request-path code (startup, background listeners, `SafeGo` fire-and-forget). Enforced by `TestGlobalLoggerBudget`; fix a failure by threading ctx, not by raising the budget.
 - Sentinel errors typed (`var ErrFoo = errors.New(...)`) + live in same package as function that returns them. HTTP layer maps to status codes; do not export HTTP semantics from inner-ring packages.
 - Constructor injection over package-level singletons. Inject clock (`auth.Clock = func() time.Time`), logger, HTTP client, etc.
 
@@ -201,6 +201,19 @@ If new helper doesn't fit, justify new package in code comment before creating.
 - snake_case for log attribute keys (`api_key_id`, not `apiKeyID`).
 - Log `Debug` for routine ops (auth checks, repo calls); `Info` for major business events (server start, key issuance). Reserve `Error` for genuine failures needing on-call attention; auth-401 is `Debug`, not `Error`.
 - Never log raw bearer tokens or hashes. 8-char prefix + 4-char suffix (`KeyPrefix`/`KeySuffix` columns on `auth.APIKey`) are safe; full token is not.
+
+**Every line must be findable.** Correlation tags are what let an operator pull one session's full log trail; a line without them is effectively lost even though it was written. The tags are attached in two layers, and both are automatic — inherit them, never re-add by hand:
+
+| Field | Bound by | Present from |
+|---|---|---|
+| `name` | `initLogger` (from `NAME`, else `OTEL_SERVICE_NAME`, else `router`) | process start — every line |
+| `request_id` | `observability.Middleware` | first touch, before the body is read |
+| `session_key`, `api_key_id`, `ingress` | `bindRequestLogger` | after the envelope parses |
+| `client_session_id` | `bindRequestLogger` | after the envelope parses, when the client sent one |
+
+`request_id` is bound before parsing on purpose: pre-parse failures ("Failed to parse Anthropic request") used to be untagged, which made exactly the errors you go hunting for the ones you could not find. It is echoed as the `X-Request-Id` response header. An inbound `X-Request-Id` is **not** adopted — it lands in `upstream_request_id` (sanitized, length-bounded) instead, so one client reusing a value can't make `request_id` stop identifying a single request.
+
+A helper that logs on the request path takes `ctx` and calls `observability.FromContext(ctx)`. Do not add a `msg`-only log helper that reaches for `observability.Get()` internally — that silently drops every tag (this is what made upstream 4xx/5xx error bodies unfindable by session; see `httputil.LogUpstreamStatus`, which now takes `ctx` for that reason).
 
 ## Things to NEVER do
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,8 @@ If new helper doesn't fit, justify new package in code comment before creating.
 
 A helper that logs on the request path takes `ctx` and calls `observability.FromContext(ctx)`. Do not add a `msg`-only log helper that reaches for `observability.Get()` internally — that silently drops every tag (this is what made upstream 4xx/5xx error bodies unfindable by session; see `httputil.LogUpstreamStatus`, which now takes `ctx` for that reason).
 
+**Never pass a bound key as a call-site attribute.** `slog` does not dedupe: re-passing `request_id`, `session_key`, `client_session_id`, `api_key_id`, `ingress`, or `name` emits the key twice and JSON consumers keep the **last** value, overwriting the bound one — so the line goes missing from exactly the search that should find it. A different-meaning value gets a distinct key (`upstream_request_id`, `rated_request_id`, `tool_name`); an identical value is simply dropped. Enforced by `TestNoReservedLogKeyShadowing`.
+
 ## Things to NEVER do
 
 - **Never put customer/company/org names or private identifiers in anything committed here.** This repo is public — commit messages, branch names, PR titles/descriptions, code comments, tests, and fixtures are world-readable. This holds even when a change is motivated by one customer's investigation (e.g. a loop-break or spiral fix found from a specific org's agentic session): describe the trigger generically ("a customer", "a large agentic session", "an org's monorepo"). No org names, org IDs, account emails, internal ticket/Linear links, or verbatim private Slack/support excerpts — those stay in the private WorkWeave repo + Linear.

--- a/internal/api/anthropic/messages.go
+++ b/internal/api/anthropic/messages.go
@@ -95,7 +95,7 @@ func stashClientIdentity(ctx context.Context, h http.Header, body []byte) contex
 	if metaEmail := proxy.NormalizeEmail(meta.Email); metaEmail != "" {
 		id.Email = metaEmail
 	}
-	observability.Get().Debug("anthropic stashClientIdentity",
+	observability.FromContext(ctx).Debug("anthropic stashClientIdentity",
 		"meta_raw_len", len(metaRaw),
 		"meta_raw_preview", observability.Preview(metaRaw, 200),
 		"parsed_email_present", meta.Email != "",

--- a/internal/api/anthropic/passthrough.go
+++ b/internal/api/anthropic/passthrough.go
@@ -36,14 +36,14 @@ func PassthroughHandler(svc *proxy.Service) gin.HandlerFunc {
 				return
 			}
 			if c.Writer.Written() {
-				log.Error("Passthrough failed mid-stream", "err", err, "path", c.Request.URL.Path)
+				log.Error("Passthrough failed mid-stream", "err", err)
 				return
 			}
 			if ok && cls.Kind == proxy.DispatchErrorNotImplemented {
 				writeAnthropicError(c, cls.Status, anthropicErrorType(cls.Kind), cls.Message)
 				return
 			}
-			log.Error("Passthrough failed", "err", err, "path", c.Request.URL.Path)
+			log.Error("Passthrough failed", "err", err)
 			writeAnthropicError(c, http.StatusBadGateway, "api_error", "Upstream call failed.")
 			return
 		}

--- a/internal/api/feedback/feedback.go
+++ b/internal/api/feedback/feedback.go
@@ -67,7 +67,7 @@ func GetContextHandler(svc *proxy.Service) gin.HandlerFunc {
 			return
 		}
 		if err != nil {
-			log.Error("Failed to load feedback context", "err", err, "request_id", claims.RequestID)
+			log.Error("Failed to load feedback context", "err", err, "rated_request_id", claims.RequestID)
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to load context"})
 			return
 		}
@@ -111,7 +111,7 @@ func SubmitHandler(svc *proxy.Service) gin.HandlerFunc {
 			Comment:        normalizeComment(req.Comment),
 		})
 		if err != nil {
-			log.Error("Failed to submit feedback", "err", err, "request_id", claims.RequestID)
+			log.Error("Failed to submit feedback", "err", err, "rated_request_id", claims.RequestID)
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to submit feedback"})
 			return
 		}
@@ -157,7 +157,7 @@ func RateHandler(svc *proxy.Service) gin.HandlerFunc {
 			Rating:         rating,
 		})
 		if err != nil {
-			log.Error("Failed to record one-click feedback", "err", err, "request_id", claims.RequestID, "rating", rating)
+			log.Error("Failed to record one-click feedback", "err", err, "rated_request_id", claims.RequestID, "rating", rating)
 			c.Data(http.StatusInternalServerError, "text/html; charset=utf-8", ratePageError("Sorry — we couldn't record that. Please try again."))
 			return
 		}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -657,7 +657,7 @@ func (s *Service) VerifyAPIKey(ctx context.Context, rawToken string) (*Installat
 		externalKeys, err = s.externalKeys.GetForInstallation(ctx, apiKey.InstallationID)
 		if err != nil {
 			// Non-fatal: proceed without external keys.
-			observability.Get().Warn("Failed to fetch external API keys", "installation_id", apiKey.InstallationID, "err", err)
+			observability.FromContext(ctx).Warn("Failed to fetch external API keys", "installation_id", apiKey.InstallationID, "err", err)
 		}
 	}
 
@@ -669,7 +669,7 @@ func (s *Service) VerifyAPIKey(ctx context.Context, rawToken string) (*Installat
 			// Non-fatal: serve this request with artifact-default routing, but
 			// don't cache the empty result — a transient DB error would otherwise
 			// disable per-key cluster restrictions for the full positive TTL.
-			observability.Get().Warn("Failed to fetch cluster model lists", "api_key_id", apiKey.ID, "err", err)
+			observability.FromContext(ctx).Warn("Failed to fetch cluster model lists", "api_key_id", apiKey.ID, "err", err)
 			clusterModelLists = nil
 			clusterModelListsFetchOK = false
 		}
@@ -689,7 +689,7 @@ func (s *Service) VerifyAPIKey(ctx context.Context, rawToken string) (*Installat
 // leaves the existing value). Never fails an authenticated request — returns
 // ctx unchanged on error.
 func (s *Service) ResolveAndStashUser(ctx context.Context, installationID, email, claudeAccountUUID, displayName string) context.Context {
-	log := observability.Get()
+	log := observability.FromContext(ctx)
 	if s.users == nil || installationID == "" {
 		log.Info("ResolveAndStashUser bailout", "reason", "nil_users_or_empty_inst", "users_nil", s.users == nil, "inst_empty", installationID == "")
 		return ctx
@@ -732,7 +732,7 @@ func (s *Service) ResolveAndStashUser(ctx context.Context, installationID, email
 		})
 	}
 	if err != nil {
-		observability.Get().Warn(
+		observability.FromContext(ctx).Warn(
 			"Failed to resolve router user",
 			"installation_id", installationID,
 			"err", err,
@@ -758,7 +758,7 @@ func (s *Service) withUserClusterLists(ctx context.Context, installationID, rout
 	if !ok {
 		fetched, err := s.userClusterModelLists.GetForUser(ctx, routerUserID)
 		if err != nil {
-			observability.Get().Warn("Failed to fetch user cluster model lists", "router_user_id", routerUserID, "err", err)
+			observability.FromContext(ctx).Warn("Failed to fetch user cluster model lists", "router_user_id", routerUserID, "err", err)
 			return ctx
 		}
 		lists = fetched

--- a/internal/auth/upstream_secrets.go
+++ b/internal/auth/upstream_secrets.go
@@ -20,7 +20,7 @@ func (s *Service) resolveUpstreamSecrets(ctx context.Context, keys []*ExternalAP
 		}
 		credential, err := s.upstreamCredential(ctx, key)
 		if err != nil {
-			observability.Get().Warn("Failed to resolve upstream credential for external API key",
+			observability.FromContext(ctx).Warn("Failed to resolve upstream credential for external API key",
 				"external_api_key_id", key.ID, "provider", key.Provider, "auth_type", key.AuthType, "err", err)
 			continue
 		}

--- a/internal/billing/service.go
+++ b/internal/billing/service.go
@@ -279,7 +279,7 @@ func (s *Service) maybeSignalRecharge(ctx context.Context, orgID string, delta, 
 	}
 	enabled, threshold, err := s.repo.GetAutopayConfig(ctx, orgID)
 	if err != nil {
-		observability.Get().Warn("Autopay crossing check skipped: config read failed",
+		observability.FromContext(ctx).Warn("Autopay crossing check skipped: config read failed",
 			"organization_id", orgID, "err", err)
 		return
 	}

--- a/internal/observability/global_logger_budget_test.go
+++ b/internal/observability/global_logger_budget_test.go
@@ -51,10 +51,6 @@ var globalLoggerBudget = map[string]int{
 }
 
 // TestGlobalLoggerBudget fails when a package gains an untagged log site.
-//
-// This is the regression guard for correlation-tagged logs: the codebase
-// previously drifted to 136 acquisition points that emitted lines with no
-// request_id, which is why a session's logs could not be read end to end.
 func TestGlobalLoggerBudget(t *testing.T) {
 	root := repoRoot(t)
 	counts := map[string]int{}
@@ -153,23 +149,26 @@ func repoRoot(t *testing.T) string {
 	}
 }
 
-// reservedLogKeys are bound by Middleware or bindRequestLogger. slog does not
-// dedupe, so a call site re-using one emits the key twice and JSON consumers
-// keep the LAST value — silently overwriting the correlation field. Searching
-// by the overwritten value then misses that line, which is the exact failure
-// correlation tags exist to prevent.
-var reservedLogKeys = []string{
-	"request_id",
-	"session_key",
-	"client_session_id",
-	"api_key_id",
-	"ingress",
-	"name",
+// alwaysBoundKeys are bound on every HTTP path: Middleware binds request_id,
+// initLogger binds name. slog does not dedupe: re-passing one emits the key
+// twice and JSON consumers keep the LAST value, overwriting the bound field.
+var alwaysBoundKeys = []string{"request_id", "name"}
+
+// bindScopedKeys are bound by bindRequestLogger, which runs inside the proxy
+// handler. Code that runs BEFORE it (route middleware) is adding the field,
+// not shadowing it — passing api_key_id there is correct and must not be
+// renamed, so these are only checked on the post-bind request path.
+var bindScopedKeys = []string{"session_key", "client_session_id", "api_key_id", "ingress"}
+
+// postBindPrefixes are packages reached only after bindRequestLogger has run.
+var postBindPrefixes = []string{
+	"internal/proxy/",
+	"internal/providers/",
+	"internal/translate/",
 }
 
-// reservedKeyAllowlist are sites that bind a reserved key onto a logger
-// deliberately (the binder itself, or an off-request-path logger that has no
-// bound value to collide with).
+// reservedKeyAllowlist are sites that bind a reserved key deliberately (the
+// binder itself, or a logger with no bound value to collide with).
 var reservedKeyAllowlist = map[string]bool{
 	"internal/observability/logger.go":   true, // Middleware binds them
 	"internal/proxy/session_key.go":      true, // bindRequestLogger binds them
@@ -179,8 +178,8 @@ var reservedKeyAllowlist = map[string]bool{
 	"internal/api/anthropic/messages.go": true, // pre-Middleware oversize-body log
 }
 
-// TestNoReservedLogKeyShadowing fails when a request-path log call passes a
-// key already bound to the logger, which would overwrite the bound value.
+// TestNoReservedLogKeyShadowing fails when a log call passes a key already
+// bound to that logger, which would overwrite the bound value.
 func TestNoReservedLogKeyShadowing(t *testing.T) {
 	root := repoRoot(t)
 
@@ -207,28 +206,36 @@ func TestNoReservedLogKeyShadowing(t *testing.T) {
 			return nil
 		}
 
-		for _, key := range findShadowedKeys(t, path) {
-			t.Errorf("%s passes reserved log key %q, which is already bound to the "+
-				"request logger. slog keeps the last value, so this overwrites the "+
-				"bound field and makes the line unfindable by it. Rename to "+
-				"upstream_%s / tool_%s, or drop it if the value is identical.",
-				rel, key, key, key)
+		check := append([]string{}, alwaysBoundKeys...)
+		for _, prefix := range postBindPrefixes {
+			if strings.HasPrefix(rel, prefix) {
+				check = append(check, bindScopedKeys...)
+				break
+			}
+		}
+
+		for _, key := range findShadowedKeys(t, path, check) {
+			t.Errorf("%s passes log key %q, which is already bound to the request "+
+				"logger here. slog keeps the last value, so this overwrites the bound "+
+				"field and makes the line unfindable by it. Rename to a distinct key "+
+				"(upstream_%s / rated_%s / tool_%s), or drop it if the value is "+
+				"identical to the bound one.", rel, key, key, key, key)
 		}
 		return nil
 	})
 	require.NoError(t, err)
 }
 
-// findShadowedKeys returns reserved keys passed as literal args to a
+// findShadowedKeys returns which of keys are passed as literal args to a
 // .Debug/.Info/.Warn/.Error call in the file.
-func findShadowedKeys(t *testing.T, path string) []string {
+func findShadowedKeys(t *testing.T, path string, keys []string) []string {
 	t.Helper()
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, path, nil, 0)
 	require.NoError(t, err, "parse %s", path)
 
 	reserved := map[string]bool{}
-	for _, k := range reservedLogKeys {
+	for _, k := range keys {
 		reserved[k] = true
 	}
 

--- a/internal/observability/global_logger_budget_test.go
+++ b/internal/observability/global_logger_budget_test.go
@@ -1,0 +1,161 @@
+package observability_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// globalLoggerBudget caps observability.Get() call sites per package.
+//
+// Get() returns the global logger, which carries the service tag but NO
+// request correlation (request_id / session_key / client_session_id). A line
+// emitted through it on the request path cannot be found when filtering a
+// session's logs — the defect this budget exists to stop from spreading.
+//
+// Every entry below is an off-request-path site (process startup, background
+// listeners, fire-and-forget writebacks, pure helpers with no ctx or receiver
+// to thread one through) where the global logger is the correct choice.
+//
+// Adding a request-path Get() call fails this test. The fix is to use
+// observability.FromContext(ctx) — not to raise the number. Only lower these.
+var globalLoggerBudget = map[string]int{
+	// Composition root: no request exists yet.
+	"cmd/router": 11,
+
+	// Pure schema-emit / validation helpers with no ctx in scope. Threading a
+	// ctx through these is a wider refactor; they are diagnostics about a
+	// tool schema, not about a request's fate.
+	"internal/translate":           13,
+	"internal/translate/toolcheck": 5,
+
+	// The exporter itself: logging its own transport failures. A ctx here
+	// would be the export's, not the request's.
+	"internal/observability/otel": 8,
+	"internal/observability/apm":  1,
+
+	// Background Pub/Sub listeners; no inbound request.
+	"internal/pubsub": 4,
+
+	// Fire-and-forget writebacks (SafeGo) + a pure predicate. Documented in
+	// root CLAUDE.md as the off-request-path exception.
+	"internal/proxy": 4,
+	"internal/auth":  2,
+
+	// Allocation failures inside LRU construction and a row-parse fallback:
+	// no ctx parameter at these call sites.
+	"internal/router/cache":         2,
+	"internal/router/banditexplore": 1,
+	"internal/postgres":             1,
+	"internal/billing":              1,
+}
+
+// TestGlobalLoggerBudget fails when a package gains an untagged log site.
+//
+// This is the regression guard for correlation-tagged logs: the codebase
+// previously drifted to 136 acquisition points that emitted lines with no
+// request_id, which is why a session's logs could not be read end to end.
+func TestGlobalLoggerBudget(t *testing.T) {
+	root := repoRoot(t)
+	counts := map[string]int{}
+
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "vendor", ".git", "node_modules", "smoke":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		n := countGlobalLoggerCalls(t, path)
+		if n == 0 {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, filepath.Dir(path))
+		if relErr != nil {
+			return relErr
+		}
+		counts[filepath.ToSlash(rel)] += n
+		return nil
+	})
+	require.NoError(t, err)
+
+	for pkg, got := range counts {
+		budget, ok := globalLoggerBudget[pkg]
+		assert.True(t, ok,
+			"package %q gained %d observability.Get() call(s) with no budget entry. "+
+				"Use observability.FromContext(ctx) so the line carries request_id/session_key; "+
+				"only add a budget entry if the site is genuinely off the request path.", pkg, got)
+		if ok {
+			assert.LessOrEqual(t, got, budget,
+				"package %q has %d observability.Get() calls, budget is %d. "+
+					"Use observability.FromContext(ctx) instead of raising the budget.", pkg, got, budget)
+		}
+	}
+
+	// A stale entry means someone did the work but left the budget high,
+	// which would silently re-admit new untagged sites.
+	for pkg, budget := range globalLoggerBudget {
+		if got := counts[pkg]; got < budget {
+			t.Errorf("package %q budget is %d but only %d observability.Get() calls remain; "+
+				"lower the budget to %d to lock in the improvement", pkg, budget, got, got)
+		}
+	}
+}
+
+// countGlobalLoggerCalls counts observability.Get() selector calls in one file.
+// Counting via the AST rather than grep so a comment mentioning the call, or a
+// call split across lines, is scored correctly.
+func countGlobalLoggerCalls(t *testing.T, path string) int {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	require.NoError(t, err, "parse %s", path)
+
+	count := 0
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Get" {
+			return true
+		}
+		// Match both the qualified form from other packages and the bare
+		// in-package call.
+		if ident, ok := sel.X.(*ast.Ident); ok && ident.Name == "observability" {
+			count++
+		}
+		return true
+	})
+	return count
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		require.NotEqual(t, dir, parent, "go.mod not found walking up from test dir")
+		dir = parent
+	}
+}

--- a/internal/observability/global_logger_budget_test.go
+++ b/internal/observability/global_logger_budget_test.go
@@ -15,17 +15,10 @@ import (
 
 // globalLoggerBudget caps observability.Get() call sites per package.
 //
-// Get() returns the global logger, which carries the service tag but NO
-// request correlation (request_id / session_key / client_session_id). A line
-// emitted through it on the request path cannot be found when filtering a
-// session's logs — the defect this budget exists to stop from spreading.
+// Get() returns the global logger: no request_id/session_key. A line emitted
+// through it on the request path cannot be found when filtering by session.
 //
-// Every entry below is an off-request-path site (process startup, background
-// listeners, fire-and-forget writebacks, pure helpers with no ctx or receiver
-// to thread one through) where the global logger is the correct choice.
-//
-// Adding a request-path Get() call fails this test. The fix is to use
-// observability.FromContext(ctx) — not to raise the number. Only lower these.
+// Use observability.FromContext(ctx) for request-path sites. Only lower these.
 var globalLoggerBudget = map[string]int{
 	// Composition root: no request exists yet.
 	"cmd/router": 11,
@@ -158,4 +151,115 @@ func repoRoot(t *testing.T) string {
 		require.NotEqual(t, dir, parent, "go.mod not found walking up from test dir")
 		dir = parent
 	}
+}
+
+// reservedLogKeys are bound by Middleware or bindRequestLogger. slog does not
+// dedupe, so a call site re-using one emits the key twice and JSON consumers
+// keep the LAST value — silently overwriting the correlation field. Searching
+// by the overwritten value then misses that line, which is the exact failure
+// correlation tags exist to prevent.
+var reservedLogKeys = []string{
+	"request_id",
+	"session_key",
+	"client_session_id",
+	"api_key_id",
+	"ingress",
+	"name",
+}
+
+// reservedKeyAllowlist are sites that bind a reserved key onto a logger
+// deliberately (the binder itself, or an off-request-path logger that has no
+// bound value to collide with).
+var reservedKeyAllowlist = map[string]bool{
+	"internal/observability/logger.go":   true, // Middleware binds them
+	"internal/proxy/session_key.go":      true, // bindRequestLogger binds them
+	"internal/auth/service.go":           true, // SafeGo loggers, off request path
+	"internal/proxy/service.go":          true, // OTel span attrs + telemetry rows
+	"internal/proxy/usage_bypass.go":     true, // OTel span attrs + telemetry rows
+	"internal/api/anthropic/messages.go": true, // pre-Middleware oversize-body log
+}
+
+// TestNoReservedLogKeyShadowing fails when a request-path log call passes a
+// key already bound to the logger, which would overwrite the bound value.
+func TestNoReservedLogKeyShadowing(t *testing.T) {
+	root := repoRoot(t)
+
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "vendor", ".git", "node_modules", "smoke", "scripts":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		rel = filepath.ToSlash(rel)
+		if reservedKeyAllowlist[rel] || strings.HasPrefix(rel, "cmd/") {
+			return nil
+		}
+
+		for _, key := range findShadowedKeys(t, path) {
+			t.Errorf("%s passes reserved log key %q, which is already bound to the "+
+				"request logger. slog keeps the last value, so this overwrites the "+
+				"bound field and makes the line unfindable by it. Rename to "+
+				"upstream_%s / tool_%s, or drop it if the value is identical.",
+				rel, key, key, key)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// findShadowedKeys returns reserved keys passed as literal args to a
+// .Debug/.Info/.Warn/.Error call in the file.
+func findShadowedKeys(t *testing.T, path string) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	require.NoError(t, err, "parse %s", path)
+
+	reserved := map[string]bool{}
+	for _, k := range reservedLogKeys {
+		reserved[k] = true
+	}
+
+	var found []string
+	seen := map[string]bool{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		switch sel.Sel.Name {
+		case "Debug", "Info", "Warn", "Error", "DebugContext", "InfoContext", "WarnContext", "ErrorContext":
+		default:
+			return true
+		}
+		for _, arg := range call.Args {
+			lit, ok := arg.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				continue
+			}
+			val := strings.Trim(lit.Value, `"`)
+			if reserved[val] && !seen[val] {
+				seen[val] = true
+				found = append(found, val)
+			}
+		}
+		return true
+	})
+	return found
 }

--- a/internal/observability/logger.go
+++ b/internal/observability/logger.go
@@ -73,23 +73,33 @@ func FromContext(ctx context.Context) *slog.Logger {
 var initOnce sync.Once
 
 func initLogger() {
-	level := slog.LevelInfo
-	switch strings.ToLower(strings.TrimSpace(os.Getenv("LOG_LEVEL"))) {
-	case "debug":
-		level = slog.LevelDebug
-	case "warn", "warning":
-		level = slog.LevelWarn
-	case "error":
-		level = slog.LevelError
-	}
-	logger := slog.New(newHandler(level))
+	slog.SetDefault(buildLogger(newHandler(resolveLevel())))
+}
+
+// buildLogger attaches the process-wide attributes every line must carry.
+// Split from initLogger so tests exercise this instead of restating it.
+func buildLogger(h slog.Handler) *slog.Logger {
+	logger := slog.New(h)
 	// Every line carries the emitting service so a multi-service log sink can
 	// be filtered down to this process. NAME is what the deployment already
 	// sets per service; OTEL_SERVICE_NAME is the self-hosted fallback.
 	if name := serviceName(); name != "" {
 		logger = logger.With("name", name)
 	}
-	slog.SetDefault(logger)
+	return logger
+}
+
+// resolveLevel reads the handler level from LOG_LEVEL.
+func resolveLevel() slog.Level {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("LOG_LEVEL"))) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	}
+	return slog.LevelInfo
 }
 
 // serviceName resolves the service tag attached to every log line.
@@ -201,10 +211,8 @@ func Middleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		initOnce.Do(initLogger)
 
-		// Always the router's own id. An inbound one is recorded separately
-		// rather than adopted: a client could otherwise send one value on
-		// every request, or collide with another tenant's, and searching by
-		// request_id would stop identifying a single request.
+		// Always mint a fresh id; adopting an inbound one lets a client reuse
+		// a value across requests and breaks request_id as a unique key.
 		requestID := uuid.New().String()
 
 		logger := slog.Default().With(

--- a/internal/observability/logger.go
+++ b/internal/observability/logger.go
@@ -46,6 +46,47 @@ func RequestIDFromContext(ctx context.Context) string {
 	return ""
 }
 
+// requestLoggerHolder is the one logger a request's views share. Middleware
+// puts it on both the gin and request contexts; PromoteRequestLogger swaps its
+// contents when later-derived fields (session_key) become known, so the access
+// log and any FromGin caller pick them up without the proxy having to write a
+// new context back onto c.Request.
+type requestLoggerHolder struct {
+	mu  sync.RWMutex
+	log *slog.Logger
+}
+
+func (h *requestLoggerHolder) get() *slog.Logger {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.log
+}
+
+func (h *requestLoggerHolder) set(log *slog.Logger) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.log = log
+}
+
+// holderContextKey carries the shared holder.
+type holderContextKey struct{}
+
+// PromoteRequestLogger makes log the request's logger for every view of it:
+// the returned context, and the gin context's logger that AccessLog reads.
+//
+// Without this a logger enriched after Middleware (session_key,
+// client_session_id) reaches only the caller's own context, so the guaranteed
+// per-request "http request" line stays unfindable by session.
+func PromoteRequestLogger(ctx context.Context, log *slog.Logger) context.Context {
+	if log == nil {
+		return ctx
+	}
+	if h, ok := ctx.Value(holderContextKey{}).(*requestLoggerHolder); ok {
+		h.set(log)
+	}
+	return WithLogger(ctx, log)
+}
+
 // WithLogger attaches a logger to ctx for downstream FromContext calls.
 func WithLogger(ctx context.Context, log *slog.Logger) context.Context {
 	if log == nil {
@@ -186,12 +227,16 @@ func Get() *slog.Logger {
 	return slog.Default()
 }
 
-// FromGin returns the request-scoped logger bound by Middleware. Falls back to
-// the request context's logger (then the global default) so a route registered
-// without Middleware still logs rather than panicking.
+// FromGin returns the request-scoped logger bound by Middleware, including any
+// fields promoted later via PromoteRequestLogger. Falls back to the request
+// context's logger (then the global default) so a route registered without
+// Middleware still logs rather than panicking.
 func FromGin(c *gin.Context) *slog.Logger {
 	initOnce.Do(initLogger)
 	if v, ok := c.Get(ginContextKey); ok {
+		if h, ok := v.(*requestLoggerHolder); ok {
+			return h.get()
+		}
 		if logger, ok := v.(*slog.Logger); ok {
 			return logger
 		}
@@ -224,10 +269,12 @@ func Middleware() gin.HandlerFunc {
 			logger = logger.With("upstream_request_id", upstream)
 		}
 
-		c.Set(ginContextKey, logger)
+		holder := &requestLoggerHolder{log: logger}
+		c.Set(ginContextKey, holder)
 		c.Header("X-Request-Id", requestID)
 
 		ctx := WithRequestID(c.Request.Context(), requestID)
+		ctx = context.WithValue(ctx, holderContextKey{}, holder)
 		ctx = WithLogger(ctx, logger)
 		c.Request = c.Request.WithContext(ctx)
 

--- a/internal/observability/logger.go
+++ b/internal/observability/logger.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/lmittmann/tint"
 	"github.com/mattn/go-isatty"
 	"github.com/vlad-tokarev/sloggcp"
@@ -19,6 +20,31 @@ const ginContextKey = "router_logger"
 // loggerContextKey is a private type so context values don't collide with
 // other packages'.
 type loggerContextKey struct{}
+
+// requestIDContextKey carries the per-request correlation id independently of
+// the logger, so code that needs the raw value (telemetry rows, billing
+// ledger) reads the same id the logs are tagged with.
+type requestIDContextKey struct{}
+
+// WithRequestID attaches a request correlation id to ctx.
+func WithRequestID(ctx context.Context, requestID string) context.Context {
+	if requestID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, requestIDContextKey{}, requestID)
+}
+
+// RequestIDFromContext returns the correlation id stamped by Middleware, or ""
+// when the caller bypassed HTTP (tests, background jobs).
+func RequestIDFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if v, ok := ctx.Value(requestIDContextKey{}).(string); ok {
+		return v
+	}
+	return ""
+}
 
 // WithLogger attaches a logger to ctx for downstream FromContext calls.
 func WithLogger(ctx context.Context, log *slog.Logger) context.Context {
@@ -56,8 +82,29 @@ func initLogger() {
 	case "error":
 		level = slog.LevelError
 	}
-	slog.SetDefault(slog.New(newHandler(level)))
+	logger := slog.New(newHandler(level))
+	// Every line carries the emitting service so a multi-service log sink can
+	// be filtered down to this process. NAME is what the deployment already
+	// sets per service; OTEL_SERVICE_NAME is the self-hosted fallback.
+	if name := serviceName(); name != "" {
+		logger = logger.With("name", name)
+	}
+	slog.SetDefault(logger)
 }
+
+// serviceName resolves the service tag attached to every log line.
+func serviceName() string {
+	for _, key := range []string{"NAME", "OTEL_SERVICE_NAME"} {
+		if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+			return v
+		}
+	}
+	return defaultServiceName
+}
+
+// defaultServiceName tags lines when the deployment sets no service name, so
+// output is never untagged.
+const defaultServiceName = "router"
 
 // newHandler builds the slog handler for the resolved format. JSON uses
 // sloggcp.ReplaceAttr so lines render correctly in GCP Cloud Logging; tint
@@ -129,6 +176,9 @@ func Get() *slog.Logger {
 	return slog.Default()
 }
 
+// FromGin returns the request-scoped logger bound by Middleware. Falls back to
+// the request context's logger (then the global default) so a route registered
+// without Middleware still logs rather than panicking.
 func FromGin(c *gin.Context) *slog.Logger {
 	initOnce.Do(initLogger)
 	if v, ok := c.Get(ginContextKey); ok {
@@ -136,18 +186,68 @@ func FromGin(c *gin.Context) *slog.Logger {
 			return logger
 		}
 	}
+	if c.Request != nil {
+		return FromContext(c.Request.Context())
+	}
 	return slog.Default()
 }
 
+// Middleware binds a request correlation id to both the gin and request
+// contexts, so every line served under it filters by request_id alone.
+//
+// Bound here rather than deeper because the body is still unparsed: first
+// touch is what makes pre-parse failures findable at all.
 func Middleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		initOnce.Do(initLogger)
+
+		// Always the router's own id. An inbound one is recorded separately
+		// rather than adopted: a client could otherwise send one value on
+		// every request, or collide with another tenant's, and searching by
+		// request_id would stop identifying a single request.
+		requestID := uuid.New().String()
+
 		logger := slog.Default().With(
+			"request_id", requestID,
 			"method", c.Request.Method,
 			"path", c.Request.URL.Path,
 		)
+		if upstream := sanitizeLogValue(c.Request.Header.Get("X-Request-Id")); upstream != "" {
+			logger = logger.With("upstream_request_id", upstream)
+		}
+
 		c.Set(ginContextKey, logger)
+		c.Header("X-Request-Id", requestID)
+
+		ctx := WithRequestID(c.Request.Context(), requestID)
+		ctx = WithLogger(ctx, logger)
+		c.Request = c.Request.WithContext(ctx)
+
 		c.Next()
 	}
+}
+
+// maxLoggedHeaderLen bounds a client-supplied header before it reaches a log
+// field, so a pathological value can't bloat every line of a request.
+const maxLoggedHeaderLen = 200
+
+// sanitizeLogValue trims a caller-controlled header to a bounded, single-line
+// value fit for a log field.
+func sanitizeLogValue(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return ""
+	}
+	v = strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\r' || r == '\t' {
+			return ' '
+		}
+		return r
+	}, v)
+	if len(v) > maxLoggedHeaderLen {
+		return v[:maxLoggedHeaderLen]
+	}
+	return v
 }
 
 // AccessLog logs one INFO line per request after handlers run — without it, a

--- a/internal/observability/logger_test.go
+++ b/internal/observability/logger_test.go
@@ -1,0 +1,161 @@
+package observability_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"workweave/router/internal/observability"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMiddlewareBindsRequestIDToGinAndRequestContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var fromGin, fromCtx string
+	engine := gin.New()
+	engine.Use(observability.Middleware())
+	engine.GET("/x", func(c *gin.Context) {
+		fromCtx = observability.RequestIDFromContext(c.Request.Context())
+		// The gin-bound logger and the context-bound logger must be the same
+		// object, or handlers using FromGin lose the correlation fields.
+		if observability.FromGin(c) == observability.FromContext(c.Request.Context()) {
+			fromGin = fromCtx
+		}
+		c.Status(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+
+	require.NotEmpty(t, fromCtx, "request id must be bound to the request context")
+	assert.Equal(t, fromCtx, fromGin, "gin and context loggers must be the same instance")
+	assert.Equal(t, fromCtx, rec.Header().Get("X-Request-Id"), "response must echo the id operators will search by")
+}
+
+// A client-supplied id must not become the router's request_id: one caller
+// reusing a value would make request_id stop identifying a single request.
+func TestMiddlewareDoesNotAdoptInboundRequestID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const inbound = "client-supplied-constant"
+	var buf strings.Builder
+	restore := swapDefaultLogger(t, &buf)
+	defer restore()
+
+	var seen string
+	engine := gin.New()
+	engine.Use(observability.Middleware())
+	engine.GET("/x", func(c *gin.Context) {
+		seen = observability.RequestIDFromContext(c.Request.Context())
+		observability.FromGin(c).Info("handler ran")
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set("X-Request-Id", inbound)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	require.NotEmpty(t, seen)
+	assert.NotEqual(t, inbound, seen, "router must mint its own id, not trust the client's")
+	assert.Equal(t, seen, rec.Header().Get("X-Request-Id"))
+
+	// The client's value is still recorded, just under its own field.
+	line := findLogLine(t, buf.String(), "handler ran")
+	assert.Equal(t, inbound, line["upstream_request_id"])
+	assert.Equal(t, seen, line["request_id"])
+}
+
+func TestMiddlewareBoundsInboundRequestIDValue(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var buf strings.Builder
+	restore := swapDefaultLogger(t, &buf)
+	defer restore()
+
+	engine := gin.New()
+	engine.Use(observability.Middleware())
+	engine.GET("/x", func(c *gin.Context) {
+		observability.FromGin(c).Info("handler ran")
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set("X-Request-Id", strings.Repeat("A", 5000)+"\ninjected=1")
+	engine.ServeHTTP(httptest.NewRecorder(), req)
+
+	line := findLogLine(t, buf.String(), "handler ran")
+	got, ok := line["upstream_request_id"].(string)
+	require.True(t, ok)
+	assert.LessOrEqual(t, len(got), 200, "a pathological header must not bloat every line")
+	assert.NotContains(t, got, "\n", "newlines must not reach a log field")
+}
+
+// The access log is the one line guaranteed to exist per request. Before the
+// bridge it carried only method/path, so it could not be joined to anything.
+func TestAccessLogCarriesRequestID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var buf strings.Builder
+	restore := swapDefaultLogger(t, &buf)
+	defer restore()
+
+	engine := gin.New()
+	engine.Use(observability.Middleware(), observability.AccessLog())
+	engine.GET("/x", func(c *gin.Context) { c.Status(http.StatusTeapot) })
+
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+
+	line := findLogLine(t, buf.String(), "http request")
+	assert.NotEmpty(t, line["request_id"], "access log must carry request_id")
+	assert.Equal(t, rec.Header().Get("X-Request-Id"), line["request_id"])
+	assert.Equal(t, float64(http.StatusTeapot), line["status"])
+}
+
+func TestRequestIDFromContextEmptyWithoutMiddleware(t *testing.T) {
+	assert.Empty(t, observability.RequestIDFromContext(context.TODO()))
+	assert.Empty(t, observability.RequestIDFromContext(t.Context()))
+}
+
+// swapDefaultLogger points slog.Default at buf as JSON so tests can assert on
+// emitted fields, restoring the prior logger on cleanup. Middleware reads
+// slog.Default() per request, so this is observed without touching initOnce.
+func swapDefaultLogger(t *testing.T, buf io.Writer) func() {
+	t.Helper()
+	// Force the package's lazy init first, so it cannot later overwrite the
+	// test handler on the first Middleware call.
+	observability.Get()
+
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	return func() { slog.SetDefault(prev) }
+}
+
+// findLogLine returns the first JSON log record whose msg matches.
+func findLogLine(t *testing.T, out, msg string) map[string]any {
+	t.Helper()
+	for raw := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		if raw == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(raw), &rec); err != nil {
+			continue
+		}
+		if rec["msg"] == msg || rec["message"] == msg {
+			return rec
+		}
+	}
+	t.Fatalf("no log line with msg %q in:\n%s", msg, out)
+	return nil
+}

--- a/internal/observability/logger_test.go
+++ b/internal/observability/logger_test.go
@@ -25,8 +25,8 @@ func TestMiddlewareBindsRequestIDToGinAndRequestContext(t *testing.T) {
 	engine.Use(observability.Middleware())
 	engine.GET("/x", func(c *gin.Context) {
 		fromCtx = observability.RequestIDFromContext(c.Request.Context())
-		// The gin-bound logger and the context-bound logger must be the same
-		// object, or handlers using FromGin lose the correlation fields.
+		// Both views must resolve to one logger, or a FromGin caller loses
+		// the correlation fields.
 		if observability.FromGin(c) == observability.FromContext(c.Request.Context()) {
 			fromGin = fromCtx
 		}
@@ -158,4 +158,49 @@ func findLogLine(t *testing.T, out, msg string) map[string]any {
 	}
 	t.Fatalf("no log line with msg %q in:\n%s", msg, out)
 	return nil
+}
+
+// The access log is the one record guaranteed per request, and it reads the
+// gin-bound logger. A field derived after Middleware (session_key, known only
+// once the body parses) must reach it, or a session-filtered query silently
+// misses the request's own summary line.
+func TestPromoteRequestLoggerReachesAccessLogAndFromGin(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var buf strings.Builder
+	restore := swapDefaultLogger(t, &buf)
+	defer restore()
+
+	engine := gin.New()
+	engine.Use(observability.Middleware(), observability.AccessLog())
+	engine.GET("/x", func(c *gin.Context) {
+		// What bindRequestLogger does once the envelope has parsed.
+		enriched := observability.FromContext(c.Request.Context()).With("session_key", "abc123")
+		c.Request = c.Request.WithContext(
+			observability.PromoteRequestLogger(c.Request.Context(), enriched),
+		)
+		// A handler that grabbed its logger via FromGin must see it too.
+		observability.FromGin(c).Info("handler after promote")
+		c.Status(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+
+	access := findLogLine(t, buf.String(), "http request")
+	assert.Equal(t, "abc123", access["session_key"],
+		"access log must carry the promoted session_key")
+	assert.Equal(t, rec.Header().Get("X-Request-Id"), access["request_id"],
+		"promoting must not drop the id bound by Middleware")
+
+	handler := findLogLine(t, buf.String(), "handler after promote")
+	assert.Equal(t, "abc123", handler["session_key"], "FromGin must observe the promotion")
+}
+
+// Promotion is a no-op without Middleware rather than a panic, so a non-HTTP
+// caller (background job, test) can share the same code path.
+func TestPromoteRequestLoggerWithoutMiddleware(t *testing.T) {
+	log := slog.Default().With("session_key", "abc123")
+	ctx := observability.PromoteRequestLogger(t.Context(), log)
+	assert.Equal(t, log, observability.FromContext(ctx))
 }

--- a/internal/observability/service_name_internal_test.go
+++ b/internal/observability/service_name_internal_test.go
@@ -1,0 +1,48 @@
+package observability
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// serviceName is what puts the "name" tag on every line. NAME is set per
+// service by the deployment; the fallbacks keep output tagged anywhere else.
+func TestServiceNamePrefersNAMEThenOTELThenDefault(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     map[string]string
+		expects string
+	}{
+		{"NAME wins", map[string]string{"NAME": "router", "OTEL_SERVICE_NAME": "other"}, "router"},
+		{"OTEL fallback", map[string]string{"OTEL_SERVICE_NAME": "router-hmm-sidecar"}, "router-hmm-sidecar"},
+		{"default when unset", nil, defaultServiceName},
+		{"whitespace-only is not a name", map[string]string{"NAME": "   "}, defaultServiceName},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("NAME", "")
+			t.Setenv("OTEL_SERVICE_NAME", "")
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			assert.Equal(t, tc.expects, serviceName())
+		})
+	}
+}
+
+// initLogger must attach the service tag, or a shared log sink cannot be
+// filtered down to this process.
+func TestInitLoggerAttachesServiceTag(t *testing.T) {
+	t.Setenv("NAME", "router-test-svc")
+	t.Setenv("LOG_FORMAT", "json")
+
+	var buf strings.Builder
+	logger := slog.New(slog.NewJSONHandler(&buf, nil)).With("name", serviceName())
+	logger.Info("hello")
+
+	assert.Contains(t, buf.String(), `"name":"router-test-svc"`)
+}

--- a/internal/observability/service_name_internal_test.go
+++ b/internal/observability/service_name_internal_test.go
@@ -34,15 +34,31 @@ func TestServiceNamePrefersNAMEThenOTELThenDefault(t *testing.T) {
 	}
 }
 
-// initLogger must attach the service tag, or a shared log sink cannot be
-// filtered down to this process.
-func TestInitLoggerAttachesServiceTag(t *testing.T) {
+// buildLogger is what initLogger installs, so this fails if the service tag
+// is ever dropped from it. Asserting on a hand-built logger instead would
+// restate the logic and stay green through that regression.
+func TestBuildLoggerAttachesServiceTag(t *testing.T) {
 	t.Setenv("NAME", "router-test-svc")
-	t.Setenv("LOG_FORMAT", "json")
 
 	var buf strings.Builder
-	logger := slog.New(slog.NewJSONHandler(&buf, nil)).With("name", serviceName())
-	logger.Info("hello")
+	buildLogger(slog.NewJSONHandler(&buf, nil)).Info("hello")
 
 	assert.Contains(t, buf.String(), `"name":"router-test-svc"`)
+}
+
+// resolveLevel gates whether Debug lines survive at all.
+func TestResolveLevelFromEnv(t *testing.T) {
+	for env, want := range map[string]slog.Level{
+		"debug":   slog.LevelDebug,
+		"warn":    slog.LevelWarn,
+		"warning": slog.LevelWarn,
+		"error":   slog.LevelError,
+		"":        slog.LevelInfo,
+		"bogus":   slog.LevelInfo,
+	} {
+		t.Run(env, func(t *testing.T) {
+			t.Setenv("LOG_LEVEL", env)
+			assert.Equal(t, want, resolveLevel())
+		})
+	}
 }

--- a/internal/providers/anthropic/client.go
+++ b/internal/providers/anthropic/client.go
@@ -340,6 +340,7 @@ func (c *Client) proxyTo(ctx context.Context, cancel context.CancelCauseFunc, ur
 			t.StampUpstreamEOF()
 		}
 		httputil.LogUpstreamStatus(
+			ctx,
 			"Upstream Anthropic returned error status",
 			resp.StatusCode,
 			"routed_model", decision.Model,
@@ -365,6 +366,7 @@ func (c *Client) proxyTo(ctx context.Context, cancel context.CancelCauseFunc, ur
 				providers.CopyUpstreamHeaders(httputil.HeaderCapture{H: errHeaders}, resp)
 				buffered.Headers = errHeaders
 				httputil.LogUpstreamStatus(
+					ctx,
 					"Upstream Anthropic returned SSE error event",
 					buffered.Status,
 					"routed_model", decision.Model,
@@ -436,7 +438,7 @@ func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest
 	providers.CopyUpstreamHeaders(w, resp)
 	w.WriteHeader(resp.StatusCode)
 	if resp.StatusCode >= 400 {
-		return httputil.WritePassthroughError(w, resp, nil, nil, "Upstream Anthropic returned error status (passthrough)", "path", r.URL.Path)
+		return httputil.WritePassthroughError(r.Context(), w, resp, nil, nil, "Upstream Anthropic returned error status (passthrough)", "path", r.URL.Path)
 	}
 	_, err = io.Copy(w, resp.Body)
 	return err

--- a/internal/providers/google/native_client.go
+++ b/internal/providers/google/native_client.go
@@ -200,7 +200,7 @@ func (c *NativeClient) Passthrough(ctx context.Context, prep providers.PreparedR
 	providers.CopyUpstreamHeaders(w, resp)
 	w.WriteHeader(resp.StatusCode)
 	if resp.StatusCode >= 400 {
-		return httputil.WritePassthroughError(w, resp, nil, nil, "Upstream Google returned error status (passthrough)", "path", r.URL.Path)
+		return httputil.WritePassthroughError(r.Context(), w, resp, nil, nil, "Upstream Google returned error status (passthrough)", "path", r.URL.Path)
 	}
 	_, err = io.Copy(w, resp.Body)
 	return err

--- a/internal/providers/httputil/errors.go
+++ b/internal/providers/httputil/errors.go
@@ -1,6 +1,7 @@
 package httputil
 
 import (
+	"context"
 	"io"
 	"net/http"
 
@@ -49,20 +50,24 @@ func (c HeaderCapture) WriteHeader(int) {}
 // LogUpstreamStatus logs non-2xx upstream responses with a body preview, at
 // ERROR except 429 (routine rate-limit signal handled via failover), which
 // logs at WARN.
-func LogUpstreamStatus(msg string, status int, attrs ...any) {
+//
+// ctx is load-bearing: on the global logger the body was written but not
+// joinable to the request, so filtering by session never surfaced it.
+func LogUpstreamStatus(ctx context.Context, msg string, status int, attrs ...any) {
+	log := observability.FromContext(ctx)
 	merged := append([]any{"status", status}, attrs...)
 	if status >= 500 || (status >= 400 && status != http.StatusTooManyRequests) {
-		observability.Get().Error(msg, merged...)
+		log.Error(msg, merged...)
 		return
 	}
-	observability.Get().Warn(msg, merged...)
+	log.Warn(msg, merged...)
 }
 
 // WritePassthroughError streams up to 1KB of resp.Body to w, logs via
 // LogUpstreamStatus (body_preview/body_total_bytes appended automatically),
 // and returns UpstreamStatusError. onFirstByte/onEOF are nil-safe OTel
 // timing hooks; pass nil, nil on paths that don't stamp upstream timing.
-func WritePassthroughError(w http.ResponseWriter, resp *http.Response, onFirstByte, onEOF func(), msg string, attrs ...any) error {
+func WritePassthroughError(ctx context.Context, w http.ResponseWriter, resp *http.Response, onFirstByte, onEOF func(), msg string, attrs ...any) error {
 	var snip [1024]byte
 	n, _ := io.ReadFull(resp.Body, snip[:])
 	if n > 0 && onFirstByte != nil {
@@ -74,7 +79,7 @@ func WritePassthroughError(w http.ResponseWriter, resp *http.Response, onFirstBy
 		onEOF()
 	}
 	merged := append(append([]any{}, attrs...), "body_preview", string(snip[:n]), "body_total_bytes", int64(n)+rest)
-	LogUpstreamStatus(msg, resp.StatusCode, merged...)
+	LogUpstreamStatus(ctx, msg, resp.StatusCode, merged...)
 	if snipWriteErr != nil {
 		return snipWriteErr
 	}

--- a/internal/providers/httputil/errors_test.go
+++ b/internal/providers/httputil/errors_test.go
@@ -1,6 +1,7 @@
 package httputil
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -50,7 +51,7 @@ func TestWritePassthroughError_WritesBodyLogsAndReturnsStatusError(t *testing.T)
 
 	rec := httptest.NewRecorder()
 	var firstByteCalls, eofCalls int
-	err := WritePassthroughError(rec, resp, func() { firstByteCalls++ }, func() { eofCalls++ }, "upstream failed", "path", "/v1/messages")
+	err := WritePassthroughError(context.Background(), rec, resp, func() { firstByteCalls++ }, func() { eofCalls++ }, "upstream failed", "path", "/v1/messages")
 
 	var statusErr *providers.UpstreamStatusError
 	require.ErrorAs(t, err, &statusErr)
@@ -66,7 +67,7 @@ func TestWritePassthroughError_NilHooksAreSafe(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader("boom")),
 	}
 	rec := httptest.NewRecorder()
-	err := WritePassthroughError(rec, resp, nil, nil, "upstream failed")
+	err := WritePassthroughError(context.Background(), rec, resp, nil, nil, "upstream failed")
 	require.Error(t, err)
 	assert.Equal(t, "boom", rec.Body.String())
 }

--- a/internal/providers/openai/client.go
+++ b/internal/providers/openai/client.go
@@ -288,7 +288,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	providers.ObserveUpstreamHeaders(ctx, resp.Header)
 
 	idleTimeout := c.idleTimeoutFor(prep.Endpoint)
-	log := observability.Get()
+	log := observability.FromContext(ctx)
 	log.Debug("OpenAI upstream response",
 		"status", resp.StatusCode,
 		"content_type", resp.Header.Get("Content-Type"),
@@ -310,7 +310,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 		bufBody, totalRead, drainErr := httputil.ReadCapped(body, providers.MaxBufferedErrorBytes)
 		stop()
 		if errors.Is(context.Cause(ctx), httputil.ErrUpstreamIdleTimeout) {
-			logStreamStall(decision.Model, path, idleTimeout, totalRead, httputil.ErrUpstreamIdleTimeout)
+			logStreamStall(ctx, decision.Model, path, idleTimeout, totalRead, httputil.ErrUpstreamIdleTimeout)
 		}
 		if len(bufBody) > 0 {
 			t.StampUpstreamFirstByte()
@@ -319,6 +319,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 			t.StampUpstreamEOF()
 		}
 		httputil.LogUpstreamStatus(
+			ctx,
 			"Upstream OpenAI returned error status",
 			resp.StatusCode,
 			"base_url", c.baseURL,
@@ -377,7 +378,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	streamErr := httputil.StreamBody(ctx, cancel, idleTimeout, body, status, w, t, opts...)
 	switch {
 	case errors.Is(streamErr, httputil.ErrUpstreamIdleTimeout), errors.Is(streamErr, httputil.ErrUpstreamOutputStall):
-		logStreamStall(decision.Model, path, c.stallBudgetFor(prep.Endpoint, streamErr), body.n, streamErr)
+		logStreamStall(ctx, decision.Model, path, c.stallBudgetFor(prep.Endpoint, streamErr), body.n, streamErr)
 	case streamErr != nil:
 		if debug {
 			log.Debug("OpenAI upstream stream ended with error", "err", streamErr, "bytes_read", body.n)
@@ -413,12 +414,12 @@ func (p *progressReader) Read(buf []byte) (n int, err error) {
 // incident) vs output_idle (ErrUpstreamOutputStall, bytes flowing but zero
 // output — 2026-06-16 incident). Both are retryable; this is the per-model
 // paper trail for how often each happens.
-func logStreamStall(model, path string, budget time.Duration, bytesReceived int64, cause error) {
+func logStreamStall(ctx context.Context, model, path string, budget time.Duration, bytesReceived int64, cause error) {
 	stallKind := "byte_idle"
 	if errors.Is(cause, httputil.ErrUpstreamOutputStall) {
 		stallKind = "output_idle"
 	}
-	observability.Get().Error("OpenAI upstream stream stalled mid-response; aborting for retry",
+	observability.FromContext(ctx).Error("OpenAI upstream stream stalled mid-response; aborting for retry",
 		"model", model,
 		"provider", providers.ProviderOpenAI,
 		"path", path,
@@ -461,7 +462,7 @@ func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest
 	providers.CopyUpstreamHeaders(w, resp)
 	w.WriteHeader(resp.StatusCode)
 	if resp.StatusCode >= 400 {
-		return httputil.WritePassthroughError(w, resp, nil, nil, "Upstream OpenAI returned error status (passthrough)", "base_url", c.baseURL, "path", r.URL.Path)
+		return httputil.WritePassthroughError(r.Context(), w, resp, nil, nil, "Upstream OpenAI returned error status (passthrough)", "base_url", c.baseURL, "path", r.URL.Path)
 	}
 	_, err = io.Copy(w, resp.Body)
 	return err

--- a/internal/providers/openai/client.go
+++ b/internal/providers/openai/client.go
@@ -294,7 +294,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 		"content_type", resp.Header.Get("Content-Type"),
 		"transfer_encoding", resp.Header.Get("Transfer-Encoding"),
 		"content_encoding", resp.Header.Get("Content-Encoding"),
-		"request_id", resp.Header.Get("X-Request-Id"),
+		"upstream_request_id", resp.Header.Get("X-Request-Id"),
 	)
 
 	// Buffer non-2xx as UpstreamErrorResponse so the dispatch loop can fail
@@ -422,7 +422,7 @@ func logStreamStall(ctx context.Context, model, path string, budget time.Duratio
 	observability.FromContext(ctx).Error("OpenAI upstream stream stalled mid-response; aborting for retry",
 		"model", model,
 		"provider", providers.ProviderOpenAI,
-		"path", path,
+		"upstream_path", path,
 		"stall_kind", stallKind,
 		"budget_ms", budget.Milliseconds(),
 		"bytes_received", bytesReceived,

--- a/internal/providers/openaicompat/client.go
+++ b/internal/providers/openaicompat/client.go
@@ -287,6 +287,7 @@ func (c *Client) proxyTo(ctx context.Context, cancel context.CancelCauseFunc, ur
 			t.StampUpstreamEOF()
 		}
 		httputil.LogUpstreamStatus(
+			ctx,
 			"Upstream OpenAI-compatible provider returned error status",
 			resp.StatusCode,
 			"base_url", baseURL,
@@ -336,7 +337,7 @@ func (c *Client) proxyTo(ctx context.Context, cancel context.CancelCauseFunc, ur
 
 	streamErr := httputil.StreamBody(ctx, cancel, c.idleTimeout(), resp.Body, resp.StatusCode, w, t)
 	if errors.Is(streamErr, httputil.ErrUpstreamIdleTimeout) || errors.Is(streamErr, httputil.ErrUpstreamOutputStall) || errors.Is(streamErr, httputil.ErrUpstreamSlowThroughput) {
-		logStreamStall(decision.Model, baseURL, streamErr)
+		logStreamStall(ctx, decision.Model, baseURL, streamErr)
 	}
 	return streamErr
 }
@@ -344,7 +345,7 @@ func (c *Client) proxyTo(ctx context.Context, cancel context.CancelCauseFunc, ur
 // logStreamStall reports a watchdog trip at ERROR after upstream returned
 // 200 + headers then stalled for the full budget. Both stall kinds are
 // retryable (dispatchWithFallback re-attempts); this is the paper trail.
-func logStreamStall(model, baseURL string, cause error) {
+func logStreamStall(ctx context.Context, model, baseURL string, cause error) {
 	stallKind := "byte_idle"
 	switch {
 	case errors.Is(cause, httputil.ErrUpstreamOutputStall):
@@ -352,7 +353,7 @@ func logStreamStall(model, baseURL string, cause error) {
 	case errors.Is(cause, httputil.ErrUpstreamSlowThroughput):
 		stallKind = "slow_throughput"
 	}
-	observability.Get().Error("Upstream OpenAI-compatible stream stalled mid-response; aborting for retry",
+	observability.FromContext(ctx).Error("Upstream OpenAI-compatible stream stalled mid-response; aborting for retry",
 		"model", model,
 		"base_url", baseURL,
 		"stall_kind", stallKind,
@@ -396,7 +397,7 @@ func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest
 	providers.CopyUpstreamHeaders(w, resp)
 	w.WriteHeader(resp.StatusCode)
 	if resp.StatusCode >= 400 {
-		return httputil.WritePassthroughError(w, resp, nil, nil, "Upstream OpenAI-compatible provider returned error status (passthrough)", "base_url", baseURL, "path", r.URL.Path)
+		return httputil.WritePassthroughError(r.Context(), w, resp, nil, nil, "Upstream OpenAI-compatible provider returned error status (passthrough)", "base_url", baseURL, "path", r.URL.Path)
 	}
 	_, err = io.Copy(w, resp.Body)
 	return err

--- a/internal/proxy/client_identity.go
+++ b/internal/proxy/client_identity.go
@@ -72,7 +72,7 @@ func sessionIDFromHeaders(h http.Header) string {
 // and account_uuid are empty — Claude CLI v2.1.x sends account_uuid only, so
 // gating on email alone would break that path.
 func ResolveUserFromContext(ctx context.Context, authSvc *auth.Service, installation *auth.Installation) context.Context {
-	log := observability.Get()
+	log := observability.FromContext(ctx)
 	if authSvc == nil || installation == nil {
 		log.Info("ResolveUserFromContext bailout",
 			"reason", "nil_dep",

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -15,8 +15,6 @@ import (
 	"workweave/router/internal/router/catalog"
 	"workweave/router/internal/router/sessionpin"
 	"workweave/router/internal/translate"
-
-	"github.com/google/uuid"
 )
 
 // ErrGeminiCrossFormatUnsupported is returned when a Gemini-source request
@@ -38,7 +36,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	}
 	log := observability.FromContext(ctx)
 	requestStart := time.Now()
-	requestID := uuid.New().String()
+	requestID := requestIDFor(ctx)
 	buf := s.newTelemetryBuffer()
 	ctx = buf.WithContext(ctx)
 

--- a/internal/proxy/loop_detection.go
+++ b/internal/proxy/loop_detection.go
@@ -81,7 +81,7 @@ const (
 // detectToolCallLoop reports whether the same (tool_name, args) signature
 // repeats loopDetectionMaxRepeats+ times within the last loopDetectionWindowSize
 // tool calls, returning the signature and count for logs/the stop message.
-func detectToolCallLoop(env *translate.RequestEnvelope) (looped bool, sig translate.ToolCallSig, count int) {
+func detectToolCallLoop(ctx context.Context, env *translate.RequestEnvelope) (looped bool, sig translate.ToolCallSig, count int) {
 	sigs := env.AssistantToolCallSignatures()
 	if len(sigs) < loopDetectionMaxRepeats {
 		return false, translate.ToolCallSig{}, 0
@@ -100,7 +100,7 @@ func detectToolCallLoop(env *translate.RequestEnvelope) (looped bool, sig transl
 		if counts[key] >= loopDetectionMaxRepeats {
 			// Dump the ordered window to distinguish a real loop (identical
 			// args) from a false positive (distinct args that canonicalize-collide).
-			log := observability.Get()
+			log := observability.FromContext(ctx)
 			args := env.AssistantToolCallArgsPreview(start, 200)
 			log.Info("loop detector window dump",
 				"tool_name", s.Name,

--- a/internal/proxy/loop_detection_internal_test.go
+++ b/internal/proxy/loop_detection_internal_test.go
@@ -28,7 +28,7 @@ func TestDetectToolCallLoop_TripsAtMaxRepeats(t *testing.T) {
 	env, err := translate.ParseAnthropic(body)
 	require.NoError(t, err)
 
-	loop, sig, count := detectToolCallLoop(env)
+	loop, sig, count := detectToolCallLoop(context.Background(), env)
 	assert.True(t, loop)
 	assert.Equal(t, "ls", sig.Name)
 	assert.GreaterOrEqual(t, count, loopDetectionMaxRepeats)
@@ -44,7 +44,7 @@ func TestDetectToolCallLoop_NoLoopBelowThreshold(t *testing.T) {
 	env, err := translate.ParseAnthropic(body)
 	require.NoError(t, err)
 
-	loop, _, _ := detectToolCallLoop(env)
+	loop, _, _ := detectToolCallLoop(context.Background(), env)
 	assert.False(t, loop, "4 identical calls must not trip the detector (threshold is 5)")
 }
 
@@ -59,7 +59,7 @@ func TestDetectToolCallLoop_DifferentArgsDoNotTrip(t *testing.T) {
 	env, err := translate.ParseAnthropic(body)
 	require.NoError(t, err)
 
-	loop, _, _ := detectToolCallLoop(env)
+	loop, _, _ := detectToolCallLoop(context.Background(), env)
 	assert.False(t, loop, "same tool name but distinct args must not trip the detector")
 }
 
@@ -78,7 +78,7 @@ func TestDetectToolCallLoop_WindowedOldEntriesDropOut(t *testing.T) {
 	env, err := translate.ParseAnthropic(body)
 	require.NoError(t, err)
 
-	loop, _, _ := detectToolCallLoop(env)
+	loop, _, _ := detectToolCallLoop(context.Background(), env)
 	assert.False(t, loop, "stale repeats outside the window must not trip the detector")
 }
 
@@ -100,7 +100,7 @@ func TestDetectToolCallLoop_AlternatingPairStillTripsOnRepeats(t *testing.T) {
 	env, err := translate.ParseAnthropic(body)
 	require.NoError(t, err)
 
-	loop, sig, count := detectToolCallLoop(env)
+	loop, sig, count := detectToolCallLoop(context.Background(), env)
 	assert.True(t, loop)
 	assert.Equal(t, "ls", sig.Name)
 	assert.GreaterOrEqual(t, count, loopDetectionMaxRepeats)

--- a/internal/proxy/observation.go
+++ b/internal/proxy/observation.go
@@ -91,7 +91,7 @@ func buildObservationContext(ctx context.Context, decision, fresh router.Decisio
 		if b, err := json.Marshal(md.CandidateScores); err == nil {
 			obs.FreshCandidateScores = b
 		} else {
-			observability.Get().Debug("Failed to marshal fresh_candidate_scores for telemetry", "err", err)
+			observability.FromContext(ctx).Debug("Failed to marshal fresh_candidate_scores for telemetry", "err", err)
 		}
 	}
 	if md := decision.Metadata; md != nil {
@@ -132,7 +132,7 @@ func buildObservationContext(ctx context.Context, decision, fresh router.Decisio
 			} else {
 				// Telemetry loss is acceptable; a marshal failure must never
 				// fail the request, so log and leave the column NULL.
-				observability.Get().Debug("Failed to marshal candidate_scores for telemetry", "err", err)
+				observability.FromContext(ctx).Debug("Failed to marshal candidate_scores for telemetry", "err", err)
 			}
 		}
 	}

--- a/internal/proxy/router_feedback.go
+++ b/internal/proxy/router_feedback.go
@@ -118,7 +118,7 @@ func (s *Service) handleRouterFeedbackCommand(
 			telemetryStrategy = turn.Strategy
 			log.Info("/router-feedback: resolved sequence to telemetry turn",
 				"sequence", cmd.Sequence,
-				"request_id", telemetryRequestID,
+				"rated_request_id", telemetryRequestID,
 				"served_model", servedModel,
 			)
 		}
@@ -175,7 +175,7 @@ func (s *Service) handleRouterFeedbackCommand(
 			RouterUserID:   routerUserID,
 		}
 		if err := s.feedbackRepo.Upsert(context.Background(), upsertParams); err != nil {
-			log.Error("/router-feedback: request_feedback upsert failed", "request_id", telemetryRequestID, "err", err)
+			log.Error("/router-feedback: request_feedback upsert failed", "rated_request_id", telemetryRequestID, "err", err)
 		}
 	}
 
@@ -232,7 +232,7 @@ func (s *Service) handleRouterFeedbackCommand(
 		"requested_model", env.Model(),
 		"role", role,
 		"sequence", cmd.Sequence,
-		"request_id", telemetryRequestID,
+		"rated_request_id", telemetryRequestID,
 		"route_id", telemetryRouteID,
 	)
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2227,7 +2227,7 @@ func writeLocalCountTokens(w http.ResponseWriter, body []byte) error {
 // provider. No model rewriting, no routing decision. Anthropic targets get
 // the body scrubbed via envelope parsing; others receive it verbatim.
 func (s *Service) PassthroughToNamedProvider(ctx context.Context, providerName string, body []byte, w http.ResponseWriter, r *http.Request) error {
-	log := observability.Get()
+	log := observability.FromContext(ctx)
 	p, err := s.provider(providerName)
 	if err != nil {
 		return err
@@ -2531,7 +2531,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	ctx = s.withUsageObserver(ctx, r.Header)
 	log := observability.FromContext(ctx)
 	requestStart := time.Now()
-	requestID := uuid.New().String()
+	requestID := requestIDFor(ctx)
 	buf := s.newTelemetryBuffer()
 	ctx = buf.WithContext(ctx)
 
@@ -2693,7 +2693,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			escalatedLoop = true
 		}
 		if !escalatedLoop {
-			if loop, sig, count := detectToolCallLoop(env); loop {
+			if loop, sig, count := detectToolCallLoop(ctx, env); loop {
 				loopRole := roleForTier(catalog.TierFor(feats.Model))
 				log.Info("ProxyMessages tool-call loop detected", "tool_sig", sig, "repeat_count", count, "role", loopRole)
 				return s.handleToolCallLoopBreak(ctx, w, env, sig, count, installationID, sessionKey, loopRole, feats.Model, providers.ProviderAnthropic, feats.Tokens)
@@ -3244,6 +3244,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 						WithToolValidator(toolValidator)
 				} else {
 					translator = translate.NewAnthropicSSETranslator(sink, d.Model, usage).
+						WithLogger(log).
 						WithRoutingMarker(targetMarker).
 						WithEstimatedInputTokens(feats.Tokens).
 						WithRequestHadTools(feats.HasTools).
@@ -3297,6 +3298,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 				}
 				// SSE chain: Gemini → OpenAI → Anthropic.
 				anthropicTr := translate.NewAnthropicSSETranslator(sink, d.Model, usage).
+					WithLogger(log).
 					WithRoutingMarker(targetMarker).
 					WithEstimatedInputTokens(feats.Tokens).
 					WithRequestHadTools(feats.HasTools).
@@ -4979,14 +4981,14 @@ func (s *Service) fireBilling(ctx context.Context, p billing.DebitInferenceParam
 	if p.OrganizationID == "" {
 		// Shouldn't happen on managed-mode authed requests. Debug level so a
 		// synthetic test exercising the hook doesn't page on-call.
-		observability.Get().Debug("Billing debit skipped: no organization_id on request")
+		observability.FromContext(ctx).Debug("Billing debit skipped: no organization_id on request")
 		return
 	}
 	dbCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	balance, err := s.billing.DebitForInference(dbCtx, p)
 	if err == nil {
-		observability.Get().Debug("Billing debit complete",
+		observability.FromContext(ctx).Debug("Billing debit complete",
 			"organization_id", p.OrganizationID,
 			"router_request_id", p.RouterRequestID,
 			"model", p.Model,
@@ -5003,7 +5005,7 @@ func (s *Service) fireBilling(ctx context.Context, p billing.DebitInferenceParam
 // logBillingDebitFailure emits a structured Error log so on-call alerting can
 // fire on the resulting log rate without a new prometheus dependency.
 func logBillingDebitFailure(ctx context.Context, p billing.DebitInferenceParams, err error) {
-	observability.Get().Error("router_billing_debit_failed",
+	observability.FromContext(ctx).Error("router_billing_debit_failed",
 		"err", err,
 		"organization_id", p.OrganizationID,
 		"router_request_id", p.RouterRequestID,
@@ -5063,7 +5065,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	ctx = s.withUsageObserver(ctx, r.Header)
 	log := observability.FromContext(ctx)
 	requestStart := time.Now()
-	requestID := uuid.New().String()
+	requestID := requestIDFor(ctx)
 	buf := s.newTelemetryBuffer()
 	ctx = buf.WithContext(ctx)
 
@@ -5202,7 +5204,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// Tool-call loop break: same path as the Anthropic ingress. See the
 	// detectToolCallLoop / handleToolCallLoopBreak doc comments for rationale.
 	if !escalatedLoop {
-		if loop, sig, count := detectToolCallLoop(env); loop {
+		if loop, sig, count := detectToolCallLoop(ctx, env); loop {
 			loopRole := roleForTier(catalog.TierFor(feats.Model))
 			log.Info("ProxyOpenAIChatCompletion tool-call loop detected", "tool_sig", sig, "repeat_count", count, "role", loopRole)
 			return s.handleToolCallLoopBreak(ctx, w, env, sig, count, installationID, sessionKey, loopRole, feats.Model, providers.ProviderOpenAI, feats.Tokens)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2272,7 +2272,7 @@ func (s *Service) PassthroughToNamedProvider(ctx context.Context, providerName s
 	proxyStart := time.Now()
 	proxyErr := p.Passthrough(ctx, prep, w, r)
 	proxyMs := time.Since(proxyStart).Milliseconds()
-	log.Info("PassthroughToProvider complete", "provider", providerName, "path", r.URL.Path, "method", r.Method, "proxy_ms", proxyMs, "proxy_err", proxyErr)
+	log.Info("PassthroughToProvider complete", "provider", providerName, "proxy_ms", proxyMs, "proxy_err", proxyErr)
 	return proxyErr
 }
 

--- a/internal/proxy/session_key.go
+++ b/internal/proxy/session_key.go
@@ -9,6 +9,8 @@ import (
 	"workweave/router/internal/observability"
 	"workweave/router/internal/router/sessionpin"
 	"workweave/router/internal/translate"
+
+	"github.com/google/uuid"
 )
 
 // shortKey returns the first 16 hex chars of a session key for log
@@ -37,10 +39,24 @@ func sessionAffinityHint(key [sessionpin.SessionKeyLen]byte) string {
 	return sessionKeyHex(key)
 }
 
+// requestIDFor returns the correlation id already stamped by
+// observability.Middleware, minting one only for callers that bypassed HTTP
+// (background paths, tests). Reusing the middleware's id is what lets a
+// telemetry row join to the log lines for the same request.
+func requestIDFor(ctx context.Context) string {
+	if id := observability.RequestIDFromContext(ctx); id != "" {
+		return id
+	}
+	return uuid.New().String()
+}
+
 // bindRequestLogger derives the session key and returns a context carrying a
 // logger pre-bound with session_key, request_id, api_key_id, and ingress, so
 // a session's path can be filtered in Cloud Logging by session_key alone. It
 // also returns the key so callers don't have to re-derive it.
+//
+// request_id is already bound by observability.Middleware at first touch, so
+// only the fields that need the parsed envelope are added here.
 func bindRequestLogger(
 	ctx context.Context,
 	env *translate.RequestEnvelope,
@@ -49,10 +65,14 @@ func bindRequestLogger(
 	key := DeriveSessionKey(env, apiKeyID)
 	log := observability.FromContext(ctx).With(
 		"session_key", shortKey(key),
-		"request_id", requestID,
 		"api_key_id", apiKeyID,
 		"ingress", ingress,
 	)
+	// Re-bind request_id only when the caller reached this without passing
+	// through the HTTP middleware (background paths, tests).
+	if observability.RequestIDFromContext(ctx) == "" {
+		log = log.With("request_id", requestID)
+	}
 	// The client's own session id, bound when present so operators can grep
 	// by the id the user actually sees. Envelope first (Claude Code packs it
 	// in metadata.user_id); header identity covers Codex, which sends

--- a/internal/proxy/session_key.go
+++ b/internal/proxy/session_key.go
@@ -87,7 +87,10 @@ func bindRequestLogger(
 	if cs != "" {
 		log = log.With("client_session_id", cs)
 	}
-	return observability.WithLogger(ctx, log), log, key
+	// Promote rather than merely attach: the access log and any FromGin caller
+	// read the gin-bound logger, so session_key would otherwise never reach
+	// the one line guaranteed to exist per request.
+	return observability.PromoteRequestLogger(ctx, log), log, key
 }
 
 // DeriveSessionKey produces a 16-byte session digest from apiKeyID,

--- a/internal/router/cluster/multiversion.go
+++ b/internal/router/cluster/multiversion.go
@@ -91,7 +91,7 @@ func (m *Multiversion) Route(ctx context.Context, req router.Request) (router.De
 		if _, ok := m.Versions[requested]; ok {
 			chosen = requested
 		} else {
-			observability.Get().Warn(
+			observability.FromContext(ctx).Warn(
 				"Cluster scorer: requested version not built; serving default",
 				"requested_version", requested,
 				"default_version", m.Default,
@@ -102,7 +102,7 @@ func (m *Multiversion) Route(ctx context.Context, req router.Request) (router.De
 	scorer, ok := m.Versions[chosen]
 	if !ok {
 		// NewMultiversion enforces Default ∈ Versions — should be unreachable.
-		observability.Get().Error(
+		observability.FromContext(ctx).Error(
 			"Cluster scorer: chosen version missing; returning ErrClusterUnavailable",
 			"chosen_version", chosen,
 		)

--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -442,7 +442,7 @@ func sortedKeys(m map[string]struct{}) []string {
 // Route embeds the prompt, scores clusters, returns the argmax decision.
 func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision, error) {
 	start := time.Now()
-	log := observability.Get()
+	log := observability.FromContext(ctx)
 
 	text := TailTruncate(req.PromptText, s.cfg.MaxPromptChars)
 	truncated := len(req.PromptText) > s.cfg.MaxPromptChars

--- a/internal/server/middleware/api_key_spend_cap.go
+++ b/internal/server/middleware/api_key_spend_cap.go
@@ -49,7 +49,7 @@ func WithAPIKeySpendCap(svc *billing.Service) gin.HandlerFunc {
 
 		result, err := svc.CheckAPIKeySpendCap(c.Request.Context(), apiKey.ID)
 		if err != nil {
-			log.Error("API key spend-cap check failed; refusing request", "err", err, "api_key_id", apiKey.ID)
+			log.Error("API key spend-cap check failed; refusing request", "err", err, "capped_api_key_id", apiKey.ID)
 			c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{
 				"error":   "billing_unavailable",
 				"message": "Billing system is temporarily unavailable. Retry in a few moments.",
@@ -68,7 +68,7 @@ func WithAPIKeySpendCap(svc *billing.Service) gin.HandlerFunc {
 				// caller's own subscription (or refuses a would-be-paid turn) and
 				// never fails over to a paid model. Paid spend stays bounded at the cap.
 				log.Info("API key spend cap reached but subscription covers the route: serving subscription-only",
-					"api_key_id", apiKey.ID,
+					"capped_api_key_id", apiKey.ID,
 					"spent_usd_micros", result.SpentMicros,
 					"spend_cap_usd_micros", *result.CapMicros,
 				)
@@ -77,7 +77,7 @@ func WithAPIKeySpendCap(svc *billing.Service) gin.HandlerFunc {
 				return
 			}
 			log.Info("Request rejected: api key spend cap reached",
-				"api_key_id", apiKey.ID,
+				"capped_api_key_id", apiKey.ID,
 				"spent_usd_micros", result.SpentMicros,
 				"spend_cap_usd_micros", *result.CapMicros,
 			)

--- a/internal/server/middleware/api_key_spend_cap.go
+++ b/internal/server/middleware/api_key_spend_cap.go
@@ -49,7 +49,7 @@ func WithAPIKeySpendCap(svc *billing.Service) gin.HandlerFunc {
 
 		result, err := svc.CheckAPIKeySpendCap(c.Request.Context(), apiKey.ID)
 		if err != nil {
-			log.Error("API key spend-cap check failed; refusing request", "err", err, "capped_api_key_id", apiKey.ID)
+			log.Error("API key spend-cap check failed; refusing request", "err", err, "api_key_id", apiKey.ID)
 			c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{
 				"error":   "billing_unavailable",
 				"message": "Billing system is temporarily unavailable. Retry in a few moments.",
@@ -68,7 +68,7 @@ func WithAPIKeySpendCap(svc *billing.Service) gin.HandlerFunc {
 				// caller's own subscription (or refuses a would-be-paid turn) and
 				// never fails over to a paid model. Paid spend stays bounded at the cap.
 				log.Info("API key spend cap reached but subscription covers the route: serving subscription-only",
-					"capped_api_key_id", apiKey.ID,
+					"api_key_id", apiKey.ID,
 					"spent_usd_micros", result.SpentMicros,
 					"spend_cap_usd_micros", *result.CapMicros,
 				)
@@ -77,7 +77,7 @@ func WithAPIKeySpendCap(svc *billing.Service) gin.HandlerFunc {
 				return
 			}
 			log.Info("Request rejected: api key spend cap reached",
-				"capped_api_key_id", apiKey.ID,
+				"api_key_id", apiKey.ID,
 				"spent_usd_micros", result.SpentMicros,
 				"spend_cap_usd_micros", *result.CapMicros,
 			)

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -521,6 +522,20 @@ type AnthropicSSETranslator struct {
 	toolIDNonce string
 	lifecycle   *StreamLifecycle
 	toolLedger  *ToolCallLedger
+
+	// logger carries the request-scoped correlation fields (session_key,
+	// request_id). Nil until WithLogger is called; log() falls back to the
+	// global so a translator built without one still emits.
+	logger *slog.Logger
+}
+
+// log returns the request-scoped logger, or the global default when the
+// translator was built without one (tests, direct construction).
+func (t *AnthropicSSETranslator) log() *slog.Logger {
+	if t.logger != nil {
+		return t.logger
+	}
+	return observability.Get()
 }
 
 // upstreamErrorBodyCap bounds how much of an upstream error body is retained
@@ -550,6 +565,13 @@ func NewAnthropicSSETranslator(w http.ResponseWriter, requestModel string, sink 
 // tool args are validated (and repaired) before emission. Pass nil to disable.
 func (t *AnthropicSSETranslator) WithToolValidator(v *toolcheck.Validator) *AnthropicSSETranslator {
 	t.toolValidator = v
+	return t
+}
+
+// WithLogger installs the request-scoped logger so this translator's lines
+// carry the same correlation fields as the rest of the request.
+func (t *AnthropicSSETranslator) WithLogger(log *slog.Logger) *AnthropicSSETranslator {
+	t.logger = log
 	return t
 }
 
@@ -705,7 +727,7 @@ func (t *AnthropicSSETranslator) WriteHeader(code int) {
 		t.inner.WriteHeader(code)
 		t.headersEmitted = true
 	}
-	observability.Get().Debug("AnthropicSSE WriteHeader",
+	t.log().Debug("AnthropicSSE WriteHeader",
 		"upstream_status", code,
 		"upstream_content_type", ct,
 		"streaming", t.streaming,
@@ -771,7 +793,7 @@ func (t *AnthropicSSETranslator) Flush() {
 // Finalize writes the buffered body for non-streaming responses, or emits
 // trailing message_delta/message_stop for streaming.
 func (t *AnthropicSSETranslator) Finalize() error {
-	observability.Get().Debug("AnthropicSSE Finalize entry",
+	t.log().Debug("AnthropicSSE Finalize entry",
 		"streaming", t.streaming,
 		"closed", t.closed,
 		"started", t.started,
@@ -1157,7 +1179,7 @@ func (t *AnthropicSSETranslator) emitValidatedToolArgsDelta(blockIdx int) error 
 		t.toolCallIssues = append(t.toolCallIssues, *verdict.Issue)
 		if verdict.Issue.Bucket == toolcheck.BucketInvalidJSON && !verdict.Issue.Repaired {
 			t.toolArgsInvalid[blockIdx] = struct{}{}
-			observability.Get().Error(
+			t.log().Error(
 				"AnthropicSSE tool_use args failed JSON validation — substituting empty args",
 				"block_index", blockIdx,
 				"upstream_model", t.modelFromUpstream,
@@ -1247,7 +1269,7 @@ func (t *AnthropicSSETranslator) synthesizeTextOnlyTurnNudge() error {
 		}
 	}
 	if isGemini3xModel(t.requestModel) || isGemini3xModel(t.modelFromUpstream) {
-		observability.Get().Debug(
+		t.log().Debug(
 			"AnthropicSSE suppressed text-only-turn nudge on Gemini-3.x (sig-less tool_use would poison next-turn history)",
 			"upstream_model", t.modelFromUpstream,
 			"request_model", t.requestModel,
@@ -1276,7 +1298,7 @@ func (t *AnthropicSSETranslator) synthesizeTextOnlyTurnNudge() error {
 	t.toolUseEmitted = true
 	t.toolUseCount++
 	t.nudgeEmitted = true
-	observability.Get().Error(
+	t.log().Error(
 		"AnthropicSSE synthesized text-only-turn recovery nudge",
 		"upstream_model", t.modelFromUpstream,
 		"request_model", t.requestModel,
@@ -1392,7 +1414,7 @@ func (t *AnthropicSSETranslator) emitIncompleteErrorEvent() error {
 func (t *AnthropicSSETranslator) emitErrorEvent() error {
 	errType := anthropicErrorTypeForStatus(t.upstreamErrorStatus)
 	msg := upstreamErrorMessage(t.upstreamErrorBody.String(), t.upstreamErrorStatus)
-	observability.Get().Debug("AnthropicSSE emit",
+	t.log().Debug("AnthropicSSE emit",
 		"event", "error",
 		"upstream_status", t.upstreamErrorStatus,
 		"error_type", errType,
@@ -1447,7 +1469,7 @@ func (t *AnthropicSSETranslator) emitMessageStart() error {
 		id = "msg_translated_" + randomHex(8)
 		t.messageID = id
 	}
-	observability.Get().Debug("AnthropicSSE emit", "event", "message_start")
+	t.log().Debug("AnthropicSSE emit", "event", "message_start")
 	t.bw.WriteString("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":")
 	sse.WriteJSONString(t.bw, id)
 	t.bw.WriteString(",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":")
@@ -1459,7 +1481,7 @@ func (t *AnthropicSSETranslator) emitMessageStart() error {
 }
 
 func (t *AnthropicSSETranslator) emitContentBlockStartText(index int) error {
-	observability.Get().Debug("AnthropicSSE emit", "event", "content_block_start", "type", "text")
+	t.log().Debug("AnthropicSSE emit", "event", "content_block_start", "type", "text")
 	t.bw.WriteString("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":")
 	sse.WriteJSONInt(t.bw, int64(index))
 	t.bw.WriteString(",\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n")
@@ -1472,7 +1494,7 @@ func (t *AnthropicSSETranslator) emitContentBlockStartText(index int) error {
 // upstreams reject with a 400 when the history routes back to them.
 // embedSignatureInID is idempotent.
 func (t *AnthropicSSETranslator) emitContentBlockStartTool(index int, id, name, sig string) error {
-	observability.Get().Debug("AnthropicSSE emit", "event", "content_block_start", "type", "tool_use", "name", name)
+	t.log().Debug("AnthropicSSE emit", "event", "content_block_start", "type", "tool_use", "name", name)
 	t.bw.WriteString("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":")
 	sse.WriteJSONInt(t.bw, int64(index))
 	t.bw.WriteString(",\"content_block\":{\"type\":\"tool_use\",\"id\":")
@@ -1494,7 +1516,7 @@ func (t *AnthropicSSETranslator) uniqueToolUseID(id string) string {
 }
 
 func (t *AnthropicSSETranslator) emitContentBlockStartThinking(index int) error {
-	observability.Get().Debug("AnthropicSSE emit", "event", "content_block_start", "type", "thinking")
+	t.log().Debug("AnthropicSSE emit", "event", "content_block_start", "type", "thinking")
 	t.bw.WriteString("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":")
 	sse.WriteJSONInt(t.bw, int64(index))
 	t.bw.WriteString(",\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}\n\n")
@@ -1502,7 +1524,7 @@ func (t *AnthropicSSETranslator) emitContentBlockStartThinking(index int) error 
 }
 
 func (t *AnthropicSSETranslator) emitContentBlockDeltaThinking(index int, text string) error {
-	observability.Get().Debug("AnthropicSSE emit", "event", "content_block_delta", "type", "thinking_delta")
+	t.log().Debug("AnthropicSSE emit", "event", "content_block_delta", "type", "thinking_delta")
 	t.bw.WriteString("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":")
 	sse.WriteJSONInt(t.bw, int64(index))
 	t.bw.WriteString(",\"delta\":{\"type\":\"thinking_delta\",\"thinking\":")
@@ -1512,7 +1534,7 @@ func (t *AnthropicSSETranslator) emitContentBlockDeltaThinking(index int, text s
 }
 
 func (t *AnthropicSSETranslator) emitContentBlockDeltaText(index int, text string) error {
-	observability.Get().Debug("AnthropicSSE emit", "event", "content_block_delta", "type", "text_delta")
+	t.log().Debug("AnthropicSSE emit", "event", "content_block_delta", "type", "text_delta")
 	t.bw.WriteString("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":")
 	sse.WriteJSONInt(t.bw, int64(index))
 	t.bw.WriteString(",\"delta\":{\"type\":\"text_delta\",\"text\":")
@@ -1522,7 +1544,7 @@ func (t *AnthropicSSETranslator) emitContentBlockDeltaText(index int, text strin
 }
 
 func (t *AnthropicSSETranslator) emitContentBlockDeltaJSON(index int, partial string) error {
-	observability.Get().Debug("AnthropicSSE emit", "event", "content_block_delta", "type", "input_json_delta")
+	t.log().Debug("AnthropicSSE emit", "event", "content_block_delta", "type", "input_json_delta")
 	t.bw.WriteString("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":")
 	sse.WriteJSONInt(t.bw, int64(index))
 	t.bw.WriteString(",\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":")
@@ -1532,7 +1554,7 @@ func (t *AnthropicSSETranslator) emitContentBlockDeltaJSON(index int, partial st
 }
 
 func (t *AnthropicSSETranslator) emitContentBlockStop(index int) error {
-	observability.Get().Debug("AnthropicSSE emit", "event", "content_block_stop")
+	t.log().Debug("AnthropicSSE emit", "event", "content_block_stop")
 	t.bw.WriteString("event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":")
 	sse.WriteJSONInt(t.bw, int64(index))
 	t.bw.WriteString("}\n\n")
@@ -1556,7 +1578,7 @@ func (t *AnthropicSSETranslator) emitMessageDelta() error {
 		t.stopReasonDemoted = true
 	}
 	t.emittedStopReason = stopReason
-	observability.Get().Debug("AnthropicSSE emit", "event", "message_delta", "stop_reason", stopReason)
+	t.log().Debug("AnthropicSSE emit", "event", "message_delta", "stop_reason", stopReason)
 	t.bw.WriteString("event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":")
 	sse.WriteJSONString(t.bw, stopReason)
 	t.bw.WriteString(",\"stop_sequence\":null},\"usage\":{")
@@ -1584,7 +1606,7 @@ func (t *AnthropicSSETranslator) emitMessageDelta() error {
 }
 
 func (t *AnthropicSSETranslator) emitMessageStop() error {
-	observability.Get().Debug("AnthropicSSE emit", "event", "message_stop")
+	t.log().Debug("AnthropicSSE emit", "event", "message_stop")
 	t.bw.WriteString("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
 	return t.flushEvent()
 }

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -1494,7 +1494,7 @@ func (t *AnthropicSSETranslator) emitContentBlockStartText(index int) error {
 // upstreams reject with a 400 when the history routes back to them.
 // embedSignatureInID is idempotent.
 func (t *AnthropicSSETranslator) emitContentBlockStartTool(index int, id, name, sig string) error {
-	t.log().Debug("AnthropicSSE emit", "event", "content_block_start", "type", "tool_use", "name", name)
+	t.log().Debug("AnthropicSSE emit", "event", "content_block_start", "type", "tool_use", "tool_name", name)
 	t.bw.WriteString("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":")
 	sse.WriteJSONInt(t.bw, int64(index))
 	t.bw.WriteString(",\"content_block\":{\"type\":\"tool_use\",\"id\":")


### PR DESCRIPTION
## Problem

A session's logs could not be read end to end. Most lines carried no correlation id, so filtering by session silently dropped them — the logs were written, just not findable.

The mechanism to do this right already existed (`observability.WithLogger` / `FromContext`, and `bindRequestLogger`, whose docstring says *"so a session's path can be filtered in Cloud Logging by session_key alone"*). Most call sites just bypassed it. Three distinct gaps:

**1. `request_id` was bound too late.** It was minted ~10 lines before `bindRequestLogger` attached it, on all three ingress paths:

| Path | id minted | bound at | untagged `Error` sites in window |
|---|---|---|---|
| Anthropic | `service.go:2534` | `:2587` | 4 |
| OpenAI | `service.go:5066` | `:5103` | 3 |
| Gemini | `gemini.go:41` | `:78` | 2 |

Those 9 sites include `"Failed to parse Anthropic request"` and `"Failed to canonicalize inbound model"` — precisely the failures you go hunting for.

**2. The gin logger was never re-bound.** `Middleware` attached only `method`/`path`, and nothing updated it after session derivation, so every `FromGin` site was permanently unjoinable — including the `http request` access log, the one line guaranteed to exist per request.

**3. 93 request-path sites used the global `observability.Get()`.** This is why upstream 4xx/5xx error bodies were logged but unfindable by session; the accepted workaround had become correlating by timestamp + model instead of by id.

Separately, `service.name` was set on the OTLP and APM resources but never on slog — even though the deployment already exports `NAME` per service.

Acquisition points before this change:

| How the logger was obtained | Sites | Carried correlation? |
|---|---|---|
| `FromContext(ctx)` | 61 | yes |
| `FromGin(c)` | 43 | no — `method`/`path` only |
| `Get()` | 93 | no — bare global |

## Approach

Follows the WorkWeave `backend/internal/pkg/log` pattern: a service tag on the global logger plus request-scoped correlation inherited from the context, rather than re-added per call.

- **`Middleware` stamps `request_id` at first touch** (before the body is read) and binds one logger to *both* the gin and request contexts. Binding pre-parse is the whole point — it's what makes parse failures findable.
- **The router always mints its own id.** An inbound `X-Request-Id` goes to `upstream_request_id`, sanitized and length-bounded. Adopting it would let one client send a constant value on every request and make `request_id` stop identifying a single request.
- **`initLogger` attaches `name`** from `NAME` → `OTEL_SERVICE_NAME` → `"router"`, mirroring `log.go:75-77`.
- **`FromGin` falls back to the context logger** instead of the bare global.
- **Request-path `Get()` sites converted to `FromContext(ctx)`**, threading ctx through `LogUpstreamStatus`, `WritePassthroughError`, `logStreamStall`, and `detectToolCallLoop`. `AnthropicSSETranslator` receives it via a `WithLogger` builder, matching the existing chain style.
- **`bindRequestLogger` reuses the middleware's id** rather than minting a second, unrelated one — so telemetry rows join to the log lines for the same request.

Off-request-path sites (startup, background Pub/Sub listeners, `SafeGo` fire-and-forget) correctly keep the global logger.

## Tag layers after this change

| Field | Bound by | Present from |
|---|---|---|
| `name` | `initLogger` | process start — every line |
| `request_id` | `observability.Middleware` | first touch, pre-parse |
| `session_key`, `api_key_id`, `ingress` | `bindRequestLogger` | after the envelope parses |
| `client_session_id` | `bindRequestLogger` | after parse, when the client sent one |

## Regression guard

`TestGlobalLoggerBudget` pins the remaining per-package `Get()` count via AST walk. A new request-path site fails the test with a message pointing at `FromContext(ctx)`; a stale budget also fails, so improvements get locked in rather than leaving headroom for new untagged sites.

This matters because the root `CLAUDE.md`/`AGENTS.md` previously recommended `Get`/`FromGin` as the default logging call — which is how this reached 136 sites. Both mirrors are updated (bodies verified byte-identical).

The guard earned its keep while being written: it caught two of my own miscounts, and correctly scored a *comment* mentioning `observability.Get()` as zero where grep counted it as a real hit.

## Validation

- `go build ./...`, `go vet ./...`, `gofmt -l` — all clean
- **Full** `go test ./...` — all packages pass
- **Verified the new tests are non-tautological**: reverted `Middleware` to its previous form and confirmed all three fail with their intended messages (`"request id must be bound to the request context"`, etc.), then restored
- **Verified the guard fires**: reintroduced a single `Get()` in `internal/api/anthropic` and confirmed the budget test failed naming that package

## Notes for review

- **`internal/translate` retains 13 untagged sites** — pure schema-emit helpers with no `ctx` or receiver to thread one through. They report on a tool schema, not a request's fate, so they're budgeted rather than forced through a wider refactor. Easy follow-up if you want them tagged.
- **Scope is correlation IDs, not per-call-site codes** (e.g. `[RTR-0142]`), matching what WorkWeave does. Per-statement codes would mean touching ~437 calls plus maintaining a registry — separate change if wanted.
- `go.mod` carries a pre-existing `golang-jwt/jwt/v5 should be direct` tidy warning, left untouched as unrelated.

🤖 Generated with [Weave Router](https://router.workweave.ai)