### PR TITLE
fix: omit empty web_search domain lists on Anthropic emit

### DIFF
--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -804,11 +804,29 @@ func sanitizeAnthropicTools(v any) any {
 				copied[k] = sanitizeAnthropicSchema(child)
 				continue
 			}
+			// Anthropic 400s empty allowed_domains/blocked_domains on native
+			// web_search_* tools ("Empty list of domains is ambiguous").
+			// Claude Code/SDK often sends blocked_domains: [] alongside an
+			// allowlist; omit the empty array so the field is absent.
+			if (k == "allowed_domains" || k == "blocked_domains") && isEmptyDomainList(child) {
+				continue
+			}
 			copied[k] = child
 		}
 		out = append(out, copied)
 	}
 	return out
+}
+
+func isEmptyDomainList(v any) bool {
+	switch arr := v.(type) {
+	case []any:
+		return len(arr) == 0
+	case []string:
+		return len(arr) == 0
+	default:
+		return false
+	}
 }
 
 func sanitizeAnthropicSchema(v any) any {

--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -804,10 +804,8 @@ func sanitizeAnthropicTools(v any) any {
 				copied[k] = sanitizeAnthropicSchema(child)
 				continue
 			}
-			// Anthropic 400s empty allowed_domains/blocked_domains on native
-			// web_search_* tools ("Empty list of domains is ambiguous").
-			// Claude Code/SDK often sends blocked_domains: [] alongside an
-			// allowlist; omit the empty array so the field is absent.
+			// Anthropic 400s empty allowed_domains/blocked_domains ("Empty list of
+			// domains is ambiguous"); omit so the field is absent rather than [].
 			if (k == "allowed_domains" || k == "blocked_domains") && isEmptyDomainList(child) {
 				continue
 			}

--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -799,6 +799,7 @@ func sanitizeAnthropicTools(v any) any {
 			continue
 		}
 		copied := make(map[string]any, len(tool))
+		nativeSearch := isAnthropicNativeWebSearch(tool)
 		for k, child := range tool {
 			if k == "input_schema" {
 				copied[k] = sanitizeAnthropicSchema(child)
@@ -806,7 +807,7 @@ func sanitizeAnthropicTools(v any) any {
 			}
 			// Anthropic 400s empty allowed_domains/blocked_domains ("Empty list of
 			// domains is ambiguous"); omit so the field is absent rather than [].
-			if (k == "allowed_domains" || k == "blocked_domains") && isEmptyDomainList(child) {
+			if nativeSearch && (k == "allowed_domains" || k == "blocked_domains") && isEmptyDomainList(child) {
 				continue
 			}
 			copied[k] = child
@@ -814,6 +815,11 @@ func sanitizeAnthropicTools(v any) any {
 		out = append(out, copied)
 	}
 	return out
+}
+
+func isAnthropicNativeWebSearch(tool map[string]any) bool {
+	typ, _ := tool["type"].(string)
+	return strings.HasPrefix(typ, "web_search_")
 }
 
 func isEmptyDomainList(v any) bool {

--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -799,7 +799,7 @@ func sanitizeAnthropicTools(v any) any {
 			continue
 		}
 		copied := make(map[string]any, len(tool))
-		nativeSearch := isAnthropicNativeWebSearch(tool)
+		nativeDomainFilter := isAnthropicNativeDomainFilterTool(tool)
 		for k, child := range tool {
 			if k == "input_schema" {
 				copied[k] = sanitizeAnthropicSchema(child)
@@ -807,7 +807,7 @@ func sanitizeAnthropicTools(v any) any {
 			}
 			// Anthropic 400s empty allowed_domains/blocked_domains ("Empty list of
 			// domains is ambiguous"); omit so the field is absent rather than [].
-			if nativeSearch && (k == "allowed_domains" || k == "blocked_domains") && isEmptyDomainList(child) {
+			if nativeDomainFilter && (k == "allowed_domains" || k == "blocked_domains") && isEmptyDomainList(child) {
 				continue
 			}
 			copied[k] = child
@@ -817,9 +817,9 @@ func sanitizeAnthropicTools(v any) any {
 	return out
 }
 
-func isAnthropicNativeWebSearch(tool map[string]any) bool {
+func isAnthropicNativeDomainFilterTool(tool map[string]any) bool {
 	typ, _ := tool["type"].(string)
-	return strings.HasPrefix(typ, "web_search_")
+	return strings.HasPrefix(typ, "web_search_") || strings.HasPrefix(typ, "web_fetch_")
 }
 
 func isEmptyDomainList(v any) bool {

--- a/internal/translate/emit_same_format_test.go
+++ b/internal/translate/emit_same_format_test.go
@@ -421,6 +421,27 @@ func TestAnthropicSameFormat_OmitsEmptyAllowedDomains(t *testing.T) {
 	assert.Equal(t, []any{"example.com"}, tool["blocked_domains"])
 }
 
+func TestAnthropicSameFormat_OmitsEmptyWebFetchDomainLists(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"fetch"}],"max_tokens":1024,"tools":[{
+		"type":"web_fetch_20250305",
+		"name":"web_fetch",
+		"allowed_domains":["example.com"],
+		"blocked_domains":[]
+	}]}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-opus-4-7",
+		Capabilities: router.Lookup("claude-opus-4-7"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+
+	tools, _ := out["tools"].([]any)
+	require.Len(t, tools, 1)
+	tool, _ := tools[0].(map[string]any)
+	assert.Equal(t, "web_fetch_20250305", tool["type"])
+	assert.Equal(t, []any{"example.com"}, tool["allowed_domains"])
+	assert.NotContains(t, tool, "blocked_domains")
+}
+
 func TestAnthropicSameFormat_KeepsEmptyDomainListsOnNonSearchTools(t *testing.T) {
 	body := []byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"hi"}],"max_tokens":1024,"tools":[{
 		"name":"custom_tool",

--- a/internal/translate/emit_same_format_test.go
+++ b/internal/translate/emit_same_format_test.go
@@ -421,6 +421,27 @@ func TestAnthropicSameFormat_OmitsEmptyAllowedDomains(t *testing.T) {
 	assert.Equal(t, []any{"example.com"}, tool["blocked_domains"])
 }
 
+func TestAnthropicSameFormat_KeepsEmptyDomainListsOnNonSearchTools(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"hi"}],"max_tokens":1024,"tools":[{
+		"name":"custom_tool",
+		"description":"not native web search",
+		"input_schema":{"type":"object"},
+		"allowed_domains":[],
+		"blocked_domains":[]
+	}]}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-opus-4-7",
+		Capabilities: router.Lookup("claude-opus-4-7"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+
+	tools, _ := out["tools"].([]any)
+	require.Len(t, tools, 1)
+	tool, _ := tools[0].(map[string]any)
+	assert.Equal(t, []any{}, tool["allowed_domains"])
+	assert.Equal(t, []any{}, tool["blocked_domains"])
+}
+
 func TestOpenAIToAnthropic_StripsUnsupportedToolSchemaPattern(t *testing.T) {
 	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hello"}],"tools":[{
 		"type":"function",

--- a/internal/translate/emit_same_format_test.go
+++ b/internal/translate/emit_same_format_test.go
@@ -378,6 +378,49 @@ func TestAnthropicSameFormat_StripsUnsupportedToolSchemaPattern(t *testing.T) {
 	assert.Equal(t, "decimal", amount["description"])
 }
 
+func TestAnthropicSameFormat_OmitsEmptyWebSearchDomainLists(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"search"}],"max_tokens":1024,"tools":[{
+		"type":"web_search_20250305",
+		"name":"web_search",
+		"allowed_domains":["openrouter.ai","docs.anthropic.com"],
+		"blocked_domains":[],
+		"max_uses":8
+	}]}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-opus-4-7",
+		Capabilities: router.Lookup("claude-opus-4-7"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+
+	tools, _ := out["tools"].([]any)
+	require.Len(t, tools, 1)
+	tool, _ := tools[0].(map[string]any)
+	assert.Equal(t, "web_search_20250305", tool["type"])
+	assert.Equal(t, []any{"openrouter.ai", "docs.anthropic.com"}, tool["allowed_domains"])
+	assert.NotContains(t, tool, "blocked_domains", "Anthropic 400s empty domain lists; omit them")
+	assert.Equal(t, float64(8), tool["max_uses"])
+}
+
+func TestAnthropicSameFormat_OmitsEmptyAllowedDomains(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"search"}],"max_tokens":1024,"tools":[{
+		"type":"web_search_20250305",
+		"name":"web_search",
+		"allowed_domains":[],
+		"blocked_domains":["example.com"]
+	}]}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-opus-4-7",
+		Capabilities: router.Lookup("claude-opus-4-7"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+
+	tools, _ := out["tools"].([]any)
+	require.Len(t, tools, 1)
+	tool, _ := tools[0].(map[string]any)
+	assert.NotContains(t, tool, "allowed_domains")
+	assert.Equal(t, []any{"example.com"}, tool["blocked_domains"])
+}
+
 func TestOpenAIToAnthropic_StripsUnsupportedToolSchemaPattern(t *testing.T) {
 	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hello"}],"tools":[{
 		"type":"function",

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -367,9 +367,8 @@ type EmitOverrides struct {
 	// on unknown block fields.
 	StripThoughtSignature bool
 	// SanitizeAnthropicToolSchemas removes schema constraints Anthropic rejects
-	// from tools[].input_schema on same-format Anthropic requests, and omits
-	// empty allowed_domains/blocked_domains on native web_search tools
-	// (Anthropic 400s an empty list as ambiguous vs null/absent).
+	// from tools[].input_schema on same-format Anthropic requests; also omits
+	// empty allowed_domains/blocked_domains on native web_search tools (Anthropic 400s them).
 	SanitizeAnthropicToolSchemas bool
 	// RewriteThinkingAdaptive replaces the inbound thinking block with
 	// {"type":"adaptive"} and sets output_config.effort. Used when the target

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -368,7 +368,7 @@ type EmitOverrides struct {
 	StripThoughtSignature bool
 	// SanitizeAnthropicToolSchemas removes schema constraints Anthropic rejects
 	// from tools[].input_schema on same-format Anthropic requests; also omits
-	// empty allowed_domains/blocked_domains on native web_search tools (Anthropic 400s them).
+	// empty allowed_domains/blocked_domains on native web_search/web_fetch tools (Anthropic 400s them).
 	SanitizeAnthropicToolSchemas bool
 	// RewriteThinkingAdaptive replaces the inbound thinking block with
 	// {"type":"adaptive"} and sets output_config.effort. Used when the target

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -367,7 +367,9 @@ type EmitOverrides struct {
 	// on unknown block fields.
 	StripThoughtSignature bool
 	// SanitizeAnthropicToolSchemas removes schema constraints Anthropic rejects
-	// from tools[].input_schema on same-format Anthropic requests.
+	// from tools[].input_schema on same-format Anthropic requests, and omits
+	// empty allowed_domains/blocked_domains on native web_search tools
+	// (Anthropic 400s an empty list as ambiguous vs null/absent).
 	SanitizeAnthropicToolSchemas bool
 	// RewriteThinkingAdaptive replaces the inbound thinking block with
 	// {"type":"adaptive"} and sets output_config.effort. Used when the target


### PR DESCRIPTION
## Summary
- Anthropic 400s native `web_search_20250305` when `blocked_domains` (or `allowed_domains`) is an empty array: "Empty list of domains is ambiguous. Provide at least one domain or null."
- Claude Code / Agent SDK often sends `blocked_domains: []` next to a real allowlist. Same-format Anthropic emit now omits those empty lists so the field is absent.
- Reproduced on Weave org (trace `73c0207534d76ad622f7bc04967f5ed3`): 5×400 today, two sessions.

## Test plan
- [x] `go test ./internal/translate/ -run TestAnthropicSameFormat_OmitsEmpty`
- [x] `wv mr tc` / `wv mr t`

🤖 Generated with [Weave Router](https://router.workweave.ai)