### PR TITLE
fix(translate): collapse Gemini nullable anyOf dates and empty enums

### DIFF
--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1349,6 +1349,10 @@ func sanitizeGeminiSchemaNode(v any, path string) (any, error) {
 		return nil, fmt.Errorf("%w at %s.oneOf: Gemini does not support oneOf", ErrGeminiSchemaIncompatible, path)
 	}
 
+	// anyOf null branches are represented by Gemini's nullable flag. Keep this
+	// outside the loop because map iteration order is undefined and a raw
+	// nullable sibling must not overwrite the normalized value.
+	nullableFromAnyOf := false
 	out := make(map[string]any, len(node))
 	for key, child := range node {
 		if key == "$defs" || key == "definitions" || key == "$ref" {
@@ -1398,13 +1402,43 @@ func sanitizeGeminiSchemaNode(v any, path string) (any, error) {
 			if !ok || len(branches) == 0 {
 				return nil, fmt.Errorf("%w at %s.anyOf: expected non-empty array", ErrGeminiSchemaIncompatible, path)
 			}
-			clean := make([]any, len(branches))
+			clean := make([]any, 0, len(branches))
 			for i, branch := range branches {
-				var err error
-				clean[i], err = sanitizeGeminiSchemaNode(branch, fmt.Sprintf("%s.anyOf[%d]", path, i))
+				if isGeminiNullSchema(branch) {
+					nullableFromAnyOf = true
+					continue
+				}
+				sanitized, err := sanitizeGeminiSchemaNode(branch, fmt.Sprintf("%s.anyOf[%d]", path, i))
 				if err != nil {
 					return nil, err
 				}
+				if object, ok := sanitized.(map[string]any); ok && isGeminiVacuousSchema(object) {
+					nullableFromAnyOf = true
+					continue
+				}
+				clean = append(clean, sanitized)
+			}
+			if len(clean) == 0 {
+				return nil, fmt.Errorf("%w at %s.anyOf: expected a non-null branch", ErrGeminiSchemaIncompatible, path)
+			}
+			if len(clean) == 1 {
+				object, ok := clean[0].(map[string]any)
+				if !ok {
+					return nil, fmt.Errorf("%w at %s.anyOf: branch is not an object schema", ErrGeminiSchemaIncompatible, path)
+				}
+				for nestedKey, nestedValue := range object {
+					if nestedKey == "nullable" {
+						continue
+					}
+					if _, exists := out[nestedKey]; exists {
+						continue
+					}
+					out[nestedKey] = nestedValue
+				}
+				if object["nullable"] == true {
+					nullableFromAnyOf = true
+				}
+				continue
 			}
 			out[key] = clean
 		case "format":
@@ -1438,6 +1472,9 @@ func sanitizeGeminiSchemaNode(v any, path string) (any, error) {
 	}
 	if err := normalizeGeminiNullableType(out, path); err != nil {
 		return nil, err
+	}
+	if nullableFromAnyOf {
+		out["nullable"] = true
 	}
 	if err := validateGeminiRequired(out, path); err != nil {
 		return nil, err
@@ -1940,10 +1977,20 @@ func resolveGeminiEnum(schema map[string]any) {
 	if !exists {
 		return
 	}
-	if enum, ok := values.([]any); ok && len(enum) > 0 && allStringEnum(enum) {
-		return
+	enum, ok := values.([]any)
+	if ok && len(enum) > 0 && allStringEnum(enum) {
+		filtered := filterEmptyStringEnum(enum)
+		if len(filtered) == 0 {
+			delete(schema, "enum")
+		} else {
+			schema["enum"] = filtered
+		}
+		if _, exists := schema["enum"]; exists {
+			return
+		}
+	} else {
+		delete(schema, "enum")
 	}
-	delete(schema, "enum")
 	// format:"enum" without an enum is itself unrepresentable.
 	if format, _ := schema["format"].(string); format == "enum" {
 		delete(schema, "format")
@@ -1953,6 +2000,58 @@ func resolveGeminiEnum(schema map[string]any) {
 func allStringEnum(enum []any) bool {
 	for _, value := range enum {
 		if _, ok := value.(string); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func filterEmptyStringEnum(enum []any) []any {
+	out := make([]any, 0, len(enum))
+	for _, value := range enum {
+		s, ok := value.(string)
+		if !ok || s == "" {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func isGeminiNullSchema(v any) bool {
+	node, ok := v.(map[string]any)
+	if !ok {
+		return false
+	}
+	if typeName, ok := node["type"].(string); ok {
+		return typeName == "null"
+	}
+	types, ok := node["type"].([]any)
+	if !ok || len(types) == 0 {
+		return false
+	}
+	for _, candidate := range types {
+		name, ok := candidate.(string)
+		if !ok || name != "null" {
+			return false
+		}
+	}
+	return true
+}
+
+func isGeminiVacuousSchema(v any) bool {
+	if isGeminiNullSchema(v) {
+		return true
+	}
+	node, ok := v.(map[string]any)
+	if !ok {
+		return false
+	}
+	for key := range node {
+		switch key {
+		case "description", "title", "nullable", "default", "example":
+			continue
+		default:
 			return false
 		}
 	}

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1349,9 +1349,7 @@ func sanitizeGeminiSchemaNode(v any, path string) (any, error) {
 		return nil, fmt.Errorf("%w at %s.oneOf: Gemini does not support oneOf", ErrGeminiSchemaIncompatible, path)
 	}
 
-	// anyOf null branches are represented by Gemini's nullable flag. Keep this
-	// outside the loop because map iteration order is undefined and a raw
-	// nullable sibling must not overwrite the normalized value.
+	// Declared before the loop: map iteration is unordered, so a raw nullable sibling must not overwrite this once set.
 	nullableFromAnyOf := false
 	out := make(map[string]any, len(node))
 	for key, child := range node {
@@ -1404,7 +1402,7 @@ func sanitizeGeminiSchemaNode(v any, path string) (any, error) {
 			}
 			clean := make([]any, 0, len(branches))
 			for i, branch := range branches {
-				if isGeminiNullSchema(branch) {
+				if isGeminiNullLikeSchema(branch) {
 					nullableFromAnyOf = true
 					continue
 				}
@@ -1412,7 +1410,7 @@ func sanitizeGeminiSchemaNode(v any, path string) (any, error) {
 				if err != nil {
 					return nil, err
 				}
-				if object, ok := sanitized.(map[string]any); ok && isGeminiVacuousSchema(object) {
+				if isGeminiNullLikeSchema(sanitized) {
 					nullableFromAnyOf = true
 					continue
 				}
@@ -1420,25 +1418,6 @@ func sanitizeGeminiSchemaNode(v any, path string) (any, error) {
 			}
 			if len(clean) == 0 {
 				return nil, fmt.Errorf("%w at %s.anyOf: expected a non-null branch", ErrGeminiSchemaIncompatible, path)
-			}
-			if len(clean) == 1 {
-				object, ok := clean[0].(map[string]any)
-				if !ok {
-					return nil, fmt.Errorf("%w at %s.anyOf: branch is not an object schema", ErrGeminiSchemaIncompatible, path)
-				}
-				for nestedKey, nestedValue := range object {
-					if nestedKey == "nullable" {
-						continue
-					}
-					if _, exists := out[nestedKey]; exists {
-						continue
-					}
-					out[nestedKey] = nestedValue
-				}
-				if object["nullable"] == true {
-					nullableFromAnyOf = true
-				}
-				continue
 			}
 			out[key] = clean
 		case "format":
@@ -1473,8 +1452,18 @@ func sanitizeGeminiSchemaNode(v any, path string) (any, error) {
 	if err := normalizeGeminiNullableType(out, path); err != nil {
 		return nil, err
 	}
+	flattened, err := flattenGeminiAnyOf(out, path)
+	if err != nil {
+		return nil, err
+	}
+	out = flattened
 	if nullableFromAnyOf {
 		out["nullable"] = true
+	}
+	if _, hasType := out["type"]; !hasType {
+		if _, hasEnum := out["enum"]; hasEnum {
+			out["type"] = "string"
+		}
 	}
 	if err := validateGeminiRequired(out, path); err != nil {
 		return nil, err
@@ -2039,7 +2028,7 @@ func isGeminiNullSchema(v any) bool {
 	return true
 }
 
-func isGeminiVacuousSchema(v any) bool {
+func isGeminiNullLikeSchema(v any) bool {
 	if isGeminiNullSchema(v) {
 		return true
 	}
@@ -2047,15 +2036,39 @@ func isGeminiVacuousSchema(v any) bool {
 	if !ok {
 		return false
 	}
+	enum, hasEnum := node["enum"].([]any)
+	if !hasEnum || len(filterEmptyStringEnum(enum)) > 0 {
+		return false
+	}
+	if typeName, ok := node["type"].(string); ok && typeName != "" && typeName != "null" {
+		return false
+	}
 	for key := range node {
 		switch key {
-		case "description", "title", "nullable", "default", "example":
+		case "enum", "type", "description", "title", "nullable", "default", "example", "format":
 			continue
 		default:
 			return false
 		}
 	}
 	return true
+}
+
+func flattenGeminiAnyOf(schema map[string]any, path string) (map[string]any, error) {
+	branches, ok := schema["anyOf"].([]any)
+	if !ok || len(branches) != 1 {
+		return schema, nil
+	}
+	object, ok := branches[0].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%w at %s.anyOf: branch is not an object schema", ErrGeminiSchemaIncompatible, path)
+	}
+	delete(schema, "anyOf")
+	merged, ok := intersectGeminiSchemas(schema, object)
+	if !ok {
+		return nil, fmt.Errorf("%w at %s.anyOf: flattened branch conflicts with sibling constraints", ErrGeminiSchemaIncompatible, path)
+	}
+	return merged, nil
 }
 
 func valueInEnum(value, enum any) bool {

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -2045,10 +2045,23 @@ func isGeminiNullLikeSchema(v any) bool {
 			return false
 		}
 	}
-	if typeName, ok := node["type"].(string); ok && typeName != "" && typeName != "null" {
-		return false
-	}
-	if !hasEnum && node["type"] == nil {
+	switch typeValue := node["type"].(type) {
+	case string:
+		if typeValue != "" && typeValue != "null" {
+			return false
+		}
+	case []any:
+		if _, ok := lowerNullableTypeArray(typeValue); ok {
+			return false
+		}
+		if !isGeminiNullSchema(node) {
+			return false
+		}
+	case nil:
+		if !hasEnum {
+			return false
+		}
+	default:
 		return false
 	}
 	for key := range node {

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1452,23 +1452,26 @@ func sanitizeGeminiSchemaNode(v any, path string) (any, error) {
 	if err := normalizeGeminiNullableType(out, path); err != nil {
 		return nil, err
 	}
+	if nullable, ok := out["nullable"].(bool); ok && nullable {
+		nullableFromAnyOf = true
+	}
 	flattened, err := flattenGeminiAnyOf(out, path)
 	if err != nil {
 		return nil, err
 	}
 	out = flattened
-	if nullableFromAnyOf {
-		out["nullable"] = true
+	if err := validateGeminiRequired(out, path); err != nil {
+		return nil, err
 	}
+	resolveGeminiEnum(out)
 	if _, hasType := out["type"]; !hasType {
 		if _, hasEnum := out["enum"]; hasEnum {
 			out["type"] = "string"
 		}
 	}
-	if err := validateGeminiRequired(out, path); err != nil {
-		return nil, err
+	if nullableFromAnyOf {
+		out["nullable"] = true
 	}
-	resolveGeminiEnum(out)
 	return stripEmptyNullable(out), nil
 }
 
@@ -2037,10 +2040,15 @@ func isGeminiNullLikeSchema(v any) bool {
 		return false
 	}
 	enum, hasEnum := node["enum"].([]any)
-	if !hasEnum || len(filterEmptyStringEnum(enum)) > 0 {
-		return false
+	if hasEnum {
+		if !allStringEnum(enum) || len(filterEmptyStringEnum(enum)) > 0 {
+			return false
+		}
 	}
 	if typeName, ok := node["type"].(string); ok && typeName != "" && typeName != "null" {
+		return false
+	}
+	if !hasEnum && node["type"] == nil {
 		return false
 	}
 	for key := range node {

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -1164,6 +1164,32 @@ func TestPrepareGemini_PreservesNumericAnyOfEnum(t *testing.T) {
 	assert.NotContains(t, priority, "type", "dropping a numeric enum must not invent type:string")
 }
 
+func TestPrepareGemini_KeepsTypeArrayAnyOfBranch(t *testing.T) {
+	body := []byte(`{
+		"messages": [{"role":"user","content":"hi"}],
+		"tools": [{
+			"name":"update_issue",
+			"input_schema":{
+				"type":"object",
+				"properties":{
+					"due_date":{"anyOf":[{"type":["string","null"],"format":"date-time"}]}
+				}
+			}
+		}]
+	}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	params := out["tools"].([]any)[0].(map[string]any)["functionDeclarations"].([]any)[0].(map[string]any)["parameters"].(map[string]any)
+	due := params["properties"].(map[string]any)["due_date"].(map[string]any)
+	assert.Equal(t, "string", due["type"])
+	assert.Equal(t, "date-time", due["format"])
+	assert.Equal(t, true, due["nullable"])
+}
+
 func TestPrepareGemini_DropsNonStringEnums(t *testing.T) {
 	// Gemini types every enum member as TYPE_STRING and 400s on anything else.
 	// Dropping is lossless: toolcheck enforces against the original schema.

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -1098,7 +1098,8 @@ func TestPrepareGemini_CollapsesNullableAnyOfDates(t *testing.T) {
 				"properties":{
 					"due_date":{"anyOf":[{"type":"string","format":"date-time"},{"type":"null"}]},
 					"start_date":{"anyOf":[{"type":"string"},{"enum":[""]}]},
-					"end_date":{"anyOf":[{"type":"string","format":"date-time"},{}]}
+					"priority":{"anyOf":[{"enum":["low","high"]},{"type":"null"}]},
+					"title":{"minLength":5,"anyOf":[{"type":"string","minLength":10}]}
 				}
 			}
 		}]
@@ -1125,11 +1126,16 @@ func TestPrepareGemini_CollapsesNullableAnyOfDates(t *testing.T) {
 	assert.NotContains(t, start, "anyOf")
 	assert.NotContains(t, start, "enum")
 
-	end := props["end_date"].(map[string]any)
-	assert.Equal(t, "string", end["type"])
-	assert.Equal(t, "date-time", end["format"])
-	assert.Equal(t, true, end["nullable"])
-	assert.NotContains(t, end, "anyOf")
+	priority := props["priority"].(map[string]any)
+	assert.Equal(t, "string", priority["type"])
+	assert.Equal(t, true, priority["nullable"])
+	assert.Equal(t, []any{"low", "high"}, priority["enum"])
+	assert.NotContains(t, priority, "anyOf")
+
+	title := props["title"].(map[string]any)
+	assert.Equal(t, "string", title["type"])
+	assert.Equal(t, float64(10), title["minLength"])
+	assert.NotContains(t, title, "anyOf")
 }
 
 func TestPrepareGemini_DropsNonStringEnums(t *testing.T) {

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -1050,9 +1050,9 @@ func TestPrepareGemini_PreservesArrayMissingItems(t *testing.T) {
 	assert.NotContains(t, nestedItems, "items")
 }
 
-func TestPrepareGemini_PreservesEnumValueTypes(t *testing.T) {
-	// Empty-string enum members are meaningful accepted values. Sanitization
-	// must preserve them rather than silently broadening the schema.
+func TestPrepareGemini_DropsEmptyStringEnumEntries(t *testing.T) {
+	// Google 400s on empty-string enum members ("enum[i]: cannot be empty").
+	// Drop them; drop the enum entirely when nothing remains.
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [{
@@ -1077,13 +1077,59 @@ func TestPrepareGemini_PreservesEnumValueTypes(t *testing.T) {
 	props := params["properties"].(map[string]any)
 
 	operator := props["operator"].(map[string]any)
-	assert.Equal(t, []any{"", "eq", "neq", "gt"}, operator["enum"])
+	assert.Equal(t, []any{"eq", "neq", "gt"}, operator["enum"], "empty string must be filtered out")
 
 	allEmpty := props["all_empty"].(map[string]any)
-	assert.Equal(t, []any{"", ""}, allEmpty["enum"])
+	assert.NotContains(t, allEmpty, "enum", "enum with only empty strings must be dropped entirely")
 
 	normal := props["normal"].(map[string]any)
 	assert.Equal(t, []any{"a", "b"}, normal["enum"], "well-formed enums must pass through unchanged")
+}
+
+func TestPrepareGemini_CollapsesNullableAnyOfDates(t *testing.T) {
+	// MCP date fields commonly encode optionality as anyOf[string, null]. Gemini
+	// then 400s on the null branch as any_of[1].enum[0]: cannot be empty.
+	body := []byte(`{
+		"messages": [{"role":"user","content":"hi"}],
+		"tools": [{
+			"name":"update_issue",
+			"input_schema":{
+				"type":"object",
+				"properties":{
+					"due_date":{"anyOf":[{"type":"string","format":"date-time"},{"type":"null"}]},
+					"start_date":{"anyOf":[{"type":"string"},{"enum":[""]}]},
+					"end_date":{"anyOf":[{"type":"string","format":"date-time"},{}]}
+				}
+			}
+		}]
+	}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	params := out["tools"].([]any)[0].(map[string]any)["functionDeclarations"].([]any)[0].(map[string]any)["parameters"].(map[string]any)
+	props := params["properties"].(map[string]any)
+
+	due := props["due_date"].(map[string]any)
+	assert.Equal(t, "string", due["type"])
+	assert.Equal(t, "date-time", due["format"])
+	assert.Equal(t, true, due["nullable"])
+	assert.NotContains(t, due, "anyOf")
+	assert.NotContains(t, due, "enum")
+
+	start := props["start_date"].(map[string]any)
+	assert.Equal(t, "string", start["type"])
+	assert.Equal(t, true, start["nullable"])
+	assert.NotContains(t, start, "anyOf")
+	assert.NotContains(t, start, "enum")
+
+	end := props["end_date"].(map[string]any)
+	assert.Equal(t, "string", end["type"])
+	assert.Equal(t, "date-time", end["format"])
+	assert.Equal(t, true, end["nullable"])
+	assert.NotContains(t, end, "anyOf")
 }
 
 func TestPrepareGemini_DropsNonStringEnums(t *testing.T) {

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -1138,6 +1138,32 @@ func TestPrepareGemini_CollapsesNullableAnyOfDates(t *testing.T) {
 	assert.NotContains(t, title, "anyOf")
 }
 
+func TestPrepareGemini_PreservesNumericAnyOfEnum(t *testing.T) {
+	body := []byte(`{
+		"messages": [{"role":"user","content":"hi"}],
+		"tools": [{
+			"name":"set_priority",
+			"input_schema":{
+				"type":"object",
+				"properties":{
+					"priority":{"anyOf":[{"enum":[0,1,2]},{"type":"null"}]}
+				}
+			}
+		}]
+	}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	params := out["tools"].([]any)[0].(map[string]any)["functionDeclarations"].([]any)[0].(map[string]any)["parameters"].(map[string]any)
+	priority := params["properties"].(map[string]any)["priority"].(map[string]any)
+	assert.Equal(t, true, priority["nullable"])
+	assert.NotContains(t, priority, "enum", "non-string enums still drop, but the branch itself must survive")
+	assert.NotContains(t, priority, "type", "dropping a numeric enum must not invent type:string")
+}
+
 func TestPrepareGemini_DropsNonStringEnums(t *testing.T) {
 	// Gemini types every enum member as TYPE_STRING and 400s on anything else.
 	// Dropping is lossless: toolcheck enforces against the original schema.


### PR DESCRIPTION
## Summary
- Google 400s Gemini function declarations whose MCP date fields encode optionality as `anyOf[string, null]` (`due_date` / `start_date` / `end_date`), surfacing as `any_of[N].enum[0]: cannot be empty`.
- Collapse those null/empty `anyOf` branches onto `nullable: true`, drop empty-string enum members, and flatten a remaining single branch.
- Add a regression covering the Conductor Gemini 3.1 tool-schema failure.

## Test plan
- [x] `go test ./internal/translate`
- [ ] After merge, retry a Gemini-routed Claude Code / Conductor session with Linear/Notion MCP tools attached.

🤖 Generated with [Weave Router](https://router.workweave.ai)