### PR TITLE
translate: find first user message regardless of leading system/developer prompt

### DIFF
--- a/internal/proxy/conformance_golden_test.go
+++ b/internal/proxy/conformance_golden_test.go
@@ -52,7 +52,9 @@ func golden(t *testing.T, name string, got []byte) {
 	}
 	want, err := os.ReadFile(path)
 	require.NoError(t, err, "missing golden %s — run `go test -update` to generate it", path)
-	require.Equal(t, string(want), string(got),
+	wantStr := strings.ReplaceAll(string(want), "\r\n", "\n")
+	gotStr := strings.ReplaceAll(string(got), "\r\n", "\n")
+	require.Equal(t, wantStr, gotStr,
 		"golden mismatch for %s — the router's translated output changed; run `go test -update` and review the diff", name)
 }
 

--- a/internal/proxy/session_key_test.go
+++ b/internal/proxy/session_key_test.go
@@ -191,3 +191,26 @@ func TestDeriveSessionKey_OpenAILeadingSystemDoesNotCollapse(t *testing.T) {
 
 	assert.NotEqual(t, kA, kB, "distinct OpenAI conversations must not share a pin when the first user message is empty")
 }
+
+func TestDeriveSessionKey_OpenAISharedSystemDifferentUserPromptDoesNotCollide(t *testing.T) {
+	// When multiple OpenAI conversations share the same system prompt under the
+	// same API key, the first user message must differentiate them.
+	convoA := openAIEnv(t, `{
+		"messages": [
+			{"role": "system", "content": "You are a helpful coding assistant."},
+			{"role": "user", "content": "Fix bug in module A"}
+		]
+	}`)
+	convoB := openAIEnv(t, `{
+		"messages": [
+			{"role": "system", "content": "You are a helpful coding assistant."},
+			{"role": "user", "content": "Write unit tests for module B"}
+		]
+	}`)
+
+	kA := proxy.DeriveSessionKey(convoA, "api-key")
+	kB := proxy.DeriveSessionKey(convoB, "api-key")
+
+	assert.NotEqual(t, kA, kB, "distinct OpenAI conversations sharing a system prompt must not collide")
+}
+

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -262,14 +262,22 @@ func (e *RequestEnvelope) FirstUserMessageText() string {
 	if e.format == FormatGemini {
 		return geminiFirstUserMessageText(e.body)
 	}
-	first := gjson.GetBytes(e.body, "messages.0")
-	if !first.Exists() {
+	messages := gjson.GetBytes(e.body, "messages")
+	if !messages.IsArray() {
 		return ""
 	}
-	if first.Get("role").String() != "user" {
+	var firstUser gjson.Result
+	messages.ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() == "user" {
+			firstUser = msg
+			return false
+		}
+		return true
+	})
+	if !firstUser.Exists() {
 		return ""
 	}
-	content := first.Get("content")
+	content := firstUser.Get("content")
 	switch e.format {
 	case FormatAnthropic:
 		return userPromptTextGJSON(content)

--- a/internal/translate/envelope_extras_test.go
+++ b/internal/translate/envelope_extras_test.go
@@ -235,3 +235,51 @@ func TestRequestEnvelope_RoutingFeatures_OpenAI_LastKind(t *testing.T) {
 		})
 	}
 }
+
+func TestRequestEnvelope_FirstUserMessageText(t *testing.T) {
+	t.Run("OpenAI with leading system message", func(t *testing.T) {
+		env, err := translate.ParseOpenAI([]byte(`{
+			"messages": [
+				{"role": "system", "content": "You are a helpful assistant."},
+				{"role": "user", "content": "First actual user question"},
+				{"role": "assistant", "content": "An answer"},
+				{"role": "user", "content": "Second user question"}
+			]
+		}`))
+		require.NoError(t, err)
+		assert.Equal(t, "First actual user question", env.FirstUserMessageText())
+	})
+
+	t.Run("OpenAI with leading developer message", func(t *testing.T) {
+		env, err := translate.ParseOpenAI([]byte(`{
+			"messages": [
+				{"role": "developer", "content": "Developer instruction"},
+				{"role": "user", "content": "Hello user"}
+			]
+		}`))
+		require.NoError(t, err)
+		assert.Equal(t, "Hello user", env.FirstUserMessageText())
+	})
+
+	t.Run("Anthropic with user message", func(t *testing.T) {
+		env, err := translate.ParseAnthropic([]byte(`{
+			"system": "System prompt",
+			"messages": [
+				{"role": "user", "content": "Anthropic user prompt"}
+			]
+		}`))
+		require.NoError(t, err)
+		assert.Equal(t, "Anthropic user prompt", env.FirstUserMessageText())
+	})
+
+	t.Run("OpenAI with no user message", func(t *testing.T) {
+		env, err := translate.ParseOpenAI([]byte(`{
+			"messages": [
+				{"role": "system", "content": "Only system"}
+			]
+		}`))
+		require.NoError(t, err)
+		assert.Equal(t, "", env.FirstUserMessageText())
+	})
+}
+


### PR DESCRIPTION
### Summary
Fixes `FirstUserMessageText` in `internal/translate/envelope.go` to find the first message with `role == "user"` by walking the messages array instead of only checking `messages.0`.

### Problem
In OpenAI Chat Completions and envelopes with leading `system` or `developer` prompts, `messages.0` is not `role == "user"`. As a result, `FirstUserMessageText()` returned an empty string `""`. When deriving session keys (`DeriveSessionKey`), this caused all OpenAI conversations under the same API key sharing a standard system prompt to derive identical session keys, leading to session pin collisions, cross-session pin thrashing, and degraded cache affinity.

### Changes
- Updated `FirstUserMessageText` to iterate through `messages` to find the first `role == "user"` block across all supported wire formats.
- Added test coverage in `internal/translate/envelope_extras_test.go` for leading system and developer messages.
- Added test in `internal/proxy/session_key_test.go` asserting that independent OpenAI conversations sharing a system prompt produce distinct session keys.
- Normalized CRLF line endings in `internal/proxy/conformance_golden_test.go` for cross-platform test stability.


