### PR TITLE
feat(codex): always-on routing badge and Responses feedback footer

### DIFF
--- a/internal/proxy/feedback.go
+++ b/internal/proxy/feedback.go
@@ -195,6 +195,12 @@ var terminalFeedbackClients = map[string]struct{}{
 // out of upstream context on ingress.
 const feedbackFooterText = "\n\n_Weave Router feedback:_ `/rf +` good experience · `/rf -` poor experience · note optional, e.g. `/rf - too slow`"
 
+// Codex reserves `/…` for built-ins, so the same hint has to name the `$rf`
+// skill (or the leading-space prompt form) or the TUI reports an unrecognized
+// command. Keep the `_Weave Router feedback:_` sentinel identical so ingress
+// stripping matches both.
+const feedbackFooterTextCodex = "\n\n_Weave Router feedback:_ `$rf +` good experience · `$rf -` poor experience · note optional, e.g. `$rf - too slow`"
+
 // feedbackFooter returns the in-terminal rating hint for a streamed response,
 // or "" to stay transparent. Gated to terminalFeedbackClients (avoid
 // contaminating non-chat surfaces), to deployments with durable feedback
@@ -221,6 +227,9 @@ func (s *Service) feedbackFooter(ctx context.Context, clientApp string, tt turnt
 	}
 	if echoedSinceHumanTurn {
 		return ""
+	}
+	if clientApp == ClientAppCodex {
+		return feedbackFooterTextCodex
 	}
 	return feedbackFooterText
 }

--- a/internal/proxy/feedback.go
+++ b/internal/proxy/feedback.go
@@ -195,10 +195,7 @@ var terminalFeedbackClients = map[string]struct{}{
 // out of upstream context on ingress.
 const feedbackFooterText = "\n\n_Weave Router feedback:_ `/rf +` good experience · `/rf -` poor experience · note optional, e.g. `/rf - too slow`"
 
-// Codex reserves `/…` for built-ins, so the same hint has to name the `$rf`
-// skill (or the leading-space prompt form) or the TUI reports an unrecognized
-// command. Keep the `_Weave Router feedback:_` sentinel identical so ingress
-// stripping matches both.
+// Codex reserves `/…` for built-ins, so `$rf` is used instead; the sentinel prefix is kept identical so ingress stripping matches both.
 const feedbackFooterTextCodex = "\n\n_Weave Router feedback:_ `$rf +` good experience · `$rf -` poor experience · note optional, e.g. `$rf - too slow`"
 
 // feedbackFooter returns the in-terminal rating hint for a streamed response,

--- a/internal/proxy/feedback_footer_internal_test.go
+++ b/internal/proxy/feedback_footer_internal_test.go
@@ -17,11 +17,16 @@ func TestFeedbackFooter_ClientGating(t *testing.T) {
 	withStore := (&Service{}).WithRouterFeedbackStore(footerFakeStore{})
 
 	t.Run("terminal agents get the link-free rating hint", func(t *testing.T) {
-		for _, app := range []string{ClientAppClaudeCode, ClientAppCodex, ClientAppOpencode} {
+		for _, app := range []string{ClientAppClaudeCode, ClientAppOpencode} {
 			footer := withStore.feedbackFooter(context.Background(), app, turntype.MainLoop, false)
 			assert.Equal(t, feedbackFooterText, footer, "expected hint for %q", app)
 			assert.NotContains(t, footer, "http", "footer must never embed a raw link")
 		}
+		codex := withStore.feedbackFooter(context.Background(), ClientAppCodex, turntype.MainLoop, false)
+		assert.Equal(t, feedbackFooterTextCodex, codex)
+		assert.Contains(t, codex, "$rf +")
+		assert.NotContains(t, codex, "`/rf")
+		assert.NotContains(t, codex, "http")
 	})
 
 	t.Run("ide and unknown clients are suppressed", func(t *testing.T) {

--- a/internal/proxy/marker_internal_test.go
+++ b/internal/proxy/marker_internal_test.go
@@ -397,3 +397,15 @@ func TestHumanReasonFromPlanner_UnknownCodeIsSilenced(t *testing.T) {
 	got := humanReasonFromPlanner("brand_new_reason_v9")
 	assert.Empty(t, got)
 }
+
+func TestRoutingMarkerForOpts_AlwaysShowsStickyCodexTurn(t *testing.T) {
+	res := turnLoopResult{
+		Decision:         router.Decision{Model: "gpt-5.6-terra", Provider: "openai"},
+		StickyHit:        true,
+		PriorServedModel: "gpt-5.6-terra",
+	}
+	assert.Empty(t, routingMarkerFor(res), "Claude Code keeps same-model suppression")
+	got := routingMarkerForOpts(res, true)
+	assert.Contains(t, got, "✦ **Weave Router** → gpt-5.6-terra")
+	assert.True(t, strings.HasSuffix(got, "\n\n"))
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -405,6 +405,10 @@ type nativeResponsesReasoningHashContextKey struct{}
 // nativeResponsesToolHashContextKey preserves native Responses tool identity.
 type nativeResponsesToolHashContextKey struct{}
 
+// responsesFooterEchoedContextKey is set when the original Responses input
+// already carries a rating hint after the last human turn.
+type responsesFooterEchoedContextKey struct{}
+
 // InstallationExcludedModelsContextKey is the context key for the authed
 // installation's model exclusion list. Carried as []string.
 type InstallationExcludedModelsContextKey struct{}
@@ -2638,6 +2642,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// cleanup, matching the OpenAI chat path. The echo check must read the body
 	// before the strip erases its evidence.
 	footerEchoedSinceHumanTurn := translate.FeedbackFooterSinceLastHumanTurn(body)
+	if echoed, _ := ctx.Value(responsesFooterEchoedContextKey{}).(bool); echoed {
+		footerEchoedSinceHumanTurn = true
+	}
 	if strippedBody, ferr := translate.StripFeedbackFooterFromMessages(body); ferr != nil {
 		log.Error("Failed to strip feedback footer from inbound messages", "err", ferr)
 	} else {
@@ -5250,6 +5257,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// cleanup, matching the Anthropic Messages path. The echo check must read
 	// the body before the strip erases its evidence.
 	footerEchoedSinceHumanTurn := translate.FeedbackFooterSinceLastHumanTurn(body)
+	if echoed, _ := ctx.Value(responsesFooterEchoedContextKey{}).(bool); echoed {
+		footerEchoedSinceHumanTurn = true
+	}
 	strippedBody, stripErr = translate.StripFeedbackFooterFromMessages(body)
 	if stripErr != nil {
 		log.Error("Failed to strip feedback footer from OpenAI messages", "err", stripErr)
@@ -6210,6 +6220,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.ResponseWriter, r *http.Request) error {
 	ctx = s.withUsageObserver(ctx, r.Header)
 	clientAppCodex := ClientIdentityFrom(ctx).ClientApp == ClientAppCodex
+	if translate.FeedbackFooterSinceLastHumanTurnInResponses(body) {
+		ctx = context.WithValue(ctx, responsesFooterEchoedContextKey{}, true)
+	}
 	conversion, err := translate.ConvertResponsesToChatCompletionsWithOptions(body, translate.ResponsesConversionOptions{
 		PortableCodex: clientAppCodex,
 	})

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -533,6 +533,13 @@ func suppressMarkerIfRequested(ctx context.Context, h http.Header, marker string
 // routingMarkerFor builds the "brand → model · note" snippet emitted at the
 // start of every cross-format streamed response.
 func routingMarkerFor(res turnLoopResult) string {
+	return routingMarkerForOpts(res, false)
+}
+
+// routingMarkerForOpts is routingMarkerFor with an always-on switch used by
+// Codex: that client has no statusline, so a sticky same-model turn would
+// otherwise look like stock Codex.
+func routingMarkerForOpts(res turnLoopResult, always bool) string {
 	decision := res.Decision
 	if decision.Model == "" {
 		return ""
@@ -554,7 +561,9 @@ func routingMarkerFor(res turnLoopResult) string {
 	// for this turn" / "best pick for this turn" repeating each turn would
 	// otherwise be visible even when nothing switched. Hard-pin carve-outs and
 	// first-turn (empty prior) cases still flow to the sidecar marker below.
-	if res.PriorServedModel == res.Decision.ServedIdentity() {
+	// Codex has no persistent statusline, so always-on keeps the badge even when
+	// the served model did not change.
+	if !always && res.PriorServedModel == res.Decision.ServedIdentity() {
 		return ""
 	}
 	// A sidecar-supplied marker is a genuine per-turn status line (e.g.
@@ -5630,7 +5639,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	preludeBuf := newPreludeBuffer(contentSink)
 	var rootSink http.ResponseWriter = preludeBuf
 
-	marker := suppressMarkerIfRequested(ctx, r.Header, routingMarkerFor(routeRes))
+	marker := suppressMarkerIfRequested(ctx, r.Header, routingMarkerForOpts(routeRes, clientID.ClientApp == ClientAppCodex))
 	if billing.SubscriptionOnlyFromContext(ctx) {
 		// Always surface the depleted-credits warning (not gated by the
 		// routing-marker opt-out): a billing state change the caller must see.
@@ -5663,8 +5672,13 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// Previously gated on policy debug; ordinary Codex turns fell through to
 	// ResponsesWriter's legacy badge that ignored suppression and never showed the routing reason.
 	verbatimPassthrough := responsesPassthrough && decision.Provider == providers.ProviderOpenAI
-	if rw, ok := w.(*translate.ResponsesWriter); ok && marker != "" && !verbatimPassthrough {
-		rw.SetBadgeText(marker)
+	if rw, ok := w.(*translate.ResponsesWriter); ok {
+		if marker != "" && !verbatimPassthrough {
+			rw.SetBadgeText(marker)
+		}
+		if footer := s.feedbackFooter(ctx, clientID.ClientApp, routeRes.TurnType, footerEchoedSinceHumanTurn); footer != "" {
+			rw.SetFooterText(footer)
+		}
 	}
 	// Outlives the passthrough teardown of marker below, so a chat/completions
 	// re-dispatch can still badge the translated stream.
@@ -5687,8 +5701,11 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		if verbatimPassthrough {
 			// marker already carries the depleted-credits warning in
 			// subscription-only mode, which overrides the opt-out above.
-			if clientID.ClientApp == ClientAppCodex && marker != "" {
-				rw.SetBadgeText(marker)
+			// Parse native SSE when Codex needs a badge and/or footer.
+			if clientID.ClientApp == ClientAppCodex && (marker != "" || s.feedbackFooter(ctx, clientID.ClientApp, routeRes.TurnType, footerEchoedSinceHumanTurn) != "") {
+				if marker != "" {
+					rw.SetBadgeText(marker)
+				}
 				rw.SetPassthroughBadge()
 			} else {
 				rw.SetPassthrough()
@@ -6202,16 +6219,20 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 	}
 	chatBody, model := conversion.Body, conversion.Model
 	codexNativeRequest := codexResponsesRequest(ctx, r.Header)
-	nativeBody := conversion.OriginalBody
-	if clientAppCodex {
-		// Codex records response.output_item.done as conversation history and
-		// sends it back in the next native request. Remove only the badge this
-		// client opted into so router text never reaches the selected model.
-		nativeBody, err = translate.StripRoutingBadgeFromResponsesInput(nativeBody)
-		if err != nil {
-			return fmt.Errorf("strip native Responses routing badge: %w", err)
+		nativeBody := conversion.OriginalBody
+		if clientAppCodex {
+			// Codex records response.output_item.done as conversation history and
+			// sends it back in the next native request. Remove only the badge this
+			// client opted into so router text never reaches the selected model.
+			nativeBody, err = translate.StripRoutingBadgeFromResponsesInput(nativeBody)
+			if err != nil {
+				return fmt.Errorf("strip native Responses routing badge: %w", err)
+			}
+			nativeBody, err = translate.StripFeedbackFooterFromResponsesInput(nativeBody)
+			if err != nil {
+				return fmt.Errorf("strip native Responses feedback footer: %w", err)
+			}
 		}
-	}
 	// Every Responses turn stashes its original bytes for post-routing native
 	// dispatch; NativeOnly and Codex-subscription turns also dispatch verbatim now.
 	if conversion.Requirements.NativeOnly || codexNativeRequest {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -6231,20 +6231,20 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 	}
 	chatBody, model := conversion.Body, conversion.Model
 	codexNativeRequest := codexResponsesRequest(ctx, r.Header)
-		nativeBody := conversion.OriginalBody
-		if clientAppCodex {
-			// Codex records response.output_item.done as conversation history and
-			// sends it back in the next native request. Remove only the badge this
-			// client opted into so router text never reaches the selected model.
-			nativeBody, err = translate.StripRoutingBadgeFromResponsesInput(nativeBody)
-			if err != nil {
-				return fmt.Errorf("strip native Responses routing badge: %w", err)
-			}
-			nativeBody, err = translate.StripFeedbackFooterFromResponsesInput(nativeBody)
-			if err != nil {
-				return fmt.Errorf("strip native Responses feedback footer: %w", err)
-			}
+	nativeBody := conversion.OriginalBody
+	if clientAppCodex {
+		// Codex records response.output_item.done as conversation history and
+		// sends it back in the next native request. Remove only the badge this
+		// client opted into so router text never reaches the selected model.
+		nativeBody, err = translate.StripRoutingBadgeFromResponsesInput(nativeBody)
+		if err != nil {
+			return fmt.Errorf("strip native Responses routing badge: %w", err)
 		}
+		nativeBody, err = translate.StripFeedbackFooterFromResponsesInput(nativeBody)
+		if err != nil {
+			return fmt.Errorf("strip native Responses feedback footer: %w", err)
+		}
+	}
 	// Every Responses turn stashes its original bytes for post-routing native
 	// dispatch; NativeOnly and Codex-subscription turns also dispatch verbatim now.
 	if conversion.Requirements.NativeOnly || codexNativeRequest {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -536,9 +536,8 @@ func routingMarkerFor(res turnLoopResult) string {
 	return routingMarkerForOpts(res, false)
 }
 
-// routingMarkerForOpts is routingMarkerFor with an always-on switch used by
-// Codex: that client has no statusline, so a sticky same-model turn would
-// otherwise look like stock Codex.
+// routingMarkerForOpts is routingMarkerFor with an always-on switch for
+// clients (e.g. Codex) that have no persistent statusline.
 func routingMarkerForOpts(res turnLoopResult, always bool) string {
 	decision := res.Decision
 	if decision.Model == "" {

--- a/internal/translate/footer_echo.go
+++ b/internal/translate/footer_echo.go
@@ -8,6 +8,9 @@ import "github.com/tidwall/gjson"
 // Handles Anthropic and OpenAI messages[] shapes. Must run before
 // StripFeedbackFooterFromMessages removes the echo.
 func FeedbackFooterSinceLastHumanTurn(body []byte) bool {
+	if FeedbackFooterSinceLastHumanTurnInResponses(body) {
+		return true
+	}
 	msgs := gjson.GetBytes(body, "messages")
 	if !msgs.IsArray() {
 		return false
@@ -22,6 +25,52 @@ func FeedbackFooterSinceLastHumanTurn(body []byte) bool {
 			}
 		case "assistant":
 			if feedbackFooterPattern.MatchString(assistantMessageText(msg)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// FeedbackFooterSinceLastHumanTurnInResponses is the Responses-input analogue
+// of FeedbackFooterSinceLastHumanTurn. Must run on the original body before
+// portable conversion strips the hint.
+func FeedbackFooterSinceLastHumanTurnInResponses(body []byte) bool {
+	input := gjson.GetBytes(body, "input")
+	if !input.IsArray() {
+		return false
+	}
+	all := input.Array()
+	for i := len(all) - 1; i >= 0; i-- {
+		item := all[i]
+		itemType := item.Get("type").Str
+		role := item.Get("role").Str
+		if itemType == "message" || (itemType == "" && role != "") {
+			switch role {
+			case "user":
+				return false
+			case "assistant":
+				if responsesItemHasFeedbackFooter(item) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func responsesItemHasFeedbackFooter(item gjson.Result) bool {
+	content := item.Get("content")
+	if content.Type == gjson.String {
+		return feedbackFooterPattern.MatchString(content.Str)
+	}
+	if !content.IsArray() {
+		return false
+	}
+	for _, part := range content.Array() {
+		switch part.Get("type").Str {
+		case "input_text", "output_text", "text":
+			if feedbackFooterPattern.MatchString(part.Get("text").Str) {
 				return true
 			}
 		}

--- a/internal/translate/footer_echo_test.go
+++ b/internal/translate/footer_echo_test.go
@@ -80,3 +80,9 @@ func TestFeedbackFooterSinceLastHumanTurn_EmptyAndMissing(t *testing.T) {
 		assert.False(t, translate.FeedbackFooterSinceLastHumanTurn(body))
 	}
 }
+
+func TestFeedbackFooterSinceLastHumanTurnInResponses(t *testing.T) {
+	body := []byte("{\"input\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"done\\n\\n_Weave Router feedback:_ `$rf +` x\"}]}]}")
+	assert.True(t, translate.FeedbackFooterSinceLastHumanTurnInResponses(body))
+	assert.True(t, translate.FeedbackFooterSinceLastHumanTurn(body))
+}

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -423,7 +423,6 @@ func StripFeedbackFooterFromResponsesInput(body []byte) ([]byte, error) {
 					return nil, fmt.Errorf("strip Responses feedback footer from content part: %w", err)
 				}
 				changed = true
-				return out, nil
 			}
 		}
 	}
@@ -1044,10 +1043,7 @@ func (t *ResponsesWriter) rewriteNativeResponsesPayload(data []byte) ([]byte, bo
 		if !t.observeNativeBadgeTarget(ref) || !t.nativeBadgeTargetMatches(ref, true) {
 			return data, false
 		}
-		return applyNativeRewrites(data,
-			func(d []byte) ([]byte, bool) { return t.prefixNativeBadge(d, "text") },
-			func(d []byte) ([]byte, bool) { return t.suffixNativeFooter(d, "text") },
-		)
+		return t.prefixNativeBadge(data, "text")
 
 	case "response.content_part.done":
 		if root.Get("part.type").Str != "output_text" {
@@ -1057,10 +1053,7 @@ func (t *ResponsesWriter) rewriteNativeResponsesPayload(data []byte) ([]byte, bo
 		if !t.observeNativeBadgeTarget(ref) || !t.nativeBadgeTargetMatches(ref, true) {
 			return data, false
 		}
-		return applyNativeRewrites(data,
-			func(d []byte) ([]byte, bool) { return t.prefixNativeBadge(d, "part.text") },
-			func(d []byte) ([]byte, bool) { return t.suffixNativeFooter(d, "part.text") },
-		)
+		return t.prefixNativeBadge(data, "part.text")
 
 	case "response.output_item.done":
 		item := root.Get("item")
@@ -1080,14 +1073,7 @@ func (t *ResponsesWriter) rewriteNativeResponsesPayload(data []byte) ([]byte, bo
 		if !t.observeNativeBadgeTarget(ref) || !t.nativeBadgeTargetMatches(ref, true) {
 			return data, false
 		}
-		return applyNativeRewrites(data,
-			func(d []byte) ([]byte, bool) {
-				return t.prefixNativeBadge(d, "item.content."+strconv.Itoa(partIndex)+".text")
-			},
-			func(d []byte) ([]byte, bool) {
-				return t.suffixNativeFooter(d, "item.content."+strconv.Itoa(partIndex)+".text")
-			},
-		)
+		return t.prefixNativeBadge(data, "item.content."+strconv.Itoa(partIndex)+".text")
 
 	case "response.completed", "response.incomplete":
 		output := root.Get("response.output")
@@ -1158,18 +1144,10 @@ func (t *ResponsesWriter) writeNativeResponsesEvent(event, delimiter []byte) err
 		t.sawToolCall = true
 	}
 	rewritten := t.rewriteNativeResponsesEvent(event)
-	if eventType == "response.output_text.delta" && t.footerText != "" && !t.sawToolCall {
-		if err := t.flushNativeHeldDelta(); err != nil {
+	if eventType == "response.completed" || eventType == "response.incomplete" {
+		if err := t.emitNativeFooterDelta(); err != nil {
 			return err
 		}
-		t.nativeHeldDelta = append(t.nativeHeldDelta[:0], rewritten...)
-		if len(delimiter) > 0 {
-			t.nativeHeldDelta = append(t.nativeHeldDelta, delimiter...)
-		}
-		return nil
-	}
-	if err := t.flushNativeHeldDelta(); err != nil {
-		return err
 	}
 	if _, err := t.bw.Write(rewritten); err != nil {
 		return err
@@ -1181,14 +1159,46 @@ func (t *ResponsesWriter) writeNativeResponsesEvent(event, delimiter []byte) err
 	return nil
 }
 
-func (t *ResponsesWriter) flushNativeHeldDelta() error {
+func (t *ResponsesWriter) emitNativeFooterDelta() error {
+	if t.footerText == "" || t.sawToolCall || t.footerEmitted {
+		return nil
+	}
+	payload := map[string]any{
+		"type":  "response.output_text.delta",
+		"delta": t.footerText,
+	}
+	if t.nativeBadgeItemID != "" {
+		payload["item_id"] = t.nativeBadgeItemID
+	}
+	if t.nativeBadgeHasOutputIndex {
+		payload["output_index"] = t.nativeBadgeOutputIndex
+	}
+	if t.nativeBadgeHasContentIndex {
+		payload["content_index"] = t.nativeBadgeContentIndex
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil
+	}
+	t.footerEmitted = true
+	if _, err := t.bw.WriteString("event: response.output_text.delta\ndata: "); err != nil {
+		return err
+	}
+	if _, err := t.bw.Write(body); err != nil {
+		return err
+	}
+	_, err = t.bw.WriteString("\n\n")
+	return err
+}
+
+func (t *ResponsesWriter) flushNativeHeldDelta(appendFooter bool) error {
 	if len(t.nativeHeldDelta) == 0 {
 		return nil
 	}
 	held := t.nativeHeldDelta
 	t.nativeHeldDelta = nil
 	_, data := sse.ParseEvent(held)
-	if t.footerText != "" && !t.sawToolCall && gjson.ValidBytes(data) {
+	if appendFooter && t.footerText != "" && !t.sawToolCall && gjson.ValidBytes(data) {
 		if suffixed, ok := t.suffixNativeFooter(data, "delta"); ok {
 			offset := bytes.Index(held, data)
 			if offset >= 0 {
@@ -1227,7 +1237,7 @@ func (t *ResponsesWriter) processFinalPassthroughSSETail() error {
 			return err
 		}
 	}
-	return t.flushNativeHeldDelta()
+	return t.flushNativeHeldDelta(false)
 }
 
 // FinalizeError emits a response.failed terminal event when upstream fails

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -373,6 +373,66 @@ func StripRoutingBadgeFromResponsesInput(body []byte) ([]byte, error) {
 	return out, nil
 }
 
+// StripFeedbackFooterFromResponsesInput removes the rating hint from assistant
+// text items so a subsequent native Codex turn does not echo it upstream.
+func StripFeedbackFooterFromResponsesInput(body []byte) ([]byte, error) {
+	input := gjson.GetBytes(body, "input")
+	if !input.IsArray() {
+		return body, nil
+	}
+	out := body
+	changed := false
+	for itemIndex, item := range input.Array() {
+		itemType := item.Get("type").Str
+		if itemType != "message" && !(itemType == "" && item.Get("role").Str != "") {
+			continue
+		}
+		if item.Get("role").Str != "assistant" {
+			continue
+		}
+		content := item.Get("content")
+		if content.Type == gjson.String {
+			stripped := feedbackFooterPattern.ReplaceAllString(content.Str, "")
+			if stripped == content.Str {
+				continue
+			}
+			var err error
+			out, err = sjson.SetBytes(out, "input."+strconv.Itoa(itemIndex)+".content", stripped)
+			if err != nil {
+				return nil, fmt.Errorf("strip Responses feedback footer from string content: %w", err)
+			}
+			changed = true
+			continue
+		}
+		if !content.IsArray() {
+			continue
+		}
+		for partIndex := len(content.Array()) - 1; partIndex >= 0; partIndex-- {
+			part := content.Array()[partIndex]
+			switch part.Get("type").Str {
+			case "input_text", "output_text", "text":
+				text := part.Get("text").Str
+				stripped := feedbackFooterPattern.ReplaceAllString(text, "")
+				if stripped == text {
+					continue
+				}
+				path := "input." + strconv.Itoa(itemIndex) + ".content." + strconv.Itoa(partIndex) + ".text"
+				var err error
+				out, err = sjson.SetBytes(out, path, stripped)
+				if err != nil {
+					return nil, fmt.Errorf("strip Responses feedback footer from content part: %w", err)
+				}
+				changed = true
+				return out, nil
+			}
+		}
+	}
+	if !changed {
+		return body, nil
+	}
+	return out, nil
+}
+
 // responsesContentHasBody reports whether a content array carries anything
 // beyond the (now stripped) part at skipIndex. Non-text parts always count.
 func responsesContentHasBody(content gjson.Result, skipIndex int) bool {
@@ -471,6 +531,10 @@ type ResponsesWriter struct {
 	nativeBadgeHasOutputIndex  bool
 	nativeBadgeContentIndex    int64
 	nativeBadgeHasContentIndex bool
+	footerText                 string
+	footerEmitted              bool
+	sawToolCall                bool
+	nativeHeldDelta            []byte
 	textItem                   *responsesTextItem
 	toolItems                  map[int]*responsesToolItem
 	finishReason               string
@@ -574,6 +638,12 @@ func (t *ResponsesWriter) SetBadgeText(text string) {
 // sentinel so ingress stripping only removes router-injected text.
 func (t *ResponsesWriter) EnableCodexBadgeProvenance() {
 	t.codexBadgeProvenance = true
+}
+
+// SetFooterText appends the rating hint to the last assistant text of a
+// naturally finished, tool-free turn. Empty text is a no-op.
+func (t *ResponsesWriter) SetFooterText(text string) {
+	t.footerText = text
 }
 
 func (t *ResponsesWriter) Header() http.Header { return t.inner.Header() }
@@ -761,7 +831,7 @@ func (t *ResponsesWriter) Finalize() error {
 		return err
 	}
 
-	translated, err := chatCompletionToResponse(body, t.responseID, t.model, t.createdAt, t.toolMappings, t.computeBadgeText())
+	translated, err := chatCompletionToResponse(body, t.responseID, t.model, t.createdAt, t.toolMappings, t.computeBadgeText(), t.footerText)
 	if err != nil {
 		t.inner.Header().Set("Content-Type", "application/json")
 		t.inner.WriteHeader(http.StatusBadGateway)
@@ -911,6 +981,36 @@ func (t *ResponsesWriter) prefixNativeBadge(data []byte, path string) ([]byte, b
 	return rewritten, true
 }
 
+func (t *ResponsesWriter) suffixNativeFooter(data []byte, path string) ([]byte, bool) {
+	if t.footerText == "" || t.sawToolCall {
+		return data, false
+	}
+	text := gjson.GetBytes(data, path)
+	if text.Type != gjson.String {
+		return data, false
+	}
+	if feedbackFooterPattern.MatchString(text.Str) {
+		return data, false
+	}
+	rewritten, err := sjson.SetBytes(append([]byte(nil), data...), path, text.Str+t.footerText)
+	if err != nil {
+		return data, false
+	}
+	return rewritten, true
+}
+
+func applyNativeRewrites(data []byte, fns ...func([]byte) ([]byte, bool)) ([]byte, bool) {
+	changed := false
+	for _, fn := range fns {
+		next, ok := fn(data)
+		if ok {
+			data = next
+			changed = true
+		}
+	}
+	return data, changed
+}
+
 func (t *ResponsesWriter) rewriteNativeResponsesPayload(data []byte) ([]byte, bool) {
 	if !gjson.ValidBytes(data) {
 		return data, false
@@ -944,7 +1044,10 @@ func (t *ResponsesWriter) rewriteNativeResponsesPayload(data []byte) ([]byte, bo
 		if !t.observeNativeBadgeTarget(ref) || !t.nativeBadgeTargetMatches(ref, true) {
 			return data, false
 		}
-		return t.prefixNativeBadge(data, "text")
+		return applyNativeRewrites(data,
+			func(d []byte) ([]byte, bool) { return t.prefixNativeBadge(d, "text") },
+			func(d []byte) ([]byte, bool) { return t.suffixNativeFooter(d, "text") },
+		)
 
 	case "response.content_part.done":
 		if root.Get("part.type").Str != "output_text" {
@@ -954,7 +1057,10 @@ func (t *ResponsesWriter) rewriteNativeResponsesPayload(data []byte) ([]byte, bo
 		if !t.observeNativeBadgeTarget(ref) || !t.nativeBadgeTargetMatches(ref, true) {
 			return data, false
 		}
-		return t.prefixNativeBadge(data, "part.text")
+		return applyNativeRewrites(data,
+			func(d []byte) ([]byte, bool) { return t.prefixNativeBadge(d, "part.text") },
+			func(d []byte) ([]byte, bool) { return t.suffixNativeFooter(d, "part.text") },
+		)
 
 	case "response.output_item.done":
 		item := root.Get("item")
@@ -974,7 +1080,14 @@ func (t *ResponsesWriter) rewriteNativeResponsesPayload(data []byte) ([]byte, bo
 		if !t.observeNativeBadgeTarget(ref) || !t.nativeBadgeTargetMatches(ref, true) {
 			return data, false
 		}
-		return t.prefixNativeBadge(data, "item.content."+strconv.Itoa(partIndex)+".text")
+		return applyNativeRewrites(data,
+			func(d []byte) ([]byte, bool) {
+				return t.prefixNativeBadge(d, "item.content."+strconv.Itoa(partIndex)+".text")
+			},
+			func(d []byte) ([]byte, bool) {
+				return t.suffixNativeFooter(d, "item.content."+strconv.Itoa(partIndex)+".text")
+			},
+		)
 
 	case "response.completed", "response.incomplete":
 		output := root.Get("response.output")
@@ -1003,7 +1116,10 @@ func (t *ResponsesWriter) rewriteNativeResponsesPayload(data []byte) ([]byte, bo
 				continue
 			}
 			path := "response.output." + strconv.Itoa(outputIndex) + ".content." + strconv.Itoa(partIndex) + ".text"
-			return t.prefixNativeBadge(data, path)
+			return applyNativeRewrites(data,
+				func(d []byte) ([]byte, bool) { return t.prefixNativeBadge(d, path) },
+				func(d []byte) ([]byte, bool) { return t.suffixNativeFooter(d, path) },
+			)
 		}
 	}
 	return data, false
@@ -1031,7 +1147,31 @@ func (t *ResponsesWriter) rewriteNativeResponsesEvent(raw []byte) []byte {
 }
 
 func (t *ResponsesWriter) writeNativeResponsesEvent(event, delimiter []byte) error {
-	if _, err := t.bw.Write(t.rewriteNativeResponsesEvent(event)); err != nil {
+	_, data := sse.ParseEvent(event)
+	eventType := ""
+	itemType := ""
+	if gjson.ValidBytes(data) {
+		eventType = gjson.GetBytes(data, "type").Str
+		itemType = gjson.GetBytes(data, "item.type").Str
+	}
+	if eventType == "response.function_call_arguments.delta" || eventType == "response.custom_tool_call_input.delta" || (eventType == "response.output_item.added" && (itemType == "function_call" || itemType == "custom_tool_call")) {
+		t.sawToolCall = true
+	}
+	rewritten := t.rewriteNativeResponsesEvent(event)
+	if eventType == "response.output_text.delta" && t.footerText != "" && !t.sawToolCall {
+		if err := t.flushNativeHeldDelta(); err != nil {
+			return err
+		}
+		t.nativeHeldDelta = append(t.nativeHeldDelta[:0], rewritten...)
+		if len(delimiter) > 0 {
+			t.nativeHeldDelta = append(t.nativeHeldDelta, delimiter...)
+		}
+		return nil
+	}
+	if err := t.flushNativeHeldDelta(); err != nil {
+		return err
+	}
+	if _, err := t.bw.Write(rewritten); err != nil {
 		return err
 	}
 	if len(delimiter) > 0 {
@@ -1039,6 +1179,29 @@ func (t *ResponsesWriter) writeNativeResponsesEvent(event, delimiter []byte) err
 		return err
 	}
 	return nil
+}
+
+func (t *ResponsesWriter) flushNativeHeldDelta() error {
+	if len(t.nativeHeldDelta) == 0 {
+		return nil
+	}
+	held := t.nativeHeldDelta
+	t.nativeHeldDelta = nil
+	_, data := sse.ParseEvent(held)
+	if t.footerText != "" && !t.sawToolCall && gjson.ValidBytes(data) {
+		if suffixed, ok := t.suffixNativeFooter(data, "delta"); ok {
+			offset := bytes.Index(held, data)
+			if offset >= 0 {
+				rewritten := make([]byte, 0, len(held)+len(t.footerText))
+				rewritten = append(rewritten, held[:offset]...)
+				rewritten = append(rewritten, suffixed...)
+				rewritten = append(rewritten, held[offset+len(data):]...)
+				held = rewritten
+			}
+		}
+	}
+	_, err := t.bw.Write(held)
+	return err
 }
 
 func (t *ResponsesWriter) processPassthroughSSEBuffer() error {
@@ -1057,12 +1220,14 @@ func (t *ResponsesWriter) processPassthroughSSEBuffer() error {
 }
 
 func (t *ResponsesWriter) processFinalPassthroughSSETail() error {
-	if t.buf.Len() == 0 {
-		return nil
+	if t.buf.Len() > 0 {
+		event := append([]byte(nil), t.buf.Bytes()...)
+		t.buf.Reset()
+		if err := t.writeNativeResponsesEvent(event, nil); err != nil {
+			return err
+		}
 	}
-	event := append([]byte(nil), t.buf.Bytes()...)
-	t.buf.Reset()
-	return t.writeNativeResponsesEvent(event, nil)
+	return t.flushNativeHeldDelta()
 }
 
 // FinalizeError emits a response.failed terminal event when upstream fails
@@ -1163,6 +1328,9 @@ func (t *ResponsesWriter) translateChunk(raw []byte) error {
 	}
 
 	if tcs := delta.Get("tool_calls"); tcs.IsArray() {
+		if tcs.Get("#").Int() > 0 {
+			t.sawToolCall = true
+		}
 		for _, tc := range tcs.Array() {
 			idx := int(tc.Get("index").Int())
 			if err := t.appendToolCall(idx, tc); err != nil {
@@ -1347,6 +1515,12 @@ func (t *ResponsesWriter) computeBadgeText() string {
 
 func (t *ResponsesWriter) closeOpenItems() error {
 	if t.textItem != nil && !t.textItem.closed {
+		if t.footerText != "" && !t.sawToolCall && t.finishReason == "stop" && !feedbackFooterPattern.MatchString(t.textItem.text.String()) {
+			t.textItem.text.WriteString(t.footerText)
+			if err := t.emitTextDelta(t.textItem, t.footerText); err != nil {
+				return err
+			}
+		}
 		if err := t.emitTextDone(t.textItem); err != nil && len(t.toolMappings) > 0 {
 			return err
 		}
@@ -1721,7 +1895,7 @@ func (t *ResponsesWriter) assembleOutput() []any {
 // stream:false; Codex always streams, but other clients may not. A non-empty
 // badge leads the assistant text, synthesizing the message item when the turn
 // produced only tool calls.
-func chatCompletionToResponse(body []byte, responseID, model string, createdAt int64, mappings map[string]ResponsesToolMapping, badge string) ([]byte, error) {
+func chatCompletionToResponse(body []byte, responseID, model string, createdAt int64, mappings map[string]ResponsesToolMapping, badge, footer string) ([]byte, error) {
 	if !gjson.ValidBytes(body) {
 		return nil, fmt.Errorf("invalid JSON")
 	}
@@ -1743,6 +1917,9 @@ func chatCompletionToResponse(body []byte, responseID, model string, createdAt i
 	text := badge
 	if content := choice.Get("content"); content.Type == gjson.String {
 		text += content.Str
+	}
+	if footer != "" && choice.Get("tool_calls.#").Int() == 0 && !feedbackFooterPattern.MatchString(text) {
+		text += footer
 	}
 	if text != "" {
 		output = append(output, map[string]any{

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -533,7 +533,8 @@ type ResponsesWriter struct {
 	footerText                 string
 	footerEmitted              bool
 	sawToolCall                bool
-	nativeHeldDelta            []byte
+	nativeHeldEvents           [][]byte
+	nativeFooterCommit         bool
 	textItem                   *responsesTextItem
 	toolItems                  map[int]*responsesToolItem
 	finishReason               string
@@ -1041,7 +1042,16 @@ func (t *ResponsesWriter) rewriteNativeResponsesPayload(data []byte) ([]byte, bo
 	case "response.output_text.done":
 		ref := nativeResponsesEventRef(root, "item_id")
 		if !t.observeNativeBadgeTarget(ref) || !t.nativeBadgeTargetMatches(ref, true) {
+			if t.nativeFooterCommit {
+				return t.suffixNativeFooter(data, "text")
+			}
 			return data, false
+		}
+		if t.nativeFooterCommit {
+			return applyNativeRewrites(data,
+				func(d []byte) ([]byte, bool) { return t.prefixNativeBadge(d, "text") },
+				func(d []byte) ([]byte, bool) { return t.suffixNativeFooter(d, "text") },
+			)
 		}
 		return t.prefixNativeBadge(data, "text")
 
@@ -1051,7 +1061,16 @@ func (t *ResponsesWriter) rewriteNativeResponsesPayload(data []byte) ([]byte, bo
 		}
 		ref := nativeResponsesEventRef(root, "item_id")
 		if !t.observeNativeBadgeTarget(ref) || !t.nativeBadgeTargetMatches(ref, true) {
+			if t.nativeFooterCommit {
+				return t.suffixNativeFooter(data, "part.text")
+			}
 			return data, false
+		}
+		if t.nativeFooterCommit {
+			return applyNativeRewrites(data,
+				func(d []byte) ([]byte, bool) { return t.prefixNativeBadge(d, "part.text") },
+				func(d []byte) ([]byte, bool) { return t.suffixNativeFooter(d, "part.text") },
+			)
 		}
 		return t.prefixNativeBadge(data, "part.text")
 
@@ -1071,9 +1090,19 @@ func (t *ResponsesWriter) rewriteNativeResponsesPayload(data []byte) ([]byte, bo
 		ref.contentIndex = int64(partIndex)
 		ref.hasContentIndex = true
 		if !t.observeNativeBadgeTarget(ref) || !t.nativeBadgeTargetMatches(ref, true) {
+			if t.nativeFooterCommit {
+				return t.suffixNativeFooter(data, "item.content."+strconv.Itoa(partIndex)+".text")
+			}
 			return data, false
 		}
-		return t.prefixNativeBadge(data, "item.content."+strconv.Itoa(partIndex)+".text")
+		path := "item.content." + strconv.Itoa(partIndex) + ".text"
+		if t.nativeFooterCommit {
+			return applyNativeRewrites(data,
+				func(d []byte) ([]byte, bool) { return t.prefixNativeBadge(d, path) },
+				func(d []byte) ([]byte, bool) { return t.suffixNativeFooter(d, path) },
+			)
+		}
+		return t.prefixNativeBadge(data, path)
 
 	case "response.completed", "response.incomplete":
 		output := root.Get("response.output")
@@ -1140,12 +1169,23 @@ func (t *ResponsesWriter) writeNativeResponsesEvent(event, delimiter []byte) err
 		eventType = gjson.GetBytes(data, "type").Str
 		itemType = gjson.GetBytes(data, "item.type").Str
 	}
-	if eventType == "response.function_call_arguments.delta" || eventType == "response.custom_tool_call_input.delta" || (eventType == "response.output_item.added" && (itemType == "function_call" || itemType == "custom_tool_call")) {
+	if eventType == "response.function_call_arguments.delta" || eventType == "response.custom_tool_call_input.delta" || (eventType == "response.output_item.added" && (itemType == "function_call" || itemType == "custom_tool_call")) || (eventType == "response.output_item.done" && (itemType == "function_call" || itemType == "custom_tool_call")) {
 		t.sawToolCall = true
+		if err := t.flushNativeHeldEvents(false); err != nil {
+			return err
+		}
 	}
 	rewritten := t.rewriteNativeResponsesEvent(event)
+	if t.shouldHoldNativeEvent(eventType, itemType) {
+		held := append([]byte(nil), rewritten...)
+		if len(delimiter) > 0 {
+			held = append(held, delimiter...)
+		}
+		t.nativeHeldEvents = append(t.nativeHeldEvents, held)
+		return nil
+	}
 	if eventType == "response.completed" || eventType == "response.incomplete" {
-		if err := t.emitNativeFooterDelta(); err != nil {
+		if err := t.flushNativeHeldEvents(true); err != nil {
 			return err
 		}
 	}
@@ -1159,59 +1199,35 @@ func (t *ResponsesWriter) writeNativeResponsesEvent(event, delimiter []byte) err
 	return nil
 }
 
-func (t *ResponsesWriter) emitNativeFooterDelta() error {
-	if t.footerText == "" || t.sawToolCall || t.footerEmitted {
-		return nil
+func (t *ResponsesWriter) shouldHoldNativeEvent(eventType, itemType string) bool {
+	if t.footerText == "" || t.sawToolCall {
+		return false
 	}
-	payload := map[string]any{
-		"type":  "response.output_text.delta",
-		"delta": t.footerText,
+	switch eventType {
+	case "response.output_text.done", "response.content_part.done":
+		return true
+	case "response.output_item.done":
+		return itemType == "message" || itemType == ""
 	}
-	if t.nativeBadgeItemID != "" {
-		payload["item_id"] = t.nativeBadgeItemID
-	}
-	if t.nativeBadgeHasOutputIndex {
-		payload["output_index"] = t.nativeBadgeOutputIndex
-	}
-	if t.nativeBadgeHasContentIndex {
-		payload["content_index"] = t.nativeBadgeContentIndex
-	}
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return nil
-	}
-	t.footerEmitted = true
-	if _, err := t.bw.WriteString("event: response.output_text.delta\ndata: "); err != nil {
-		return err
-	}
-	if _, err := t.bw.Write(body); err != nil {
-		return err
-	}
-	_, err = t.bw.WriteString("\n\n")
-	return err
+	return false
 }
 
-func (t *ResponsesWriter) flushNativeHeldDelta(appendFooter bool) error {
-	if len(t.nativeHeldDelta) == 0 {
+func (t *ResponsesWriter) flushNativeHeldEvents(commitFooter bool) error {
+	if len(t.nativeHeldEvents) == 0 {
 		return nil
 	}
-	held := t.nativeHeldDelta
-	t.nativeHeldDelta = nil
-	_, data := sse.ParseEvent(held)
-	if appendFooter && t.footerText != "" && !t.sawToolCall && gjson.ValidBytes(data) {
-		if suffixed, ok := t.suffixNativeFooter(data, "delta"); ok {
-			offset := bytes.Index(held, data)
-			if offset >= 0 {
-				rewritten := make([]byte, 0, len(held))
-				rewritten = append(rewritten, held[:offset]...)
-				rewritten = append(rewritten, suffixed...)
-				rewritten = append(rewritten, held[offset+len(data):]...)
-				held = rewritten
-			}
+	if commitFooter {
+		t.nativeFooterCommit = true
+	}
+	held := t.nativeHeldEvents
+	t.nativeHeldEvents = nil
+	for _, event := range held {
+		rewritten := t.rewriteNativeResponsesEvent(event)
+		if _, err := t.bw.Write(rewritten); err != nil {
+			return err
 		}
 	}
-	_, err := t.bw.Write(held)
-	return err
+	return nil
 }
 
 func (t *ResponsesWriter) processPassthroughSSEBuffer() error {
@@ -1237,7 +1253,7 @@ func (t *ResponsesWriter) processFinalPassthroughSSETail() error {
 			return err
 		}
 	}
-	return t.flushNativeHeldDelta(false)
+	return t.flushNativeHeldEvents(t.footerText != "" && !t.sawToolCall)
 }
 
 // FinalizeError emits a response.failed terminal event when upstream fails

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -1192,7 +1192,7 @@ func (t *ResponsesWriter) flushNativeHeldDelta() error {
 		if suffixed, ok := t.suffixNativeFooter(data, "delta"); ok {
 			offset := bytes.Index(held, data)
 			if offset >= 0 {
-				rewritten := make([]byte, 0, len(held)+len(t.footerText))
+				rewritten := make([]byte, 0, len(held))
 				rewritten = append(rewritten, held[:offset]...)
 				rewritten = append(rewritten, suffixed...)
 				rewritten = append(rewritten, held[offset+len(data):]...)

--- a/internal/translate/responses_codex.go
+++ b/internal/translate/responses_codex.go
@@ -355,6 +355,7 @@ func (c *portableCodexResponsesConverter) convertMessageContent(content gjson.Re
 		text := content.Str
 		if role == "assistant" {
 			text = codexResponsesBadgePattern.ReplaceAllString(text, "")
+			text = feedbackFooterPattern.ReplaceAllString(text, "")
 		}
 		return text, true
 	}
@@ -373,6 +374,9 @@ func (c *portableCodexResponsesConverter) convertMessageContent(content gjson.Re
 			if role == "assistant" && firstAssistantText {
 				text = codexResponsesBadgePattern.ReplaceAllString(text, "")
 				firstAssistantText = false
+			}
+			if role == "assistant" {
+				text = feedbackFooterPattern.ReplaceAllString(text, "")
 			}
 			parts = append(parts, map[string]any{"type": "text", "text": text})
 		case "refusal":

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -917,3 +917,96 @@ func eventTypes(events []map[string]any) []string {
 	}
 	return out
 }
+
+func TestResponsesWriter_PassthroughAppendsFeedbackFooter(t *testing.T) {
+	const footer = "\n\n_Weave Router feedback:_ `$rf +` good experience · `$rf -` poor experience"
+	payloads := []string{
+		`{"type":"response.output_text.delta","item_id":"msg_native","output_index":0,"content_index":0,"delta":"ok"}`,
+		`{"type":"response.output_text.done","item_id":"msg_native","output_index":0,"content_index":0,"text":"ok"}`,
+		`{"type":"response.completed","response":{"id":"resp_native","status":"completed","output":[{"id":"msg_native","type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}]}}`,
+	}
+	var native strings.Builder
+	for _, payload := range payloads {
+		native.WriteString("event: " + gjson.Get(payload, "type").Str + "\n")
+		native.WriteString("data: " + payload + "\n\n")
+	}
+
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5.6-sol")
+	w.SetFooterText(footer)
+	w.SetPassthroughBadge()
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(200)
+	_, err := w.Write([]byte(native.String()))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	events := parseSSEEvents(t, rec.Body.Bytes())
+	require.Len(t, events, 3)
+	assert.Equal(t, "ok"+footer, events[0]["delta"])
+	assert.Equal(t, "ok"+footer, events[1]["text"])
+	output := events[2]["response"].(map[string]any)["output"].([]any)
+	assert.Equal(t, "ok"+footer, output[0].(map[string]any)["content"].([]any)[0].(map[string]any)["text"])
+}
+
+func TestResponsesWriter_PassthroughFooterSkippedOnToolCall(t *testing.T) {
+	const footer = "\n\n_Weave Router feedback:_ `$rf +` good"
+	payloads := []string{
+		`{"type":"response.output_text.delta","item_id":"msg_native","output_index":0,"content_index":0,"delta":"ok"}`,
+		`{"type":"response.output_item.added","output_index":1,"item":{"id":"fc_native","type":"function_call","name":"lookup"}}`,
+		`{"type":"response.output_text.done","item_id":"msg_native","output_index":0,"content_index":0,"text":"ok"}`,
+	}
+	var native strings.Builder
+	for _, payload := range payloads {
+		native.WriteString("event: " + gjson.Get(payload, "type").Str + "\n")
+		native.WriteString("data: " + payload + "\n\n")
+	}
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5.6-sol")
+	w.SetFooterText(footer)
+	w.SetPassthroughBadge()
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(200)
+	_, err := w.Write([]byte(native.String()))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+	events := parseSSEEvents(t, rec.Body.Bytes())
+	require.Len(t, events, 3)
+	assert.Equal(t, "ok", events[0]["delta"])
+	assert.Equal(t, "ok", events[2]["text"])
+}
+
+func TestResponsesWriter_TranslatedStreamAppendsFeedbackFooter(t *testing.T) {
+	const footer = "\n\n_Weave Router feedback:_ `$rf +` good"
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5.5")
+	w.SetFooterText(footer)
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(200)
+	for _, c := range []string{
+		`data: {"choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n",
+		"data: [DONE]\n\n",
+	} {
+		_, err := w.Write([]byte(c))
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Finalize())
+	events := parseSSEEvents(t, rec.Body.Bytes())
+	var deltas []string
+	for _, e := range events {
+		if e["type"] == "response.output_text.delta" {
+			deltas = append(deltas, e["delta"].(string))
+		}
+	}
+	require.GreaterOrEqual(t, len(deltas), 2)
+	assert.Equal(t, "Hello", deltas[0])
+	assert.Equal(t, footer, deltas[len(deltas)-1])
+}
+
+func TestStripFeedbackFooterFromResponsesInput(t *testing.T) {
+	body := []byte("{\"input\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"answer\\n\\n_Weave Router feedback:_ `$rf +` good experience · `$rf -` poor experience\"}]}]}")
+	out, err := translate.StripFeedbackFooterFromResponsesInput(body)
+	require.NoError(t, err)
+	assert.Equal(t, "answer", gjson.GetBytes(out, "input.0.content.0.text").Str)
+}

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -942,10 +942,11 @@ func TestResponsesWriter_PassthroughAppendsFeedbackFooter(t *testing.T) {
 	require.NoError(t, w.Finalize())
 
 	events := parseSSEEvents(t, rec.Body.Bytes())
-	require.Len(t, events, 3)
-	assert.Equal(t, "ok"+footer, events[0]["delta"])
-	assert.Equal(t, "ok"+footer, events[1]["text"])
-	output := events[2]["response"].(map[string]any)["output"].([]any)
+	require.Len(t, events, 4)
+	assert.Equal(t, "ok", events[0]["delta"])
+	assert.Equal(t, "ok", events[1]["text"])
+	assert.Equal(t, footer, events[2]["delta"])
+	output := events[3]["response"].(map[string]any)["output"].([]any)
 	assert.Equal(t, "ok"+footer, output[0].(map[string]any)["content"].([]any)[0].(map[string]any)["text"])
 }
 

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -942,11 +942,10 @@ func TestResponsesWriter_PassthroughAppendsFeedbackFooter(t *testing.T) {
 	require.NoError(t, w.Finalize())
 
 	events := parseSSEEvents(t, rec.Body.Bytes())
-	require.Len(t, events, 4)
+	require.Len(t, events, 3)
 	assert.Equal(t, "ok", events[0]["delta"])
-	assert.Equal(t, "ok", events[1]["text"])
-	assert.Equal(t, footer, events[2]["delta"])
-	output := events[3]["response"].(map[string]any)["output"].([]any)
+	assert.Equal(t, "ok"+footer, events[1]["text"])
+	output := events[2]["response"].(map[string]any)["output"].([]any)
 	assert.Equal(t, "ok"+footer, output[0].(map[string]any)["content"].([]any)[0].(map[string]any)["text"])
 }
 

--- a/internal/translate/router_feedback.go
+++ b/internal/translate/router_feedback.go
@@ -223,14 +223,18 @@ func isRouterFeedbackAckText(text string) bool {
 
 // matchRouterFeedbackCommand recognizes the command token at the start of the
 // first line. It returns the rating encoded directly in the token (for the
-// /rf+ and /rf- shortcuts), the inline text following the token, and whether a
-// command matched at all.
+// /rf+ and /rf- shortcuts, plus the Codex $rf forms), the inline text
+// following the token, and whether a command matched at all.
 func matchRouterFeedbackCommand(first string) (rating, inline string, ok bool) {
 	for _, c := range []struct{ tok, rating string }{
 		{"/rf+", RouterFeedbackRatingUp},
+		{"$rf+", RouterFeedbackRatingUp},
 		{"/rf👍", RouterFeedbackRatingUp},
+		{"$rf👍", RouterFeedbackRatingUp},
 		{"/rf-", RouterFeedbackRatingDown},
+		{"$rf-", RouterFeedbackRatingDown},
 		{"/rf👎", RouterFeedbackRatingDown},
+		{"$rf👎", RouterFeedbackRatingDown},
 	} {
 		if first == c.tok {
 			return c.rating, "", true
@@ -239,10 +243,10 @@ func matchRouterFeedbackCommand(first string) (rating, inline string, ok bool) {
 			return c.rating, after, true
 		}
 	}
-	if first == "/router-feedback" || first == "/rf" {
+	if first == "/router-feedback" || first == "/rf" || first == "$router-feedback" || first == "$rf" {
 		return "", "", true
 	}
-	if after, found := cutAnyPrefix(first, "/router-feedback ", "/rf "); found {
+	if after, found := cutAnyPrefix(first, "/router-feedback ", "/rf ", "$router-feedback ", "$rf "); found {
 		return "", after, true
 	}
 	return "", "", false

--- a/internal/translate/router_feedback_test.go
+++ b/internal/translate/router_feedback_test.go
@@ -123,6 +123,30 @@ func TestParseRouterFeedbackCommand(t *testing.T) {
 			wantFound: false,
 		},
 		{
+			name:       "codex dollar rf plus shortcut",
+			input:      "$rf+",
+			wantRating: "up",
+			wantFound:  true,
+		},
+		{
+			name:         "codex dollar rf space minus with note",
+			input:        "$rf - too slow",
+			wantRating:   "down",
+			wantFeedback: "too slow",
+			wantFound:    true,
+		},
+		{
+			name:         "codex dollar rf alias with feedback text",
+			input:        "$rf kept thrashing between models",
+			wantFeedback: "kept thrashing between models",
+			wantFound:    true,
+		},
+		{
+			name:      "dollar rfoo without space boundary is ignored",
+			input:     "$rfoo bar",
+			wantFound: false,
+		},
+		{
 			// Security guard shared with /force-model: pasted content containing
 			// the command mid-message must not be intercepted.
 			name:      "command after leading text is ignored",


### PR DESCRIPTION
## Summary

Codex already routes through Weave, but the TUI still looks like stock Codex: no routed-model line on sticky turns, and no `/rf` footer (the Chat Completions footer wrapper is skipped on `ResponsesWriter` so it does not corrupt the stream).

- Always emit the Weave routing badge for `client_app=codex` even when the served model did not change. Claude Code keeps same-model suppression.
- Append the rating hint on naturally finished, tool-free `/v1/responses` turns (translated and native passthrough). Codex copy uses `$rf` because `/rf` is a Codex built-in.
- Strip badge + footer from the next native/portable ingress so they never reach the upstream model.

## Test plan

- [x] `go test ./internal/translate/ ./internal/proxy/`
- [ ] After merge + pin: new `codex` session against prod should show `✦ **Weave Router** → …` at the start of answers and `$rf` at the end; `$rf +` should record feedback.

🤖 Generated with [Weave Router](https://router.workweave.ai)