### PR TITLE
providers: fail the call on a refused redirect instead of returning the 3xx

### DIFF
--- a/internal/providers/anthropic/client_test.go
+++ b/internal/providers/anthropic/client_test.go
@@ -577,3 +577,30 @@ func TestProxy_ForwardsConfiguredIdentityHeader(t *testing.T) {
 	assert.Equal(t, "engineer@example.com", gotIdentity,
 		"an endpoint authenticating the service, not the person, can only attribute spend from this header")
 }
+
+func TestPassthrough_RelaysNothingFromARefusedRedirect(t *testing.T) {
+	var redirectTargetCalls int
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		redirectTargetCalls++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"internal"}`))
+	}))
+	defer redirectTarget.Close()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirectTarget.URL, http.StatusFound)
+	}))
+	defer upstream.Close()
+
+	c := anthropic.NewClient("deployment-key", upstream.URL)
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	prep := providers.PreparedRequest{Headers: make(http.Header)}
+
+	err := c.Passthrough(context.Background(), prep, rec, clientReq)
+
+	require.Error(t, err, "a refused redirect is a dispatch failure, not a response to relay")
+	assert.Equal(t, 0, redirectTargetCalls, "the redirect target must never be contacted")
+	assert.Empty(t, rec.Header().Get("Location"), "the unconfigured host must not reach the caller")
+	assert.Empty(t, rec.Body.String(), "no redirect body reaches the caller")
+}

--- a/internal/providers/httputil/client_test.go
+++ b/internal/providers/httputil/client_test.go
@@ -35,9 +35,8 @@ func TestNewClientFailsTheCallOnARedirect(t *testing.T) {
 	assert.ErrorIs(t, err, ErrRefusedRedirect)
 	assert.False(t, redirectTargetHit, "the redirect target must never be contacted")
 
-	// Do returns the pre-redirect response alongside the error with its body
-	// already closed. Adapters check err first, so it never reaches a relay
-	// path -- this pins that it is unusable even if one ever did not.
+	// Do returns the pre-redirect response alongside the error with its body already
+	// closed; pin that it is unusable even if an adapter ever skipped the err check.
 	require.NotNil(t, resp)
 	n, readErr := resp.Body.Read(make([]byte, 1))
 	assert.Zero(t, n)

--- a/internal/providers/httputil/client_test.go
+++ b/internal/providers/httputil/client_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewClientDoesNotFollowRedirects(t *testing.T) {
+func TestNewClientFailsTheCallOnARedirect(t *testing.T) {
 	var redirectTargetHit bool
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		redirectTargetHit = true
@@ -28,10 +28,18 @@ func TestNewClientDoesNotFollowRedirects(t *testing.T) {
 	require.NoError(t, err)
 
 	resp, err := client.Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
 
-	assert.Equal(t, http.StatusFound, resp.StatusCode, "the 3xx is returned to the caller rather than followed")
-	assert.Equal(t, target.URL, resp.Header.Get("Location"))
+	require.Error(t, err, "a refused redirect fails the call rather than yielding a relayable response")
+	// http.Client wraps CheckRedirect's error in *url.Error; the sentinel has to
+	// survive that for dispatch classification to recognize it.
+	assert.ErrorIs(t, err, ErrRefusedRedirect)
 	assert.False(t, redirectTargetHit, "the redirect target must never be contacted")
+
+	// Do returns the pre-redirect response alongside the error with its body
+	// already closed. Adapters check err first, so it never reaches a relay
+	// path -- this pins that it is unusable even if one ever did not.
+	require.NotNil(t, resp)
+	n, readErr := resp.Body.Read(make([]byte, 1))
+	assert.Zero(t, n)
+	assert.Error(t, readErr, "the returned response body is closed")
 }

--- a/internal/providers/httputil/httputil.go
+++ b/internal/providers/httputil/httputil.go
@@ -237,17 +237,14 @@ func NewTransportWithResponseHeaderTimeout(dialTimeout, tlsTimeout, responseHead
 	return t
 }
 
-// ErrRefusedRedirect is the cause when an upstream answered with a redirect.
-// A provider base URL is configuration, not discovery, so the redirect is
-// neither followed nor relayed: its Location names a host the deployment never
-// configured, and adapters treat only 4xx and 5xx as a response worth passing
-// to the caller.
+// ErrRefusedRedirect is returned when an upstream answers with a redirect.
+// A provider base URL is configuration, not discovery — the Location names a
+// host the deployment never configured, so the call is failed rather than relayed.
 var ErrRefusedRedirect = errors.New("upstream returned a redirect, which is not followed")
 
 // NewClient returns an http.Client on transport that refuses redirects.
-// Failing the call is what keeps a 3xx off every relay path at once — returning
-// the response instead would hand each adapter a status it classifies as
-// success, committing the redirect's headers and body to the caller.
+// Failing the call keeps a 3xx off every relay path — returning it would let
+// each adapter treat the redirect status as success.
 func NewClient(transport http.RoundTripper) *http.Client {
 	return &http.Client{Transport: transport, CheckRedirect: refuseRedirect}
 }

--- a/internal/providers/httputil/httputil.go
+++ b/internal/providers/httputil/httputil.go
@@ -237,15 +237,23 @@ func NewTransportWithResponseHeaderTimeout(dialTimeout, tlsTimeout, responseHead
 	return t
 }
 
+// ErrRefusedRedirect is the cause when an upstream answered with a redirect.
+// A provider base URL is configuration, not discovery, so the redirect is
+// neither followed nor relayed: its Location names a host the deployment never
+// configured, and adapters treat only 4xx and 5xx as a response worth passing
+// to the caller.
+var ErrRefusedRedirect = errors.New("upstream returned a redirect, which is not followed")
+
 // NewClient returns an http.Client on transport that refuses redirects.
-// A provider base URL is configuration, not discovery — a 3xx would forward
-// credentials to an unconfigured host.
+// Failing the call is what keeps a 3xx off every relay path at once — returning
+// the response instead would hand each adapter a status it classifies as
+// success, committing the redirect's headers and body to the caller.
 func NewClient(transport http.RoundTripper) *http.Client {
 	return &http.Client{Transport: transport, CheckRedirect: refuseRedirect}
 }
 
 func refuseRedirect(*http.Request, []*http.Request) error {
-	return http.ErrUseLastResponse
+	return ErrRefusedRedirect
 }
 
 // StartIdleWatchdog cancels ctx with ErrUpstreamIdleTimeout once idleTimeout


### PR DESCRIPTION
Follow-up to #1066, which introduced the condition this fixes. Cursor flagged it there; the thread was resolved without a code change, and the behavior is still on `main`.

## The problem

`CheckRedirect` returns `http.ErrUseLastResponse`, so a refused redirect comes back as a *response*. Adapters classify only `>= 400` as an error worth buffering, so a 3xx takes the success path:

- `Passthrough` calls `CopyUpstreamHeaders` and `WriteHeader(302)` before any status check, so the caller receives the redirect status **and its `Location`** — which names a host the deployment never configured.
- On the routed path `StreamBody` does surface the non-2xx, but only at EOF, after headers have committed. That is past the point where failover can run.
- `flushBufferedIfPresent` relays a buffered error's headers verbatim, so raising the threshold to `>= 300` would have leaked `Location` there too.
- Model-list and `cortexagents` parse a 3xx body as success.

## The fix

`CheckRedirect` returns a sentinel error instead. `http.Client` then fails the call, and every adapter already returns on that error — so this covers the routed, passthrough, and model-listing paths in one change rather than adjusting a status threshold in five packages and separately scrubbing `Location` from three relay paths.

Two behaviors worth knowing, both pinned by tests:

- `Do` returns the pre-redirect response *alongside* the error, with its body already closed. Adapters check `err` first so it never reaches a relay path; the test asserts the body is unusable anyway.
- `http.Client` wraps `CheckRedirect`'s error in `*url.Error`, so `errors.Is(err, ErrRefusedRedirect)` still matches through the chain.

Retry classification is deliberately unchanged. `IsRetryable`'s contract is "safe to retry — no response bytes reached the client", and that is exactly the case here, so a refused redirect stays retryable and a misconfigured endpoint on one arm does not fail a request another arm could serve.

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./internal/providers/... ./internal/proxy/` green.
- `httputil/client_test.go`: the call fails with the sentinel through `*url.Error`, the redirect target is never contacted, and the returned response's body is closed.
- `anthropic/client_test.go`: a passthrough against a redirecting upstream returns an error and writes **no** `Location` and **no** body to the caller.

🤖 Generated with [Weave Router](https://router.workweave.ai)