### PR TITLE
translate: strip Anthropic native server tools on non-Anthropic emit

### DIFF
--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -604,6 +604,13 @@ type RequestMutationStats struct {
 	// CCOnlyToolsStripped counts Claude-Code-only tools removed before
 	// dispatching to a non-Anthropic upstream. See claudecode_tool_filter.go.
 	CCOnlyToolsStripped int
+	// ServerToolsStripped counts Anthropic native server tools (web_search_*,
+	// web_fetch_*) removed before dispatching to a non-Anthropic upstream.
+	// Those tools are executed by Anthropic, not by the model: converted as
+	// ordinary function tools they would become phantom client tools the
+	// caller never registered, so the model can emit a tool_use block the
+	// harness cannot answer. See websearch.StripServerTools.
+	ServerToolsStripped int
 	// GeminiReminderInjected is true when the Gemini 3.x tool-use reminder was
 	// appended to systemInstruction. See translate/system_reminder.go.
 	GeminiReminderInjected bool

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -605,11 +605,9 @@ type RequestMutationStats struct {
 	// dispatching to a non-Anthropic upstream. See claudecode_tool_filter.go.
 	CCOnlyToolsStripped int
 	// ServerToolsStripped counts Anthropic native server tools (web_search_*,
-	// web_fetch_*) removed before dispatching to a non-Anthropic upstream.
-	// Those tools are executed by Anthropic, not by the model: converted as
-	// ordinary function tools they would become phantom client tools the
-	// caller never registered, so the model can emit a tool_use block the
-	// harness cannot answer. See websearch.StripServerTools.
+	// web_fetch_*) removed before emitting to a non-Anthropic upstream.
+	// Anthropic executes these itself; passed through they become phantom
+	// function tools the caller never registered. See websearch.StripServerTools.
 	ServerToolsStripped int
 	// GeminiReminderInjected is true when the Gemini 3.x tool-use reminder was
 	// appended to systemInstruction. See translate/system_reminder.go.

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -604,10 +604,8 @@ type RequestMutationStats struct {
 	// CCOnlyToolsStripped counts Claude-Code-only tools removed before
 	// dispatching to a non-Anthropic upstream. See claudecode_tool_filter.go.
 	CCOnlyToolsStripped int
-	// ServerToolsStripped counts Anthropic native server tools (web_search_*,
-	// web_fetch_*) removed before emitting to a non-Anthropic upstream.
-	// Anthropic executes these itself; passed through they become phantom
-	// function tools the caller never registered. See websearch.StripServerTools.
+	// ServerToolsStripped counts native server tools (web_search_*, web_fetch_*)
+	// removed before emitting to a non-Anthropic upstream. See websearch.StripServerTools.
 	ServerToolsStripped int
 	// GeminiReminderInjected is true when the Gemini 3.x tool-use reminder was
 	// appended to systemInstruction. See translate/system_reminder.go.

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -12,8 +12,8 @@ import (
 
 	"workweave/router/internal/observability"
 	"workweave/router/internal/providers"
-	"workweave/router/internal/websearch"
 	"workweave/router/internal/router"
+	"workweave/router/internal/websearch"
 
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -86,9 +86,7 @@ func (e *RequestEnvelope) PrepareGemini(_ http.Header, opts EmitOptions) (provid
 			return providers.PreparedRequest{}, fmt.Errorf("strip claude-code-only tools: %w", err)
 		}
 		stats.CCOnlyToolsStripped = removed
-		// See buildOpenAIFromAnthropic: native server tools cannot cross to a
-		// non-Anthropic upstream without becoming phantom client tools. Strip
-		// before the reminder gate so Stats reflects what reached upstream.
+		// See buildOpenAIFromAnthropic: strip native server tools before the reminder gate so Stats reflects what actually reached upstream.
 		filtered, stats.ServerToolsStripped = websearch.StripServerTools(filtered)
 		// Mirror writeGeminiFromAnthropic's reminder gate so Stats reflects
 		// whether the reminder actually reached upstream.

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -12,6 +12,7 @@ import (
 
 	"workweave/router/internal/observability"
 	"workweave/router/internal/providers"
+	"workweave/router/internal/websearch"
 	"workweave/router/internal/router"
 
 	"github.com/tidwall/gjson"
@@ -85,6 +86,10 @@ func (e *RequestEnvelope) PrepareGemini(_ http.Header, opts EmitOptions) (provid
 			return providers.PreparedRequest{}, fmt.Errorf("strip claude-code-only tools: %w", err)
 		}
 		stats.CCOnlyToolsStripped = removed
+		// See buildOpenAIFromAnthropic: native server tools cannot cross to a
+		// non-Anthropic upstream without becoming phantom client tools. Strip
+		// before the reminder gate so Stats reflects what reached upstream.
+		filtered, stats.ServerToolsStripped = websearch.StripServerTools(filtered)
 		// Mirror writeGeminiFromAnthropic's reminder gate so Stats reflects
 		// whether the reminder actually reached upstream.
 		if reminder := geminiSystemReminder(opts.TargetModel); reminder != "" && hasNonEmptyTools(filtered) {

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 
 	"workweave/router/internal/providers"
-	"workweave/router/internal/websearch"
 	"workweave/router/internal/router"
+	"workweave/router/internal/websearch"
 
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -284,10 +284,8 @@ func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, pr
 		return nil, stats, fmt.Errorf("strip claude-code-only tools: %w", err)
 	}
 	stats.CCOnlyToolsStripped = removed
-	// Anthropic executes web_search_*/web_fetch_* itself. A non-Anthropic
-	// upstream cannot, and writeOpenAIToolsFromAnthropic would otherwise
-	// convert them into parameterless function tools the caller never
-	// registered. Drop them instead.
+	// Anthropic executes web_search_*/web_fetch_* itself; passing them through
+	// writeOpenAIToolsFromAnthropic creates phantom function tools. Drop them.
 	body, stats.ServerToolsStripped = websearch.StripServerTools(body)
 	jw := newJSONWriter()
 	jw.Obj()

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"workweave/router/internal/providers"
+	"workweave/router/internal/websearch"
 	"workweave/router/internal/router"
 
 	"github.com/tidwall/gjson"
@@ -283,6 +284,11 @@ func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, pr
 		return nil, stats, fmt.Errorf("strip claude-code-only tools: %w", err)
 	}
 	stats.CCOnlyToolsStripped = removed
+	// Anthropic executes web_search_*/web_fetch_* itself. A non-Anthropic
+	// upstream cannot, and writeOpenAIToolsFromAnthropic would otherwise
+	// convert them into parameterless function tools the caller never
+	// registered. Drop them instead.
+	body, stats.ServerToolsStripped = websearch.StripServerTools(body)
 	jw := newJSONWriter()
 	jw.Obj()
 	jw.Key("model")

--- a/internal/translate/emit_openai_responses.go
+++ b/internal/translate/emit_openai_responses.go
@@ -7,8 +7,8 @@ import (
 
 	"workweave/router/internal/observability"
 	"workweave/router/internal/providers"
-	"workweave/router/internal/websearch"
 	"workweave/router/internal/router"
+	"workweave/router/internal/websearch"
 
 	"github.com/tidwall/gjson"
 )

--- a/internal/translate/emit_openai_responses.go
+++ b/internal/translate/emit_openai_responses.go
@@ -7,6 +7,7 @@ import (
 
 	"workweave/router/internal/observability"
 	"workweave/router/internal/providers"
+	"workweave/router/internal/websearch"
 	"workweave/router/internal/router"
 
 	"github.com/tidwall/gjson"
@@ -202,6 +203,9 @@ func (e *RequestEnvelope) buildResponsesFromAnthropic(opts EmitOptions) ([]byte,
 		return nil, stats, fmt.Errorf("strip claude-code-only tools: %w", err)
 	}
 	stats.CCOnlyToolsStripped = removed
+	// See buildOpenAIFromAnthropic: native server tools cannot cross to a
+	// non-Anthropic upstream without becoming phantom client tools.
+	body, stats.ServerToolsStripped = websearch.StripServerTools(body)
 
 	jw := newJSONWriter()
 	jw.Obj()

--- a/internal/translate/server_tool_strip_test.go
+++ b/internal/translate/server_tool_strip_test.go
@@ -11,9 +11,9 @@ import (
 	"workweave/router/internal/translate"
 )
 
-// Anthropic executes web_search_*/web_fetch_* server-side. Emitted to a
+// Anthropic executes web_search_*/web_fetch_* server-side; emitted to a
 // non-Anthropic upstream they become phantom function tools (same failure
-// claudecode_tool_filter.go prevents). These tests pin the strip.
+// claudecode_tool_filter.go prevents).
 const anthropicServerToolBody = `{
 	"model":"claude-opus-5",
 	"messages":[{"role":"user","content":"what changed upstream?"}],

--- a/internal/translate/server_tool_strip_test.go
+++ b/internal/translate/server_tool_strip_test.go
@@ -11,9 +11,8 @@ import (
 	"workweave/router/internal/translate"
 )
 
-// Anthropic executes web_search_*/web_fetch_* server-side; emitted to a
-// non-Anthropic upstream they become phantom function tools (same failure
-// claudecode_tool_filter.go prevents).
+// Anthropic executes web_search_*/web_fetch_* server-side; emitted to a non-Anthropic
+// upstream they become phantom function tools (same failure claudecode_tool_filter.go prevents).
 const anthropicServerToolBody = `{
 	"model":"claude-opus-5",
 	"messages":[{"role":"user","content":"what changed upstream?"}],

--- a/internal/translate/server_tool_strip_test.go
+++ b/internal/translate/server_tool_strip_test.go
@@ -1,0 +1,97 @@
+package translate_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/translate"
+)
+
+// Anthropic executes web_search_*/web_fetch_* server-side; the model only sees
+// the result blocks. Emitted to a non-Anthropic upstream those declarations
+// were converted like any other tool — into a `function` entry with a name and
+// no parameters — so the model could "call" a tool the client never
+// registered and the harness has no way to answer. That is the same phantom
+// tool_use failure claudecode_tool_filter.go exists to prevent, and it is why
+// the HMM policy has had to force every web_search-advertising turn onto an
+// Anthropic arm. These tests pin the strip that removes the need for that.
+const anthropicServerToolBody = `{
+	"model":"claude-opus-5",
+	"messages":[{"role":"user","content":"what changed upstream?"}],
+	"tools":[
+		{"type":"web_search_20250305","name":"web_search","max_uses":5},
+		{"type":"web_fetch_20250910","name":"web_fetch"},
+		{"name":"Read","description":"","input_schema":{"type":"object"}}
+	],
+	"max_tokens":256
+}`
+
+// Only the native server tools are declared, so the whole tools array goes.
+const anthropicServerToolOnlyBody = `{
+	"model":"claude-opus-5",
+	"messages":[{"role":"user","content":"Perform a web search for the query: weave router"}],
+	"tools":[{"type":"web_search_20250305","name":"web_search"}],
+	"tool_choice":{"type":"tool","name":"web_search"},
+	"max_tokens":256
+}`
+
+func TestServerTools_AnthropicSourceOpenAITarget_Stripped(t *testing.T) {
+	env, err := translate.ParseAnthropic([]byte(anthropicServerToolBody))
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "openai/gpt-5.6-luna"})
+	require.NoError(t, err)
+
+	names := emittedToolNames(t, out.Body)
+	assert.ElementsMatch(t, []string{"Read"}, names,
+		"client tools survive; Anthropic native server tools are dropped on Anthropic→OpenAI")
+	assert.Equal(t, 2, out.Stats.ServerToolsStripped)
+}
+
+func TestServerTools_AnthropicSourceGeminiTarget_Stripped(t *testing.T) {
+	env, err := translate.ParseAnthropic([]byte(anthropicServerToolBody))
+	require.NoError(t, err)
+
+	out, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{TargetModel: "gemini-3.1-pro-preview"})
+	require.NoError(t, err)
+
+	names := emittedGeminiToolNames(t, out.Body)
+	assert.ElementsMatch(t, []string{"Read"}, names)
+	assert.Equal(t, 2, out.Stats.ServerToolsStripped)
+}
+
+// The Anthropic→Anthropic passthrough must keep them: that upstream is the one
+// that can actually execute the search.
+func TestServerTools_AnthropicSourceAnthropicTarget_Kept(t *testing.T) {
+	env, err := translate.ParseAnthropic([]byte(anthropicServerToolBody))
+	require.NoError(t, err)
+
+	out, err := env.PrepareAnthropic(nil, translate.EmitOptions{TargetModel: "claude-opus-5"})
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(out.Body, &doc))
+	raw, _ := doc["tools"].([]any)
+	assert.Len(t, raw, 3, "Anthropic→Anthropic keeps the native server tools")
+	assert.Equal(t, 0, out.Stats.ServerToolsStripped)
+}
+
+// A forced tool_choice naming a stripped tool would 400 on the upstream, so
+// the strip drops the now-empty tools array and the dangling choice with it.
+func TestServerTools_OnlyServerToolsDeclared_DropsToolChoice(t *testing.T) {
+	env, err := translate.ParseAnthropic([]byte(anthropicServerToolOnlyBody))
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "openai/gpt-5.6-luna"})
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(out.Body, &doc))
+	assert.NotContains(t, doc, "tools")
+	assert.NotContains(t, doc, "tool_choice")
+	assert.Equal(t, 1, out.Stats.ServerToolsStripped)
+}

--- a/internal/translate/server_tool_strip_test.go
+++ b/internal/translate/server_tool_strip_test.go
@@ -11,14 +11,9 @@ import (
 	"workweave/router/internal/translate"
 )
 
-// Anthropic executes web_search_*/web_fetch_* server-side; the model only sees
-// the result blocks. Emitted to a non-Anthropic upstream those declarations
-// were converted like any other tool — into a `function` entry with a name and
-// no parameters — so the model could "call" a tool the client never
-// registered and the harness has no way to answer. That is the same phantom
-// tool_use failure claudecode_tool_filter.go exists to prevent, and it is why
-// the HMM policy has had to force every web_search-advertising turn onto an
-// Anthropic arm. These tests pin the strip that removes the need for that.
+// Anthropic executes web_search_*/web_fetch_* server-side. Emitted to a
+// non-Anthropic upstream they become phantom function tools (same failure
+// claudecode_tool_filter.go prevents). These tests pin the strip.
 const anthropicServerToolBody = `{
 	"model":"claude-opus-5",
 	"messages":[{"role":"user","content":"what changed upstream?"}],

--- a/internal/websearch/anthropic_request.go
+++ b/internal/websearch/anthropic_request.go
@@ -46,15 +46,34 @@ func FindServerTool(body []byte) (ServerTool, bool) {
 	return found, found.Type != ""
 }
 
-// StripServerTools removes native web-search tools from an Anthropic Messages
-// body and reports how many it removed. Used to keep a turn alive on an
-// upstream that rejects the tool outright instead of failing the whole turn.
+// nativeServerToolPrefixes are the dated Anthropic server tools the *provider*
+// executes rather than the model. Broader than serverToolPrefix on purpose:
+// FindServerTool/DetectSearchTurn are about the one tool we know how to
+// emulate, while this list is about every tool a non-Anthropic upstream cannot
+// run at all.
+var nativeServerToolPrefixes = []string{serverToolPrefix, "web_fetch_"}
+
+func isNativeServerTool(toolType string) bool {
+	for _, prefix := range nativeServerToolPrefixes {
+		if strings.HasPrefix(toolType, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// StripServerTools removes Anthropic native server tools (web_search_*,
+// web_fetch_*) from an Anthropic Messages body and reports how many it
+// removed. Used to keep a turn alive on an upstream that cannot execute them --
+// either one that rejects the declaration outright, or one that would silently
+// accept it as an ordinary function tool and then emit a tool_use block the
+// client never registered a handler for.
 func StripServerTools(body []byte) ([]byte, int) {
 	removed := 0
 	// Reverse order: deleting by index shifts every later element.
 	tools := gjson.GetBytes(body, "tools").Array()
 	for i := len(tools) - 1; i >= 0; i-- {
-		if !strings.HasPrefix(tools[i].Get("type").String(), serverToolPrefix) {
+		if !isNativeServerTool(tools[i].Get("type").String()) {
 			continue
 		}
 		out, err := sjson.DeleteBytes(body, "tools."+strconv.Itoa(i))

--- a/internal/websearch/anthropic_request.go
+++ b/internal/websearch/anthropic_request.go
@@ -48,8 +48,7 @@ func FindServerTool(body []byte) (ServerTool, bool) {
 
 // nativeServerToolPrefixes lists Anthropic server tools the provider executes,
 // not the model. Broader than serverToolPrefix: FindServerTool/DetectSearchTurn
-// cover the one tool we can emulate; this covers all tools non-Anthropic
-// upstreams cannot run.
+// cover only the tool we can emulate; this covers all non-Anthropic-runnable tools.
 var nativeServerToolPrefixes = []string{serverToolPrefix, "web_fetch_"}
 
 func isNativeServerTool(toolType string) bool {
@@ -63,8 +62,7 @@ func isNativeServerTool(toolType string) bool {
 
 // StripServerTools removes Anthropic native server tools (web_search_*,
 // web_fetch_*) from an Anthropic Messages body. Non-Anthropic upstreams cannot
-// execute them; passed through they become phantom function tools that emit
-// unhandleable tool_use blocks.
+// execute them; passed through they become phantom function tools emitting unhandleable tool_use blocks.
 func StripServerTools(body []byte) ([]byte, int) {
 	removed := 0
 	strippedNames := make(map[string]struct{})

--- a/internal/websearch/anthropic_request.go
+++ b/internal/websearch/anthropic_request.go
@@ -62,7 +62,8 @@ func isNativeServerTool(toolType string) bool {
 
 // StripServerTools removes Anthropic native server tools (web_search_*,
 // web_fetch_*) from an Anthropic Messages body. Non-Anthropic upstreams cannot
-// execute them; passed through they become phantom function tools emitting unhandleable tool_use blocks.
+// execute them; passed through they become phantom function tools emitting
+// unhandleable tool_use blocks.
 func StripServerTools(body []byte) ([]byte, int) {
 	removed := 0
 	strippedNames := make(map[string]struct{})

--- a/internal/websearch/anthropic_request.go
+++ b/internal/websearch/anthropic_request.go
@@ -62,11 +62,9 @@ func isNativeServerTool(toolType string) bool {
 }
 
 // StripServerTools removes Anthropic native server tools (web_search_*,
-// web_fetch_*) from an Anthropic Messages body and reports how many it
-// removed. Used to keep a turn alive on an upstream that cannot execute them --
-// either one that rejects the declaration outright, or one that would silently
-// accept it as an ordinary function tool and then emit a tool_use block the
-// client never registered a handler for.
+// web_fetch_*) from an Anthropic Messages body and reports how many were
+// removed. Non-Anthropic upstreams cannot execute them; passed through, they
+// become phantom function tools that emit unhandleable tool_use blocks.
 func StripServerTools(body []byte) ([]byte, int) {
 	removed := 0
 	strippedNames := make(map[string]struct{})

--- a/internal/websearch/anthropic_request.go
+++ b/internal/websearch/anthropic_request.go
@@ -59,9 +59,9 @@ func isNativeServerTool(toolType string) bool {
 	return false
 }
 
-// StripServerTools removes Anthropic native server tools (web_search_*, web_fetch_*) from an
-// Anthropic Messages body. Non-Anthropic upstreams cannot execute them; passed through they
-// become phantom function tools emitting unhandleable tool_use blocks.
+// StripServerTools removes Anthropic native server tools (web_search_*, web_fetch_*)
+// from an Anthropic Messages body; non-Anthropic upstreams cannot execute them and
+// they become phantom function tools emitting unhandleable tool_use blocks.
 func StripServerTools(body []byte) ([]byte, int) {
 	removed := 0
 	strippedNames := make(map[string]struct{})

--- a/internal/websearch/anthropic_request.go
+++ b/internal/websearch/anthropic_request.go
@@ -46,9 +46,8 @@ func FindServerTool(body []byte) (ServerTool, bool) {
 	return found, found.Type != ""
 }
 
-// nativeServerToolPrefixes lists Anthropic server tools the provider executes,
-// not the model. Broader than serverToolPrefix: FindServerTool/DetectSearchTurn
-// cover only the tool we can emulate; this covers all non-Anthropic-runnable tools.
+// nativeServerToolPrefixes lists Anthropic server tools the provider executes, not the model.
+// Broader than serverToolPrefix: FindServerTool/DetectSearchTurn cover only the tool we can emulate.
 var nativeServerToolPrefixes = []string{serverToolPrefix, "web_fetch_"}
 
 func isNativeServerTool(toolType string) bool {
@@ -60,10 +59,9 @@ func isNativeServerTool(toolType string) bool {
 	return false
 }
 
-// StripServerTools removes Anthropic native server tools (web_search_*,
-// web_fetch_*) from an Anthropic Messages body. Non-Anthropic upstreams cannot
-// execute them; passed through they become phantom function tools emitting
-// unhandleable tool_use blocks.
+// StripServerTools removes Anthropic native server tools (web_search_*, web_fetch_*) from an
+// Anthropic Messages body. Non-Anthropic upstreams cannot execute them; passed through they
+// become phantom function tools emitting unhandleable tool_use blocks.
 func StripServerTools(body []byte) ([]byte, int) {
 	removed := 0
 	strippedNames := make(map[string]struct{})

--- a/internal/websearch/anthropic_request.go
+++ b/internal/websearch/anthropic_request.go
@@ -48,7 +48,7 @@ func FindServerTool(body []byte) (ServerTool, bool) {
 
 // nativeServerToolPrefixes lists Anthropic server tools the provider executes,
 // not the model. Broader than serverToolPrefix: FindServerTool/DetectSearchTurn
-// cover the one tool we can emulate; this covers every tool non-Anthropic
+// cover the one tool we can emulate; this covers all tools non-Anthropic
 // upstreams cannot run.
 var nativeServerToolPrefixes = []string{serverToolPrefix, "web_fetch_"}
 

--- a/internal/websearch/anthropic_request.go
+++ b/internal/websearch/anthropic_request.go
@@ -62,9 +62,9 @@ func isNativeServerTool(toolType string) bool {
 }
 
 // StripServerTools removes Anthropic native server tools (web_search_*,
-// web_fetch_*) from an Anthropic Messages body and reports how many were
-// removed. Non-Anthropic upstreams cannot execute them; passed through, they
-// become phantom function tools that emit unhandleable tool_use blocks.
+// web_fetch_*) from an Anthropic Messages body. Non-Anthropic upstreams cannot
+// execute them; passed through they become phantom function tools that emit
+// unhandleable tool_use blocks.
 func StripServerTools(body []byte) ([]byte, int) {
 	removed := 0
 	strippedNames := make(map[string]struct{})

--- a/internal/websearch/anthropic_request.go
+++ b/internal/websearch/anthropic_request.go
@@ -46,11 +46,10 @@ func FindServerTool(body []byte) (ServerTool, bool) {
 	return found, found.Type != ""
 }
 
-// nativeServerToolPrefixes are the dated Anthropic server tools the *provider*
-// executes rather than the model. Broader than serverToolPrefix on purpose:
-// FindServerTool/DetectSearchTurn are about the one tool we know how to
-// emulate, while this list is about every tool a non-Anthropic upstream cannot
-// run at all.
+// nativeServerToolPrefixes lists Anthropic server tools the provider executes,
+// not the model. Broader than serverToolPrefix: FindServerTool/DetectSearchTurn
+// cover the one tool we can emulate; this covers every tool non-Anthropic
+// upstreams cannot run.
 var nativeServerToolPrefixes = []string{serverToolPrefix, "web_fetch_"}
 
 func isNativeServerTool(toolType string) bool {
@@ -70,18 +69,24 @@ func isNativeServerTool(toolType string) bool {
 // client never registered a handler for.
 func StripServerTools(body []byte) ([]byte, int) {
 	removed := 0
+	strippedNames := make(map[string]struct{})
 	// Reverse order: deleting by index shifts every later element.
 	tools := gjson.GetBytes(body, "tools").Array()
 	for i := len(tools) - 1; i >= 0; i-- {
-		if !isNativeServerTool(tools[i].Get("type").String()) {
+		tool := tools[i]
+		if !isNativeServerTool(tool.Get("type").String()) {
 			continue
 		}
+		name := tool.Get("name").String()
 		out, err := sjson.DeleteBytes(body, "tools."+strconv.Itoa(i))
 		if err != nil {
 			continue
 		}
 		body = out
 		removed++
+		if name != "" {
+			strippedNames[name] = struct{}{}
+		}
 	}
 	if removed == 0 {
 		return body, 0
@@ -92,6 +97,13 @@ func StripServerTools(body []byte) ([]byte, int) {
 		}
 		if out, err := sjson.DeleteBytes(body, "tool_choice"); err == nil {
 			body = out
+		}
+	} else if gjson.GetBytes(body, "tool_choice.type").String() == "tool" {
+		choiceName := gjson.GetBytes(body, "tool_choice.name").String()
+		if _, ok := strippedNames[choiceName]; ok {
+			if out, err := sjson.DeleteBytes(body, "tool_choice"); err == nil {
+				body = out
+			}
 		}
 	}
 	return body, removed

--- a/internal/websearch/websearch_test.go
+++ b/internal/websearch/websearch_test.go
@@ -45,6 +45,20 @@ func TestStripServerToolsKeepsClientTools(t *testing.T) {
 	}
 }
 
+func TestStripServerToolsDropsForcedChoiceForRemovedTool(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"web_search_20250305","name":"web_search"},{"name":"Read"}],"tool_choice":{"type":"tool","name":"web_search"}}`)
+	out, removed := websearch.StripServerTools(body)
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1", removed)
+	}
+	if names := gjson.GetBytes(out, "tools.#.name").Array(); len(names) != 1 || names[0].String() != "Read" {
+		t.Fatalf("remaining tools = %v", names)
+	}
+	if gjson.GetBytes(out, "tool_choice").Exists() {
+		t.Fatal("tool_choice naming the stripped tool was not dropped")
+	}
+}
+
 func TestStripServerToolsDropsToolChoiceWhenNothingIsLeft(t *testing.T) {
 	body := []byte(`{"tools":[{"type":"web_search_20250305","name":"web_search"}],"tool_choice":{"type":"tool","name":"web_search"}}`)
 	out, removed := websearch.StripServerTools(body)


### PR DESCRIPTION
## Why

Anthropic executes `web_search_*` / `web_fetch_*` server-side — the model only ever sees the synthesized result blocks. On the Anthropic→non-Anthropic emit paths those declarations were converted like any other tool: `writeOpenAIToolsFromAnthropic` iterates every entry in `tools`, so

```json
{"type":"web_search_20250305","name":"web_search"}
```

(no `input_schema`) became

```json
{"type":"function","function":{"name":"web_search"}}
```

The upstream model can then call a tool the client never registered a handler for, producing a `tool_use` block the harness cannot answer. That is the same phantom-tool failure `claudecode_tool_filter.go` was written for — 224 phantom CC-only `tool_use` blocks on the v0.57 SWE-bench eval.

`websearch.StripServerTools` already did exactly this, was tested, and had **no production caller**.

## What

- Wire `StripServerTools` into `buildOpenAIFromAnthropic`, `buildResponsesFromAnthropic`, and the Gemini `FormatAnthropic` branch, next to the existing Claude-Code-only tool filter, behind a new `RequestMutationStats.ServerToolsStripped`.
- Widen the helper from `web_search_` to a `nativeServerToolPrefixes` list including `web_fetch_`. Writing the tests surfaced this: `web_fetch` survived the strip and became a phantom tool too. `serverToolPrefix` stays search-only so `FindServerTool`/`DetectSearchTurn` keep their narrower meaning — that pair is about the one tool the router knows how to *emulate*, a strictly smaller set than the tools a non-Anthropic upstream cannot *run*.
- Anthropic→Anthropic passthrough is untouched: that upstream is the one that can execute them.

## Behaviour

**None today.** The HMM policy still forces every `web_search`-advertising turn onto an Anthropic arm (`_native_web_search_decision`), so this path is unreachable. This is the groundwork that makes narrowing that guard safe — without the strip, narrowing it would send main-agent turns to OpenAI with a phantom `web_search` function attached.

Context for why the guard is worth narrowing: on the 50-task SWE-Together run `hmm-v65c-swetog-50t-cc2197-20260827b`, the guard fired on 5,750 calls costing **\$738.32 — 66.8% of the run's spend** — and the decision reasons show the policy had chosen `openai/gpt-5.6-luna` for **100%** of them. None were real search turns (20k–58k-token prompts; `DetectSearchTurn` requires a single-message search sub-turn).

## Testing

- New `internal/translate/server_tool_strip_test.go`: OpenAI strips, Gemini strips, Anthropic→Anthropic keeps, and a server-tools-only body drops the now-dangling `tool_choice`.
- `go build ./...`, `go vet`, and the full `go test ./...` suite pass on this base.

🤖 Generated with [Weave Router](https://router.workweave.ai)