### PR TITLE
Add z-ai/glm-5.3-flash to the catalog

### DIFF
--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -529,7 +529,8 @@ prices='{
     "xiaomi/mimo-v2.5-pro":             0.001,
     "z-ai/glm-5":                       0.001,
     "z-ai/glm-5.1":                     0.0014,
-    "z-ai/glm-5.2":                     0.0014
+    "z-ai/glm-5.2":                     0.0014,
+    "z-ai/glm-5.3-flash":               0.00015
   },
   "output": {
     "claude-fable-5":                   0.05,
@@ -604,7 +605,8 @@ prices='{
     "xiaomi/mimo-v2.5-pro":             0.003,
     "z-ai/glm-5":                       0.0032,
     "z-ai/glm-5.1":                     0.0044,
-    "z-ai/glm-5.2":                     0.0044
+    "z-ai/glm-5.2":                     0.0044,
+    "z-ai/glm-5.3-flash":               0.0005
   }
 }'
 # END_GENERATED_PRICES

--- a/install/install.sh
+++ b/install/install.sh
@@ -3576,7 +3576,8 @@ prices='{
     "xiaomi/mimo-v2.5-pro":             0.001,
     "z-ai/glm-5":                       0.001,
     "z-ai/glm-5.1":                     0.0014,
-    "z-ai/glm-5.2":                     0.0014
+    "z-ai/glm-5.2":                     0.0014,
+    "z-ai/glm-5.3-flash":               0.00015
   },
   "output": {
     "claude-fable-5":                   0.05,
@@ -3651,7 +3652,8 @@ prices='{
     "xiaomi/mimo-v2.5-pro":             0.003,
     "z-ai/glm-5":                       0.0032,
     "z-ai/glm-5.1":                     0.0044,
-    "z-ai/glm-5.2":                     0.0044
+    "z-ai/glm-5.2":                     0.0044,
+    "z-ai/glm-5.3-flash":               0.0005
   }
 }'
 # END_GENERATED_PRICES

--- a/install/pi-router/src/pricing.generated.ts
+++ b/install/pi-router/src/pricing.generated.ts
@@ -6,7 +6,7 @@ export interface ModelPricing {
 	outputUsdPerMillion: number;
 }
 
-export const PRICING_VERSION = "catalog-sha256:25e57a89d32e62f3";
+export const PRICING_VERSION = "catalog-sha256:3863968c8737c92a";
 
 export const MODEL_PRICING: Readonly<Record<string, ModelPricing>> = Object.freeze({
 	"claude-fable-5": { inputUsdPerMillion: 10, outputUsdPerMillion: 50 },
@@ -82,4 +82,5 @@ export const MODEL_PRICING: Readonly<Record<string, ModelPricing>> = Object.free
 	"z-ai/glm-5": { inputUsdPerMillion: 1, outputUsdPerMillion: 3.2 },
 	"z-ai/glm-5.1": { inputUsdPerMillion: 1.4, outputUsdPerMillion: 4.4 },
 	"z-ai/glm-5.2": { inputUsdPerMillion: 1.4, outputUsdPerMillion: 4.4 },
+	"z-ai/glm-5.3-flash": { inputUsdPerMillion: 0.15, outputUsdPerMillion: 0.5 },
 });

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -139,16 +139,17 @@ var forceModelAliases = map[string]string{
 	"kimi-k2.6": "moonshotai/kimi-k2.6",
 	// Generic glm/zai aliases stay on 5.1 (Together/Fireworks/OpenRouter);
 	// 5.2 is Fireworks-only day-0, so it requires an explicit pin.
-	"glm":          "z-ai/glm-5.1",
-	"zai":          "z-ai/glm-5.1",
-	"z-ai":         "z-ai/glm-5.1",
-	"glm-5.2":      "z-ai/glm-5.2",
-	"glm-5.1":      "z-ai/glm-5.1",
-	"glm-5":        "z-ai/glm-5",
-	"minimax":      "minimax/minimax-m3",
-	"minimax-m3":   "minimax/minimax-m3",
-	"minimax-m2.7": "minimax/minimax-m2.7",
-	"mistral":      "mistralai/mistral-small-2603",
+	"glm":           "z-ai/glm-5.1",
+	"zai":           "z-ai/glm-5.1",
+	"z-ai":          "z-ai/glm-5.1",
+	"glm-5.3-flash": "z-ai/glm-5.3-flash",
+	"glm-5.2":       "z-ai/glm-5.2",
+	"glm-5.1":       "z-ai/glm-5.1",
+	"glm-5":         "z-ai/glm-5",
+	"minimax":       "minimax/minimax-m3",
+	"minimax-m3":    "minimax/minimax-m3",
+	"minimax-m2.7":  "minimax/minimax-m2.7",
+	"mistral":       "mistralai/mistral-small-2603",
 }
 
 // resolveForceModel is the legacy two-return surface. New pin-and-effort

--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -581,6 +581,21 @@ var Models = []Model{
 		{Provider: providers.ProviderWaferAnthropic, UpstreamID: "GLM-5.2",
 			Price: Pricing{InputUSDPer1M: 1.260, OutputUSDPer1M: 3.960, CacheReadMultiplier: 0.23 / 1.260}},
 	}},
+	// GLM-5.3-Flash: first native-multimodal (image+video) model in the GLM-5
+	// line, so ImageInput stays default (unlike 5/5.1/5.2, which 4xx on image
+	// parts). Thinking cannot be disabled (docs.z.ai/guides/vlm/glm-5.3-flash:
+	// "thinking.type only supports enabled") — do not add it to
+	// openRouterReasoningHint. OpenRouter-only for now: Together and Fireworks
+	// both list it "coming soon" with no live serverless price as of
+	// 2026-08-27. Priced at the standard post-promo rate ($0.15/$0.50, cache
+	// $0.03 — matching Z.ai's own list price) rather than the $0.075/$0.25
+	// introductory rate shared across Z.ai/NovitaAI/GMICloud (through
+	// 2026-09-09 16:00 UTC) — avoids a compile-time price going stale (cf.
+	// gemini-3.7-flash).
+	{ID: "z-ai/glm-5.3-flash", Tier: TierLow, ContextWindow: 1_310_720, Providers: []ProviderBinding{
+		{Provider: providers.ProviderOpenRouter,
+			Price: Pricing{InputUSDPer1M: 0.150, OutputUSDPer1M: 0.500, CacheReadMultiplier: 0.03 / 0.150}},
+	}},
 	// Fireworks-dedicated rows below carry an OpenRouter trailing binding so
 	// managed-prod deploys without a Fireworks key can still resolve them.
 	{ID: "mistralai/mistral-small-2603", Tier: TierMid, ContextWindow: 262_144, Providers: []ProviderBinding{

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -243,6 +243,10 @@ func (e *RequestEnvelope) buildOpenAIFromOpenAI(opts EmitOptions) ([]byte, error
 	if err != nil {
 		return nil, err
 	}
+	body, err = applyGLM53FlashFlagsIfNeeded(body, opts)
+	if err != nil {
+		return nil, err
+	}
 	return body, nil
 }
 
@@ -356,6 +360,10 @@ func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, pr
 	if err != nil {
 		return nil, stats, err
 	}
+	body, err = applyGLM53FlashFlagsIfNeeded(body, opts)
+	if err != nil {
+		return nil, stats, err
+	}
 	return body, stats, nil
 }
 
@@ -386,6 +394,23 @@ func applyGLM51FlagsIfNeeded(body []byte, opts EmitOptions) ([]byte, error) {
 		body = out
 	}
 	return body, nil
+}
+
+// applyGLM53FlashFlagsIfNeeded sets tool_stream=true for GLM-5.3-Flash
+// (docs.z.ai/guides/vlm/glm-5.3-flash requires it for streaming tool calls).
+// Unlike GLM-5.1, thinking is not force-disabled — it can't be turned off.
+func applyGLM53FlashFlagsIfNeeded(body []byte, opts EmitOptions) ([]byte, error) {
+	if !isGLM53Flash(opts.TargetModel) {
+		return body, nil
+	}
+	if gjson.GetBytes(body, "tool_stream").Exists() {
+		return body, nil
+	}
+	out, err := sjson.SetBytes(body, "tool_stream", true)
+	if err != nil {
+		return nil, fmt.Errorf("set glm-5.3-flash tool_stream: %w", err)
+	}
+	return out, nil
 }
 
 // applyQwen3SamplersIfNeeded layers the Qwen3 model-card sampling defaults

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -1297,6 +1297,7 @@ var modelMaxOutputTokens = map[string]int{
 	"minimax/minimax-m2.7":             65536,
 	"z-ai/glm-5":                       65536,
 	"z-ai/glm-5.1":                     65536,
+	"z-ai/glm-5.3-flash":               131072, // OpenRouter reports a 131,072 completion token ceiling
 	"google/gemini-3.7-flash":          65536,
 }
 

--- a/internal/translate/glm53flash_flags_test.go
+++ b/internal/translate/glm53flash_flags_test.go
@@ -1,0 +1,83 @@
+package translate_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router"
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGLM53FlashFlags_OpenRouter_ToolStreamSet(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel:    "z-ai/glm-5.3-flash",
+		TargetProvider: providers.ProviderOpenRouter,
+		Capabilities:   router.Lookup("z-ai/glm-5.3-flash"),
+	})
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &out))
+	assert.Equal(t, true, out["tool_stream"], "glm-5.3-flash must receive tool_stream=true")
+	_, hasKwargs := out["chat_template_kwargs"]
+	assert.False(t, hasKwargs, "glm-5.3-flash has no vLLM binding, so no chat_template_kwargs")
+	_, hasReasoning := out["reasoning"]
+	assert.False(t, hasReasoning, "glm-5.3-flash thinking can't be disabled, so no reasoning hint")
+}
+
+func TestGLM53FlashFlags_AnthropicCrossFormat_ToolStreamSet(t *testing.T) {
+	body := []byte(`{
+		"model": "claude-opus-4-7",
+		"max_tokens": 256,
+		"messages": [{"role":"user","content":"hi"}]
+	}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel:    "z-ai/glm-5.3-flash",
+		TargetProvider: providers.ProviderOpenRouter,
+		Capabilities:   router.Lookup("z-ai/glm-5.3-flash"),
+	})
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &out))
+	assert.Equal(t, true, out["tool_stream"], "anthropic→openrouter glm-5.3-flash must receive tool_stream=true")
+}
+
+func TestGLM53FlashFlags_ClientSetToolStreamPreserved(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"tool_stream":false}`)
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel:    "z-ai/glm-5.3-flash",
+		TargetProvider: providers.ProviderOpenRouter,
+		Capabilities:   router.Lookup("z-ai/glm-5.3-flash"),
+	})
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &out))
+	assert.Equal(t, false, out["tool_stream"], "client-set tool_stream=false must be preserved")
+}
+
+func TestGLM53FlashFlags_NotAppliedToOtherModels(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel:    "z-ai/glm-5",
+		TargetProvider: providers.ProviderOpenRouter,
+		Capabilities:   router.Lookup("z-ai/glm-5"),
+	})
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &out))
+	_, hasToolStream := out["tool_stream"]
+	assert.False(t, hasToolStream, "glm-5 must not receive glm-5.3-flash's tool_stream injection")
+}

--- a/internal/translate/provider_hint.go
+++ b/internal/translate/provider_hint.go
@@ -58,6 +58,14 @@ func isGLM51(model string) bool {
 	return model == "z-ai/glm-5.1"
 }
 
+// isGLM53Flash reports whether the model id is z-ai/glm-5.3-flash. Like
+// GLM-5.1 it needs tool_stream=true opted in (docs.z.ai/guides/vlm/glm-5.3-flash).
+// Unlike GLM-5.1, thinking can't be disabled, so it's absent from
+// openRouterReasoningHint and gets no chat_template_kwargs handling.
+func isGLM53Flash(model string) bool {
+	return model == "z-ai/glm-5.3-flash"
+}
+
 // isQwen3Family reports whether the model id belongs to the qwen3.x family.
 // These variants drift into tool-call/thinking loops without the model
 // card's recommended sampling defaults, which we layer in when unset.


### PR DESCRIPTION
## Summary
Adds GLM-5.3-Flash (z.ai) as a servable catalog model. Stage A of the [add-router-model](https://openrouter.ai/z-ai/glm-5.3-flash) workflow — this makes the model servable via passthrough / `/force-model`; it is **not** yet in the HMM roster, so it won't be auto-selected in prod (Stage C, tracked separately).

## What's in this PR
- **Catalog entry** (`z-ai/glm-5.3-flash`, TierLow, 1,310,720 ctx): OpenRouter-only for now — Together and Fireworks both list it "coming soon" with no live serverless price as of 2026-08-27. Priced at the standard post-promo rate ($0.15/$0.50/1M, cache $0.03) rather than the $0.075/$0.25 introductory rate (expires 2026-09-09 16:00 UTC), so the catalog price doesn't silently go stale.
- **`/force-model glm-5.3-flash`** alias (generic `glm`/`zai`/`z-ai` aliases stay pinned to 5.1, matching how 5.2 was rolled out).
- **`tool_stream=true`** forced for streaming tool calls, mirroring GLM-5.1's fix — z.ai's docs document this as required for GLM-5.3-Flash too.
- **No thinking-disable hint**: unlike GLM-5.1, GLM-5.3-Flash's thinking mode cannot be turned off (z.ai docs: "thinking.type only supports enabled"), so it's deliberately excluded from `openRouterReasoningHint`.
- **`ImageInput` left at default** (supported): GLM-5.3-Flash is the first native-multimodal (image+video) model in the GLM-5 line, unlike 5/5.1/5.2 which 4xx on image parts.
- Max output tokens (131,072), pricing tables (`install.sh`, `cc-statusline.sh`, `pricing.generated.ts`) regenerated via `go run ./cmd/genprices`.

## Testing
- `go build ./...`, `go vet ./...`, `go test ./...` — all green (53 packages).
- New tests in `internal/translate/glm53flash_flags_test.go` cover: `tool_stream` injection on both same-format and Anthropic→OpenAI cross-format paths, client-set `tool_stream` preservation, and no leakage to other GLM models. Verified non-tautological by temporarily removing the same-format wiring and confirming the test fails.

## Not in this PR
- **HMM roster / prior (Stage C)** — the model is not routable in prod until it's added to `ml_dev/hmm_router/rosters/roster_v2.json` with a prior. Follow-up via the `hmm-add-model-prior` skill; needs a decision on neutral-prior vs. a paid solo bake-off.
- **WorkWeave pin bump (Stage B)** — happens in a separate WorkWeave PR after this merges (`wv mr sync`).

🤖 Generated with [Weave Router](https://router.workweave.ai)