### PR TITLE
translate/gemini: fix tool call fragmentation across multi-chunk streaming deltas

### DIFF
--- a/internal/translate/gemini_stream.go
+++ b/internal/translate/gemini_stream.go
@@ -35,7 +35,9 @@ type GeminiToOpenAISSETranslator struct {
 	lifecycle *StreamLifecycle
 	// pendingSig is a thoughtSignature from a text part with no functionCall
 	// sibling, held for the next tool_call chunk.
-	pendingSig string
+	pendingSig      string
+	currentToolID   string
+	currentToolName string
 
 	usageSink UsageSink
 
@@ -202,13 +204,11 @@ func (t *GeminiToOpenAISSETranslator) translateEvent(raw []byte) error {
 	parts := candidate.Get("content.parts")
 	if parts.IsArray() {
 		var emitErr error
+		partIdx := 0
 		parts.ForEach(func(_, part gjson.Result) bool {
 			if fc := part.Get("functionCall"); fc.Exists() {
 				name := fc.Get("name").String()
 				argsRaw := fc.Get("args").Raw
-				if argsRaw == "" || argsRaw == "null" {
-					argsRaw = "{}"
-				}
 				sig := part.Get("thoughtSignature").String()
 				if sig == "" && t.pendingSig != "" {
 					sig = t.pendingSig
@@ -218,11 +218,40 @@ func (t *GeminiToOpenAISSETranslator) translateEvent(raw []byte) error {
 					// part in a turn carries one.
 					t.pendingSig = sig
 				}
-				if err := t.emitToolCallChunk(t.toolIdx, name, argsRaw, sig); err != nil {
-					emitErr = err
-					return false
+
+				if partIdx > 0 && t.currentToolID != "" {
+					// Multiple functionCall parts within the same response chunk
+					t.toolIdx++
+					t.currentToolID = embedSignatureInID(generateToolCallID(), sig)
+					t.currentToolName = name
+				} else if name != "" && t.currentToolName != "" && t.currentToolName != name {
+					// Tool name changed in a subsequent chunk
+					t.toolIdx++
+					t.currentToolID = embedSignatureInID(generateToolCallID(), sig)
+					t.currentToolName = name
+				} else if t.currentToolID == "" {
+					t.currentToolID = embedSignatureInID(generateToolCallID(), sig)
+					t.currentToolName = name
 				}
-				t.toolIdx++
+
+				if name != "" {
+					if argsRaw == "" || argsRaw == "null" {
+						argsRaw = "{}"
+					}
+					if err := t.emitToolCallChunk(t.toolIdx, t.currentToolID, name, argsRaw); err != nil {
+						emitErr = err
+						return false
+					}
+				} else {
+					if argsRaw == "" || argsRaw == "null" {
+						argsRaw = ""
+					}
+					if err := t.emitToolCallArgsOnlyChunk(t.toolIdx, argsRaw); err != nil {
+						emitErr = err
+						return false
+					}
+				}
+				partIdx++
 				return true
 			}
 			if text := part.Get("text"); text.Exists() && text.String() != "" {
@@ -234,6 +263,7 @@ func (t *GeminiToOpenAISSETranslator) translateEvent(raw []byte) error {
 					return false
 				}
 			}
+			partIdx++
 			return true
 		})
 		if emitErr != nil {
@@ -244,7 +274,8 @@ func (t *GeminiToOpenAISSETranslator) translateEvent(raw []byte) error {
 	usage := geminiUsageFromBytes(data)
 	finishReason := candidate.Get("finishReason").String()
 	if finishReason != "" {
-		mapped := mapGeminiFinishReason(finishReason, t.toolIdx > 0)
+		hasTools := t.currentToolID != "" || t.toolIdx > 0
+		mapped := mapGeminiFinishReason(finishReason, hasTools)
 		if err := t.emitFinalChunk(mapped, usage); err != nil {
 			return err
 		}
@@ -301,10 +332,9 @@ func (t *GeminiToOpenAISSETranslator) emitTextDelta(text string) error {
 }
 
 // emitToolCallChunk emits an OpenAI tool_calls delta with the full arguments
-// JSON in one chunk. The Gemini thoughtSignature is smuggled into the tool-call
-// id (embedSignatureInID) so it replays on the next request without an
-// off-spec field that typed SDKs drop and Anthropic upstreams reject.
-func (t *GeminiToOpenAISSETranslator) emitToolCallChunk(idx int, name, argsRaw, sig string) error {
+// JSON or initial declaration. The Gemini thoughtSignature is smuggled into
+// the tool-call id (embedSignatureInID) so it replays on the next request.
+func (t *GeminiToOpenAISSETranslator) emitToolCallChunk(idx int, id, name, argsRaw string) error {
 	if err := t.ensureStarted(); err != nil {
 		return err
 	}
@@ -312,7 +342,6 @@ func (t *GeminiToOpenAISSETranslator) emitToolCallChunk(idx int, name, argsRaw, 
 		return err
 	}
 	t.markOutputProgress()
-	id := embedSignatureInID(generateToolCallID(), sig)
 	t.writeChunkHeader()
 	t.bw.WriteString(`"choices":[{"index":0,"delta":{"tool_calls":[{"index":`)
 	sse.WriteJSONInt(t.bw, int64(idx))
@@ -322,6 +351,24 @@ func (t *GeminiToOpenAISSETranslator) emitToolCallChunk(idx int, name, argsRaw, 
 	sse.WriteJSONString(t.bw, name)
 	t.bw.WriteString(`,"arguments":`)
 	// arguments must be a JSON-encoded string in OpenAI's wire format.
+	sse.WriteJSONString(t.bw, argsRaw)
+	t.bw.WriteString(`}}]},"finish_reason":null}]}`)
+	t.bw.WriteString("\n\n")
+	return t.flushEvent()
+}
+
+func (t *GeminiToOpenAISSETranslator) emitToolCallArgsOnlyChunk(idx int, argsRaw string) error {
+	if err := t.ensureStarted(); err != nil {
+		return err
+	}
+	if err := t.lifecycle.Output(0); err != nil {
+		return err
+	}
+	t.markOutputProgress()
+	t.writeChunkHeader()
+	t.bw.WriteString(`"choices":[{"index":0,"delta":{"tool_calls":[{"index":`)
+	sse.WriteJSONInt(t.bw, int64(idx))
+	t.bw.WriteString(`,"function":{"arguments":`)
 	sse.WriteJSONString(t.bw, argsRaw)
 	t.bw.WriteString(`}}]},"finish_reason":null}]}`)
 	t.bw.WriteString("\n\n")

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -1402,3 +1402,43 @@ func TestIsIntrinsicallyIncompatible(t *testing.T) {
 		})
 	}
 }
+
+func TestGeminiToOpenAISSETranslator_MultiChunkToolCall(t *testing.T) {
+	rec := httptest.NewRecorder()
+	tr := translate.NewGeminiToOpenAISSETranslator(rec, "gemini-3.1-pro-preview", nil)
+	rec.Header().Set("Content-Type", "text/event-stream")
+	tr.WriteHeader(http.StatusOK)
+
+	// Feed chunk 1: start of tool call with name
+	chunk1 := []byte("data: " + `{"candidates":[{"content":{"parts":[{"functionCall":{"name":"execute_command","args":{"cmd":"ls"}}}]}}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5}}` + "\n\n")
+	_, err := tr.Write(chunk1)
+	require.NoError(t, err)
+
+	// Feed chunk 2: continuation with partial args, no name
+	chunk2 := []byte("data: " + `{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"flags":"-la"}}}]}}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":10}}` + "\n\n")
+	_, err = tr.Write(chunk2)
+	require.NoError(t, err)
+
+	// Feed chunk 3: finishReason STOP
+	chunk3 := []byte("data: " + `{"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":12}}` + "\n\n")
+	_, err = tr.Write(chunk3)
+	require.NoError(t, err)
+	require.NoError(t, tr.Finalize())
+
+	body := rec.Body.String()
+	lines := strings.Split(body, "\n")
+	var toolChunks []string
+	for _, l := range lines {
+		if strings.HasPrefix(l, "data: {") && strings.Contains(l, `"delta":{"tool_calls"`) {
+			toolChunks = append(toolChunks, l)
+		}
+	}
+	require.Len(t, toolChunks, 2, "must emit 2 tool delta chunks")
+
+	// Both chunks must be index 0 (not incrementing index)
+	assert.Contains(t, toolChunks[0], `"index":0`)
+	assert.Contains(t, toolChunks[0], `"name":"execute_command"`)
+	assert.Contains(t, toolChunks[1], `"index":0`)
+	assert.NotContains(t, toolChunks[1], `"index":1`)
+}
+


### PR DESCRIPTION
### Summary
Fixes function call streaming translation in `GeminiToOpenAISSETranslator` (`internal/translate/gemini_stream.go`) so multi-chunk streaming tool calls retain stable tool call IDs and indices without fragmenting into distinct duplicate tool calls.

### Problem
In `GeminiToOpenAISSETranslator.translateEvent`, receiving a `functionCall` part unconditionally minted a new tool call ID and incremented `toolIdx++`. When upstream Gemini models stream function call arguments across multiple SSE chunks (or send args continuation deltas without re-sending the function name), this caused a single function call to be emitted as multiple distinct OpenAI tool calls with incrementing indices and mismatched IDs, causing downstream client parser and execution failures.

### Changes
- Added active tool call tracking (`currentToolID`, `currentToolName`) to `GeminiToOpenAISSETranslator`.
- Tool index and IDs are preserved across partial argument deltas of the same function call.
- Added `emitToolCallArgsOnlyChunk` for args-only deltas.
- Added unit test `TestGeminiToOpenAISSETranslator_MultiChunkToolCall` asserting that multi-chunk function call streaming preserves index 0 and stable function attributes.

