### PR TITLE
providers: extend the no-redirect policy to sidecar and token clients, harden tests

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -1340,7 +1340,15 @@ func buildClusterScorer(availableProviders map[string]struct{}) (router.Router, 
 // a deployment without Azure keys never contacts Microsoft Entra.
 func buildEntraTokenSource(logger *slog.Logger) auth.EntraTokenSource {
 	logger.Debug("Microsoft Entra client credentials token source initialized")
-	return entra.NewClientCredentialsSource(&http.Client{Timeout: 10 * time.Second}, time.Now)
+	// This client posts the decrypted BYOK client_secret; never follow a
+	// redirect with it. The refused 3xx fails mint()'s 2xx status check.
+	entraClient := &http.Client{
+		Timeout: 10 * time.Second,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	return entra.NewClientCredentialsSource(entraClient, time.Now)
 }
 
 // buildWIFTokenSource constructs the workload attestation source backing BYOK

--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -94,7 +94,14 @@ func New(baseURL string, client *http.Client, timeout time.Duration, opts ...Opt
 		timeout = DefaultTimeout
 	}
 	if client == nil {
-		client = &http.Client{Timeout: timeout}
+		// Same no-redirect policy as newGoogleIDTokenHTTPClient (auth.go):
+		// a 3xx fails the != 200 status checks instead of being followed.
+		client = &http.Client{
+			Timeout: timeout,
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
 	}
 	sidecar := &Client{
 		baseURL:        strings.TrimRight(baseURL, "/"),

--- a/internal/providers/anthropic/redirect_test.go
+++ b/internal/providers/anthropic/redirect_test.go
@@ -1,0 +1,65 @@
+package anthropic_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/providers/anthropic"
+	"workweave/router/internal/providers/httputil"
+	"workweave/router/internal/router"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProxy_RefusedRedirectFailsRetryablyWithoutTouchingWriter: routed-path
+// counterpart of TestPassthrough_RelaysNothingFromARefusedRedirect — the
+// call fails with the sentinel before any bytes reach the client, so the
+// failover loop may still retry another binding.
+func TestProxy_RefusedRedirectFailsRetryablyWithoutTouchingWriter(t *testing.T) {
+	var targetHit atomic.Bool
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		targetHit.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+r.URL.Path, http.StatusTemporaryRedirect)
+	}))
+	defer upstream.Close()
+
+	c := anthropic.NewClient("deployment-key", upstream.URL)
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	prep := providers.PreparedRequest{Body: []byte(`{"model":"x"}`), Headers: make(http.Header)}
+
+	err := c.Proxy(context.Background(), router.Decision{Model: "claude-opus-4-8"}, prep, rec, clientReq)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, httputil.ErrRefusedRedirect, "the sentinel must survive the adapter's wrapping for classification")
+	assert.True(t, providers.IsRetryable(err), "no bytes reached the client, so the next binding may be tried")
+	assert.Zero(t, rec.Body.Len(), "writer must not be touched on a refused redirect")
+	assert.Empty(t, rec.Header().Get("Location"), "the redirect Location must never reach the client")
+	assert.False(t, targetHit.Load(), "the redirect target must never be contacted")
+}
+
+// TestListModels_RedirectRefused: a redirecting /v1/models must fail loud
+// instead of feeding redirect boilerplate to the roster parser.
+func TestListModels_RedirectRefused(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://unconfigured.example"+r.URL.Path, http.StatusMovedPermanently)
+	}))
+	defer upstream.Close()
+
+	c := anthropic.NewClient("deployment-key", upstream.URL)
+	ids, err := c.ListModels(context.Background())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, httputil.ErrRefusedRedirect)
+	assert.Empty(t, ids)
+}

--- a/internal/providers/anthropic/redirect_test.go
+++ b/internal/providers/anthropic/redirect_test.go
@@ -18,9 +18,7 @@ import (
 )
 
 // TestProxy_RefusedRedirectFailsRetryablyWithoutTouchingWriter: routed-path
-// counterpart of TestPassthrough_RelaysNothingFromARefusedRedirect — the
-// call fails with the sentinel before any bytes reach the client, so the
-// failover loop may still retry another binding.
+// counterpart of TestPassthrough_RelaysNothingFromARefusedRedirect.
 func TestProxy_RefusedRedirectFailsRetryablyWithoutTouchingWriter(t *testing.T) {
 	var targetHit atomic.Bool
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/providers/httputil/client_test.go
+++ b/internal/providers/httputil/client_test.go
@@ -3,6 +3,7 @@ package httputil
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,9 +12,12 @@ import (
 )
 
 func TestNewClientFailsTheCallOnARedirect(t *testing.T) {
-	var redirectTargetHit bool
+	// atomic: written on the httptest handler goroutine, read here — and the
+	// write only ever happens when the policy regresses, exactly when the
+	// assertion must be race-clean.
+	var redirectTargetHit atomic.Bool
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		redirectTargetHit = true
+		redirectTargetHit.Store(true)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer target.Close()
@@ -33,7 +37,7 @@ func TestNewClientFailsTheCallOnARedirect(t *testing.T) {
 	// http.Client wraps CheckRedirect's error in *url.Error; the sentinel has to
 	// survive that for dispatch classification to recognize it.
 	assert.ErrorIs(t, err, ErrRefusedRedirect)
-	assert.False(t, redirectTargetHit, "the redirect target must never be contacted")
+	assert.False(t, redirectTargetHit.Load(), "the redirect target must never be contacted")
 
 	// Do returns the pre-redirect response alongside the error with its body already
 	// closed; pin that it is unusable even if an adapter ever skipped the err check.

--- a/internal/providers/httputil/client_test.go
+++ b/internal/providers/httputil/client_test.go
@@ -12,9 +12,7 @@ import (
 )
 
 func TestNewClientFailsTheCallOnARedirect(t *testing.T) {
-	// atomic: written on the httptest handler goroutine, read here — and the
-	// write only ever happens when the policy regresses, exactly when the
-	// assertion must be race-clean.
+	// atomic: written on the httptest handler goroutine, read here.
 	var redirectTargetHit atomic.Bool
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		redirectTargetHit.Store(true)

--- a/internal/providers/openaicompat/redirect_test.go
+++ b/internal/providers/openaicompat/redirect_test.go
@@ -36,11 +36,8 @@ func redirectFixture(t *testing.T) (upstream *httptest.Server, targetHit *atomic
 	return upstream, &hit
 }
 
-// TestProxy_RefusedRedirectFailsRetryablyWithoutTouchingWriter pins the
-// dispatch contract on a redirecting upstream: the call fails with
-// ErrRefusedRedirect before any bytes reach the client, so the failover
-// loop may retry another binding, and the Location never reaches the
-// client (which would follow it carrying its own key and the prompt).
+// TestProxy_RefusedRedirectFailsRetryablyWithoutTouchingWriter: refused
+// redirect fails retryably; Location never reaches the client.
 func TestProxy_RefusedRedirectFailsRetryablyWithoutTouchingWriter(t *testing.T) {
 	upstream, targetHit := redirectFixture(t)
 

--- a/internal/providers/openaicompat/redirect_test.go
+++ b/internal/providers/openaicompat/redirect_test.go
@@ -17,9 +17,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// redirectFixture stands up a redirecting upstream plus the host it points
-// at, so tests can assert neither the router nor (via a relayed Location)
-// the client is steered to the unconfigured target.
+// redirectFixture stands up a redirecting upstream and an isolated target,
+// so tests can assert the router never contacts the unconfigured host.
 func redirectFixture(t *testing.T) (upstream *httptest.Server, targetHit *atomic.Bool) {
 	t.Helper()
 	var hit atomic.Bool
@@ -75,9 +74,8 @@ func TestPassthrough_RefusedRedirectRelaysNothing(t *testing.T) {
 	assert.False(t, targetHit.Load(), "the redirect target must never be contacted")
 }
 
-// TestListModels_RedirectRefused: the catalog GET is the likeliest place a
-// gateway redirects; the roster fetch must fail loud, not parse redirect
-// boilerplate into an empty roster.
+// TestListModels_RedirectRefused: roster fetch must fail loud instead of
+// parsing redirect boilerplate into an empty model list.
 func TestListModels_RedirectRefused(t *testing.T) {
 	upstream, targetHit := redirectFixture(t)
 

--- a/internal/providers/openaicompat/redirect_test.go
+++ b/internal/providers/openaicompat/redirect_test.go
@@ -1,0 +1,94 @@
+package openaicompat_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/providers/httputil"
+	"workweave/router/internal/providers/openaicompat"
+	"workweave/router/internal/router"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// redirectFixture stands up a redirecting upstream plus the host it points
+// at, so tests can assert neither the router nor (via a relayed Location)
+// the client is steered to the unconfigured target.
+func redirectFixture(t *testing.T) (upstream *httptest.Server, targetHit *atomic.Bool) {
+	t.Helper()
+	var hit atomic.Bool
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hit.Store(true)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(target.Close)
+	upstream = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+r.URL.Path, http.StatusFound)
+	}))
+	t.Cleanup(upstream.Close)
+	return upstream, &hit
+}
+
+// TestProxy_RefusedRedirectFailsRetryablyWithoutTouchingWriter pins the
+// dispatch contract on a redirecting upstream: the call fails with
+// ErrRefusedRedirect before any bytes reach the client, so the failover
+// loop may retry another binding, and the Location never reaches the
+// client (which would follow it carrying its own key and the prompt).
+func TestProxy_RefusedRedirectFailsRetryablyWithoutTouchingWriter(t *testing.T) {
+	upstream, targetHit := redirectFixture(t)
+
+	c := openaicompat.NewClient("test-key", upstream.URL+"/api/v1")
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+	prep := providers.PreparedRequest{Body: []byte(`{"model":"m","messages":[]}`), Headers: make(http.Header)}
+
+	err := c.Proxy(context.Background(), router.Decision{Model: "m"}, prep, rec, clientReq)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, httputil.ErrRefusedRedirect, "the sentinel must survive the adapter's wrapping for classification")
+	assert.True(t, providers.IsRetryable(err), "no bytes reached the client, so the next binding may be tried")
+	assert.Zero(t, rec.Body.Len(), "writer must not be touched on a refused redirect")
+	assert.Empty(t, rec.Header().Get("Location"), "the redirect Location must never reach the client")
+	assert.False(t, targetHit.Load(), "the redirect target must never be contacted")
+}
+
+// TestPassthrough_RefusedRedirectRelaysNothing: same invariant on the
+// passthrough path, which writes directly on success.
+func TestPassthrough_RefusedRedirectRelaysNothing(t *testing.T) {
+	upstream, targetHit := redirectFixture(t)
+
+	c := openaicompat.NewClient("test-key", upstream.URL+"/api/v1")
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	prep := providers.PreparedRequest{Headers: make(http.Header)}
+
+	err := c.Passthrough(context.Background(), prep, rec, clientReq)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, httputil.ErrRefusedRedirect)
+	assert.Zero(t, rec.Body.Len(), "no redirect body reaches the caller")
+	assert.Empty(t, rec.Header().Get("Location"), "the unconfigured host must not reach the caller")
+	assert.False(t, targetHit.Load(), "the redirect target must never be contacted")
+}
+
+// TestListModels_RedirectRefused: the catalog GET is the likeliest place a
+// gateway redirects; the roster fetch must fail loud, not parse redirect
+// boilerplate into an empty roster.
+func TestListModels_RedirectRefused(t *testing.T) {
+	upstream, targetHit := redirectFixture(t)
+
+	c := openaicompat.NewClient("test-key", upstream.URL+"/v1")
+	ids, err := c.ListModels(context.Background())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, httputil.ErrRefusedRedirect)
+	assert.Empty(t, ids)
+	assert.False(t, targetHit.Load(), "the redirect target must never be contacted")
+}

--- a/internal/router/rl/client.go
+++ b/internal/router/rl/client.go
@@ -36,7 +36,14 @@ func NewHTTPDeciderWithHeaders(baseURL string, client *http.Client, timeout time
 		if timeout <= 0 {
 			timeout = DefaultTimeout
 		}
-		client = &http.Client{Timeout: timeout}
+		// Sidecar URL is configuration, not discovery: hand a 3xx back (it
+		// fails the != 200 status check) instead of following it elsewhere.
+		client = &http.Client{
+			Timeout: timeout,
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
 	}
 	copied := map[string]string{}
 	for k, v := range headers {


### PR DESCRIPTION
## Summary

Follow-ups to the refused-redirect work (#1066, #1068). #1068 already made `NewClient` fail the call outright on a redirect (`ErrRefusedRedirect`), which closes the relay path for all provider adapters; this PR covers what's left:

- **Extend the policy to the remaining credential-bearing clients** still on Go's default follow-redirects behavior:
  - the Entra client-credentials source in `cmd/router/main.go` — it POSTs the decrypted BYOK `client_secret` to the token endpoint, the highest-value credential still exposed to a redirect
  - the RL sidecar decider's default client (`internal/router/rl`)
  - `policyclient.New`'s default client — its sibling `newGoogleIDTokenHTTPClient` (auth.go) already refused redirects, so this also removes an inconsistency within the package

  `ErrUseLastResponse` suffices for these three: their `!= 200` status gates make a returned 3xx fail cleanly, and no relay path exists.
- **Fix the data race** in `TestNewClientFailsTheCallOnARedirect`: the handler-goroutine `bool` is written exactly when the policy regresses and the assertion must be race-clean, so make it `atomic.Bool`.
- **Add provider-level regression tests** (anthropic, openaicompat) pinning the dispatch contract on a redirecting upstream — the invariant #1068's unit test can't see: `ErrRefusedRedirect` survives the adapter's wrapping, `IsRetryable` holds (no bytes reached the client, so failover may proceed), the writer stays untouched, no `Location` reaches the client, and `ListModels` fails loud instead of parsing redirect boilerplate into an empty roster.

## Test plan

- New: `TestProxy_RefusedRedirectFailsRetryablyWithoutTouchingWriter` (anthropic + openaicompat), `TestPassthrough_RefusedRedirectRelaysNothing`, `TestListModels_RedirectRefused` ×2.
- `go build ./...`, full `go test ./...`, `go vet`, `gofmt` clean on top of main (`294fc346`).

🤖 Generated with [Weave Router](https://router.workweave.ai)