### PR TITLE
middleware: exempt subscription turns from spend caps without requiring UsageBypassEnabled

### DIFF
--- a/internal/server/middleware/api_key_spend_cap.go
+++ b/internal/server/middleware/api_key_spend_cap.go
@@ -38,14 +38,11 @@ func WithAPIKeySpendCap(svc *billing.Service) gin.HandlerFunc {
 			return
 		}
 
-		// The cap bounds PAID spend, not free subscription usage: a usage-bypass
-		// org presenting a Claude/Codex credential that covers this route serves at
+		// The cap bounds PAID spend, not free subscription usage: a request
+		// presenting a Claude/Codex credential that covers this route serves at
 		// $0 on the caller's own plan, so exempt it from the cap-reached 402 below
-		// (mirrors WithBalanceCheck). This gate keys off the api key, so read the
-		// installation from context to check UsageBypassEnabled.
-		installation := InstallationFrom(c)
-		subscriptionExempt := installation != nil && installation.UsageBypassEnabled &&
-			proxy.RequestPresentsCoveringSubscription(c.Request.Context(), c.Request.Header, c.FullPath())
+		// (mirrors WithBalanceCheck).
+		subscriptionExempt := proxy.RequestPresentsCoveringSubscription(c.Request.Context(), c.Request.Header, c.FullPath())
 
 		result, err := svc.CheckAPIKeySpendCap(c.Request.Context(), apiKey.ID)
 		if err != nil {

--- a/internal/server/middleware/api_key_spend_cap_test.go
+++ b/internal/server/middleware/api_key_spend_cap_test.go
@@ -141,10 +141,13 @@ func TestAPIKeySpendCap_CapReachedNoSubscriptionStillRejected(t *testing.T) {
 	assert.Equal(t, http.StatusPaymentRequired, w.Code)
 }
 
-func TestAPIKeySpendCap_CapReachedSubscriptionWithoutBypassRejected(t *testing.T) {
+func TestAPIKeySpendCap_CapReachedSubscriptionWithoutBypassServesSubscriptionOnly(t *testing.T) {
+	// Exemption depends only on whether the request presents a covering subscription,
+	// not on UsageBypassEnabled (matching WithBalanceCheck).
 	repo := &stubBillingRepo{spendFound: true, capMicros: capPtr(1_000_000), spendMicros: 1_000_000}
 	setInstall := func(c *gin.Context) { withInstallation(c, "org_prepaid") }
-	w, reached, _ := runSpendCapSub(t, "/v1/messages", "k9", setInstall, "Bearer sk-ant-oat-abc123", repo)
-	assert.False(t, reached, "exemption must not apply without the usage-bypass gate")
-	assert.Equal(t, http.StatusPaymentRequired, w.Code)
+	w, reached, subOnly := runSpendCapSub(t, "/v1/messages", "k9", setInstall, "Bearer sk-ant-oat-abc123", repo)
+	assert.True(t, reached, "a covered turn must pass even when the org lacks the usage-bypass toggle")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, subOnly, "the request must be flagged subscription-only")
 }

--- a/internal/server/middleware/org_monthly_spend_cap.go
+++ b/internal/server/middleware/org_monthly_spend_cap.go
@@ -36,12 +36,11 @@ func WithOrgMonthlySpendCap(svc *billing.Service) gin.HandlerFunc {
 			return
 		}
 
-		// The cap bounds PAID spend, not free subscription usage: a usage-bypass
-		// org presenting a Claude/Codex credential that covers this route serves at
+		// The cap bounds PAID spend, not free subscription usage: a request
+		// presenting a Claude/Codex credential that covers this route serves at
 		// $0 on the caller's own plan, so exempt it from the cap-reached 402 below
 		// (mirrors WithBalanceCheck).
-		subscriptionExempt := installation.UsageBypassEnabled &&
-			proxy.RequestPresentsCoveringSubscription(c.Request.Context(), c.Request.Header, c.FullPath())
+		subscriptionExempt := proxy.RequestPresentsCoveringSubscription(c.Request.Context(), c.Request.Header, c.FullPath())
 
 		result, err := svc.CheckOrgMonthlySpend(c.Request.Context(), orgID)
 		if err != nil {

--- a/internal/server/middleware/org_monthly_spend_cap_test.go
+++ b/internal/server/middleware/org_monthly_spend_cap_test.go
@@ -128,12 +128,15 @@ func TestOrgMonthlySpendCap_CapReachedNoSubscriptionStillRejected(t *testing.T) 
 	assert.Equal(t, http.StatusPaymentRequired, w.Code)
 }
 
-func TestOrgMonthlySpendCap_CapReachedSubscriptionWithoutBypassRejected(t *testing.T) {
+func TestOrgMonthlySpendCap_CapReachedSubscriptionWithoutBypassServesSubscriptionOnly(t *testing.T) {
+	// Exemption depends only on whether the request presents a covering subscription,
+	// not on UsageBypassEnabled (matching WithBalanceCheck).
 	repo := &stubBillingRepo{orgMonthSpent: 1_000_000, orgMonthLimit: capPtr(1_000_000)}
 	setInstall := func(c *gin.Context) { withInstallation(c, "org_prepaid") }
-	w, reached, _ := runOrgMonthlyCapSub(t, "/v1/messages", setInstall, "Bearer sk-ant-oat-abc123", repo)
-	assert.False(t, reached, "exemption must not apply without the usage-bypass gate")
-	assert.Equal(t, http.StatusPaymentRequired, w.Code)
+	w, reached, subOnly := runOrgMonthlyCapSub(t, "/v1/messages", setInstall, "Bearer sk-ant-oat-abc123", repo)
+	assert.True(t, reached, "a covered turn must pass even when the org lacks the usage-bypass toggle")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, subOnly, "the request must be flagged subscription-only")
 }
 
 func TestOrgMonthlySpendCap_OverridePassesThrough(t *testing.T) {


### PR DESCRIPTION
### Summary
Aligns `WithOrgMonthlySpendCap` and `WithAPIKeySpendCap` with `WithBalanceCheck` so that subscription-covered requests (which debit $0) are exempt from spend limits without requiring `UsageBypassEnabled`.

### Problem
In `WithBalanceCheck`, any request presenting a valid covering credential (e.g. `X-Weave-Anthropic-Subscription` or `X-Weave-OpenAI-Subscription`) passes through flagged `subscription-only` because subscription turns debit $0 on the caller's own plan.
However, `WithOrgMonthlySpendCap` and `WithAPIKeySpendCap` erroneously required `installation.UsageBypassEnabled && ...`. This caused organizations or keys with valid subscription credentials (but without the usage-bypass toggle active) to be rejected with HTTP 402 once their monthly or key limit was reached, even though the turn is free and incurs no platform cost.

### Changes
- Updated `WithOrgMonthlySpendCap` and `WithAPIKeySpendCap` to check `proxy.RequestPresentsCoveringSubscription(...)` directly, mirroring `WithBalanceCheck`.
- Updated unit tests in `org_monthly_spend_cap_test.go` and `api_key_spend_cap_test.go` to assert that covered requests pass through as subscription-only regardless of whether `UsageBypassEnabled` is enabled.


