### PR TITLE
Show routing markers for native Codex Responses traffic

### DIFF
--- a/.claude/skills/test-codex-locally/SKILL.md
+++ b/.claude/skills/test-codex-locally/SKILL.md
@@ -23,7 +23,7 @@ The sibling skill [test-claude-locally](../test-claude-locally/SKILL.md) is the 
 - **Docker may not be running.** `docker compose` fails with a `unix://…/.docker/run/docker.sock` connect error if Desktop is stopped. `open -a Docker` and wait for `docker info` before step 1.
 - **Other agents in the same workspace can `docker compose down` and delete `/tmp` scratch.** If health suddenly 404s or `CODEX_HOME` vanishes mid-run, re-up the stack and reseed — do not reuse a key you can no longer `/validate`.
 - **Session key is `apiKeyID` + first user message.** Reusing the same curl/prompt body on the same key reuses the pin slot. `routingMarkerFor` then returns empty when `PriorServedModel == ServedIdentity()` (sticky same-model). For first-turn marker tests, seed a **new** key or change the first user text. Isolated `/validate` first: `curl -sS -o /dev/null -w '%{http_code}\n' -H "X-Weave-Router-Key: $KEY" http://localhost:8080/validate` must be `200`.
-- **Native GPT passthrough + tool-only still has no badge.** `SetPassthroughBadge` can only rewrite `response.output_text.*` events. A ChatGPT-subscription turn that opens with reasoning and goes straight to a tool call never emits those, and the rewriter will not invent an `output_item` (would renumber a stream Codex expects to be byte-faithful). The translated path (`ensureBadgeItem`) *does* synthesize a leading message item ahead of a tool call. Don't treat a silent OAuth/tool-only GPT turn as a regression of the translated-path fix.
+- **Native GPT passthrough + tool-only emits a synthetic badge item.** `SetPassthroughBadge` rewrites existing `response.output_text.*` events and, when a ChatGPT-subscription turn has no assistant text, inserts a leading assistant message item before native tool/reasoning output. Verify the badge in the Responses SSE/JSON; the Codex TUI can bury the first-turn line under tool chatter.
 - **`GET /v1/models` 501 from a mock is fine.** Codex probes `<base_url>/models` first, logs an HTML 501, then continues to `POST /v1/responses`. The real local router implements `GET /v1/models` as Anthropic passthrough, so this only shows up against a Python mock.
 - **Port 8085 conflict.** The monorepo's pubsub emulator may already own host port 8085. Drop the router's host binding with a `docker-compose.override.yml` (see workflow). The server still reaches the emulator over the compose network.
 - **No credits / no key = no reproduction.** If the real upstream returns an error (e.g. OpenRouter "Insufficient credits"), use the mock-upstream path instead.
@@ -76,6 +76,22 @@ A 401 mid-session usually means the stack was torn down and reseeded (new instal
 
 **Real provider** — set the provider key in `.env.local` (e.g. `OPENAI_API_KEY=...`, `FIREWORKS_API_KEY=...`) and restart `docker compose up -d server`. Confirm the boot log shows `<Provider> provider enabled` with the real base_url. Use this to confirm a model genuinely produces the behavior.
 
+For an actual Codex subscription response, do not set `ROUTER_CODEX_BASE_URL`
+and do not run either mock. Remove that environment entry from
+`docker-compose.override.yml`, then rebuild the server:
+
+```bash
+unset ROUTER_CODEX_BASE_URL  # also remove it from docker-compose.override.yml
+docker compose up -d --build server
+```
+
+Use a throwaway `CODEX_HOME` containing a copy of the real
+`~/.codex/auth.json`, with `requires_openai_auth = true` and `X-App = "codex"`.
+The router detects the OAuth bearer plus `ChatGPT-Account-ID` and calls the
+real `https://chatgpt.com/backend-api/codex/responses` endpoint. This consumes
+the user's ChatGPT quota and requires a valid login; the mock is only for
+repeatable tests when that endpoint is unavailable or too expensive.
+
 **Mock upstream** — for a deterministic, credit-free repro of a precise SSE shape. Point the provider's base URL at a local mock and restart. Codex talks to the *router* (`POST /v1/responses`); the mock sits behind the router as the upstream the router dispatches to:
 
 ```bash
@@ -88,13 +104,34 @@ python3 .claude/skills/test-claude-locally/scripts/mock_openai_upstream.py >/tmp
 docker compose up -d server
 ```
 
-Edit the mock's emitted chunks to match the upstream shape you're reproducing. Provider→env-var names live in `internal/providers/provider.go`; base-URL overrides are read in `cmd/router/main.go` (`<PROVIDER>_BASE_URL`). There is **no** `ANTHROPIC_BASE_URL` / `CODEX_BASE_URL` override for the ChatGPT subscription backend (`chatgpt.com/backend-api/codex`) — native GPT subscription traffic always hits the real Codex backend unless you temporarily edit `internal/providers/openai/client.go` (`chatGPTCodexBaseURL`) and revert after.
+To exercise the production-equivalent native Codex subscription path, use a
+native Responses mock instead of the Chat Completions mock:
+
+```bash
+python3 .claude/skills/test-codex-locally/scripts/mock_codex_upstream.py >/tmp/mock-codex.log 2>&1 &
+```
+
+Add this to the `server` service in `docker-compose.override.yml`:
+
+```yaml
+environment:
+  ROUTER_CODEX_BASE_URL: http://host.docker.internal:8099/v1
+extra_hosts: ["host.docker.internal:host-gateway"]
+```
+
+This preserves real Codex subscription detection (OAuth bearer plus
+`ChatGPT-Account-ID`) and native Responses passthrough, while replacing only
+the outbound ChatGPT backend with a deterministic tool-only stream. The mock
+emits a function call, so the expected result is a synthetic marker message at
+`output_index: 0`, followed by the native tool at `output_index: 1`.
+
+Edit the mock's emitted chunks to match the upstream shape you're reproducing. Provider→env-var names live in `internal/providers/provider.go`; base-URL overrides are read in `cmd/router/main.go` (`<PROVIDER>_BASE_URL`). For local testing, `ROUTER_CODEX_BASE_URL` overrides only the subscription backend; the default remains `https://chatgpt.com/backend-api/codex`.
 
 **Subscription vs prepaid (important for marker / passthrough tests):**
 
 Codex will attach a ChatGPT JWT. The local router then treats the turn as a Codex subscription:
 
-- OpenAI-family decision → verbatim Responses passthrough (`SetPassthrough` / `SetPassthroughBadge`) to `chatgpt.com/backend-api/codex`. This is the path the routing-marker-on-Codex work exercises.
+- OpenAI-family decision → verbatim Responses passthrough (`SetPassthrough` / `SetPassthroughBadge`) to the Codex backend (or `ROUTER_CODEX_BASE_URL` in the native mock setup). This is the path the routing-marker-on-Codex work exercises.
 - Non-OpenAI decision → Chat Completions translation + `ResponsesWriter.SetBadgeText`.
 
 To force the prepaid/BYOK translation path (no ChatGPT backend, uses `OPENAI_API_KEY` / other provider keys):
@@ -188,11 +225,11 @@ If you only see other models, the pin didn't take. Recheck: (1) `x-weave-force-m
 **Routing-marker specific checks (the usual reason to use this skill):**
 
 - Cross-format (non-OpenAI decision, or prepaid OpenAI): first assistant text is `✦ **Weave Router** → <model> · <reason>`. Log field `routing_marker` is non-empty.
-- Verbatim GPT passthrough (Codex subscription + OpenAI decision): same marker injected as a synthetic `response.output_text.delta` before upstream deltas (`SetPassthroughBadge`). Log still has `routing_marker`.
+- Verbatim GPT passthrough (Codex subscription + OpenAI decision): same marker is injected into the first native assistant text, or as a synthetic assistant message item before tool/reasoning-only output (`SetPassthroughBadge`). Log still has `routing_marker`.
 - `X-Weave-Routing-Marker: off` (and not subscription-only warning): no badge. Subscription-only depleted-credits warning still wins over the opt-out.
 - Same model, second action (`prior_served_model` equals `decision_model`): `routing_marker=""`. Expected. Seed a new key (or change the first user text) to re-see a first-turn badge.
 - Tool-call-only on the **translated** path: marker is a leading `output_item` (`output_index` 0) ahead of the function call — including `stream:false` JSON. Confirm in the SSE / JSON, not only in `codex exec` stdout (the TUI can bury the first-turn line under tool chatter).
-- Tool-call-only on **verbatim GPT passthrough**: still no badge (see gotchas). Don't fail the check.
+- Tool-call-only on **verbatim GPT passthrough**: a leading synthetic message item carries the badge, followed by the native tool call. Sequence/output indices are shifted to remain valid.
 - Non-Codex client (`X-App` unset) on a translated decision still gets the `✦ **Weave Router** → …` text badge today; native OpenAI passthrough without `X-App: codex` stays byte-identical (`SetPassthrough` with no badge rewrite).
 - For curl-level checks (no Codex CLI), `POST /v1/responses` with `X-Weave-Router-Key` + `X-App: codex` is enough. Isolate first-turn cases with a freshly seeded key.
 
@@ -200,6 +237,7 @@ If you only see other models, the pin didn't take. Recheck: (1) `x-weave-force-m
 
 ```bash
 pkill -f mock_openai_upstream.py 2>/dev/null
+pkill -f mock_codex_upstream.py 2>/dev/null
 rm -rf /tmp/weave-codex-local
 rm -f docker-compose.override.yml
 # `docker compose down` if you want to stop the stack

--- a/.claude/skills/test-codex-locally/scripts/mock_codex_upstream.py
+++ b/.claude/skills/test-codex-locally/scripts/mock_codex_upstream.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Deterministic native Responses upstream for local Codex routing tests.
+
+The router's Codex subscription branch normally targets chatgpt.com. Set
+ROUTER_CODEX_BASE_URL to this server's /v1 URL to exercise that same native
+Responses path without spending credits or calling the real backend.
+"""
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+PORT = 8099
+
+
+def event(event_type, sequence, **fields):
+    payload = {"type": event_type, "sequence_number": sequence, **fields}
+    return (f"event: {event_type}\ndata: {json.dumps(payload)}\n\n").encode()
+
+
+def stream():
+    response = {"id": "resp_mock", "model": "gpt-5.6-sol", "status": "in_progress", "output": []}
+    yield event("response.created", 0, response=response)
+    item = {"id": "fc_mock", "type": "function_call", "call_id": "call_mock", "name": "shell", "arguments": "", "status": "in_progress"}
+    yield event("response.output_item.added", 1, output_index=0, item=item)
+    yield event("response.function_call_arguments.delta", 2, item_id="fc_mock", output_index=0, delta='{"cmd":"pwd"}')
+    yield event("response.function_call_arguments.done", 3, item_id="fc_mock", output_index=0, arguments='{"cmd":"pwd"}')
+    item["arguments"] = '{"cmd":"pwd"}'
+    item["status"] = "completed"
+    yield event("response.output_item.done", 4, output_index=0, item=item)
+    response["status"] = "completed"
+    response["output"] = [item]
+    yield event("response.completed", 5, response=response)
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *_args):
+        pass
+
+    def do_POST(self):
+        self.rfile.read(int(self.headers.get("content-length", 0)))
+        self.send_response(200)
+        self.send_header("content-type", "text/event-stream")
+        self.end_headers()
+        for chunk in stream():
+            self.wfile.write(chunk)
+        self.wfile.flush()
+
+
+if __name__ == "__main__":
+    print(f"mock native Codex Responses upstream on :{PORT}")
+    ThreadingHTTPServer(("0.0.0.0", PORT), Handler).serve_forever()

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -211,11 +211,19 @@ func main() {
 		}
 		// Codex (ChatGPT) subscription reroute to the Codex backend lives in
 		// the OpenAI client itself, keyed off the resolved credential.
-		providerMap[providers.ProviderOpenAI] = openaiProvider.NewClientWithModelIDMap(
+		openaiClient := openaiProvider.NewClientWithModelIDMap(
 			openaiKey,
 			openaiBaseURL,
 			upstreamIDsForProvider(providers.ProviderOpenAI),
 		)
+		// Local tests can point the subscription branch at a deterministic native
+		// Responses mock without changing the production ChatGPT endpoint.
+		if deploymentMode == server.DeploymentModeSelfHosted {
+			if codexBaseURL := config.GetOr("ROUTER_CODEX_BASE_URL", ""); codexBaseURL != "" {
+				openaiClient.SetCodexBaseURL(codexBaseURL)
+			}
+		}
+		providerMap[providers.ProviderOpenAI] = openaiClient
 		switch {
 		case byokOnly:
 			logger.Info("OpenAI provider enabled (BYOK only)", "base_url", openaiBaseURL)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -33,6 +33,7 @@ Claude Code keep using the user's logged-in plan.
 | `ANTHROPIC_API_KEY`   | *(none — passthrough)*                                    | Router's own Anthropic key. When unset, client `Authorization` headers pass through. |
 | `OPENAI_API_KEY`      | *(none)*                                                  | Enables the OpenAI provider (Chat Completions API). |
 | `OPENAI_BASE_URL`     | `https://api.openai.com`                                  | Override for OpenAI (e.g. Azure OpenAI). |
+| `ROUTER_CODEX_BASE_URL` | `https://chatgpt.com/backend-api/codex`                  | Local-testing override for the ChatGPT subscription Responses backend; leave unset in production. |
 | `GOOGLE_API_KEY`      | *(none)*                                                  | Enables Gemini via its OpenAI-compatible endpoint. |
 | `GOOGLE_BASE_URL`     | `https://generativelanguage.googleapis.com/v1beta/openai` | Override for Gemini. |
 | `ANTHROPIC_GATEWAY_BASE_URL` | *(none)*                                           | Base URL of an Anthropic-compatible gateway; `/v1/messages` is appended to it. |

--- a/internal/providers/openai/client.go
+++ b/internal/providers/openai/client.go
@@ -124,9 +124,7 @@ func NewClientWithModelIDMap(apiKey, baseURL string, modelIDMap map[string]strin
 	return newClientWithModelIDMap(apiKey, baseURL, responseHeaderTimeout, modelIDMap)
 }
 
-// SetCodexBaseURL overrides the ChatGPT Codex subscription endpoint. It is
-// intended for local deterministic testing; managed deployments always use
-// the built-in chatgpt.com endpoint.
+// SetCodexBaseURL overrides the Codex subscription endpoint for local testing.
 func (c *Client) SetCodexBaseURL(baseURL string) {
 	if baseURL != "" {
 		c.codexBaseURL = baseURL

--- a/internal/providers/openai/client.go
+++ b/internal/providers/openai/client.go
@@ -124,6 +124,15 @@ func NewClientWithModelIDMap(apiKey, baseURL string, modelIDMap map[string]strin
 	return newClientWithModelIDMap(apiKey, baseURL, responseHeaderTimeout, modelIDMap)
 }
 
+// SetCodexBaseURL overrides the ChatGPT Codex subscription endpoint. It is
+// intended for local deterministic testing; managed deployments always use
+// the built-in chatgpt.com endpoint.
+func (c *Client) SetCodexBaseURL(baseURL string) {
+	if baseURL != "" {
+		c.codexBaseURL = baseURL
+	}
+}
+
 // NewClientWithResponseHeaderTimeout is NewClient with a caller-chosen
 // time-to-first-byte guard, so tests can exercise bounded-stall behavior
 // (#331) without waiting out the 120s default.

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -5689,8 +5689,8 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			rw.SetFooterText(footer)
 		}
 	}
-	// Outlives the passthrough teardown of marker below, so a chat/completions
-	// re-dispatch can still badge the translated stream.
+	// Keep a stable copy for a possible chat/completions fallback after a native
+	// Responses endpoint rejects the request.
 	translatedMarker := marker
 
 	// Responses entry point delegates the eager response.created emit to
@@ -5734,11 +5734,6 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		sink = captureW
 	}
 
-	if verbatimPassthrough {
-		// The client receives raw Responses SSE from the Codex backend; a
-		// chat-completions routing-marker chunk would corrupt that stream.
-		marker = ""
-	}
 	_, isResponses := w.(*translate.ResponsesWriter)
 	// makeMarkerSink wraps sink with an OpenAIRoutingMarkerWriter emitting the
 	// marker chunk + HTTP 200 eagerly (skipped for /v1/responses). Called per

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -739,9 +739,7 @@ func (t *ResponsesWriter) Write(data []byte) (int, error) {
 		}
 		if t.passthroughBadge {
 			t.buf.Write(data)
-			// Some native Codex upstream responses omit Content-Type when the
-			// proxy has already committed headers. Detect SSE from the buffered
-			// event itself so the native badge path is not mistaken for JSON.
+			// Some upstreams omit Content-Type; detect SSE from the first buffered event.
 			if nativeResponsesSSEBuffer(t.buf.Bytes()) {
 				t.streaming = true
 				if err := t.processPassthroughSSEBuffer(); err != nil {
@@ -1163,18 +1161,28 @@ func (t *ResponsesWriter) rewriteNativeResponsesPayload(data []byte) ([]byte, bo
 				hasOutputIndex: true,
 			}
 			if t.nativeBadgeTargetSelected && !t.nativeBadgeTargetMatches(ref, false) {
+				// The badge rides its own synthetic item, so this message only
+				// needs the footer.
+				textPart, ok := firstNativeOutputTextPart(item)
+				if !ok {
+					continue
+				}
+				footerPath := "response.output." + strconv.Itoa(outputIndex) + ".content." + strconv.Itoa(textPart) + ".text"
+				if rewritten, changed := t.suffixNativeFooter(data, footerPath); changed {
+					return rewritten, true
+				}
 				continue
 			}
 			partIndex, ok := t.nativeOutputTextPart(item)
 			if !ok {
 				continue
 			}
+			path := "response.output." + strconv.Itoa(outputIndex) + ".content." + strconv.Itoa(partIndex) + ".text"
 			ref.contentIndex = int64(partIndex)
 			ref.hasContentIndex = true
 			if !t.observeNativeBadgeTarget(ref) || !t.nativeBadgeTargetMatches(ref, true) {
 				continue
 			}
-			path := "response.output." + strconv.Itoa(outputIndex) + ".content." + strconv.Itoa(partIndex) + ".text"
 			return applyNativeRewrites(data,
 				func(d []byte) ([]byte, bool) { return t.prefixNativeBadge(d, path) },
 				func(d []byte) ([]byte, bool) { return t.suffixNativeFooter(d, path) },
@@ -1281,14 +1289,27 @@ func (t *ResponsesWriter) rewriteNativeNonStreamingBody(data []byte) ([]byte, bo
 }
 
 func (t *ResponsesWriter) rewriteNativeResponsesEvent(raw []byte) []byte {
+	return t.rewriteNativeEventWith(raw, true)
+}
+
+// rewriteNativeHeldEvent re-applies badge/footer text to an event that was held
+// back for the footer decision. Coordinates were already shifted when the event
+// was first seen, and the shift is not idempotent.
+func (t *ResponsesWriter) rewriteNativeHeldEvent(raw []byte) []byte {
+	return t.rewriteNativeEventWith(raw, false)
+}
+
+func (t *ResponsesWriter) rewriteNativeEventWith(raw []byte, shiftFields bool) []byte {
 	_, data := sse.ParseEvent(raw)
 	if len(data) == 0 {
 		return raw
 	}
 	rewrittenData, changed := t.rewriteNativeResponsesPayload(data)
-	if fields, fieldsChanged := t.rewriteNativePassthroughFields(rewrittenData); fieldsChanged {
-		rewrittenData = fields
-		changed = true
+	if shiftFields {
+		if fields, fieldsChanged := t.rewriteNativePassthroughFields(rewrittenData); fieldsChanged {
+			rewrittenData = fields
+			changed = true
+		}
 	}
 	if !changed {
 		return raw
@@ -1322,9 +1343,8 @@ func (t *ResponsesWriter) writeNativeEvent(eventType string, sequence int64, pay
 	return err
 }
 
-// emitNativeBadgeBeforeOutput prepends a badge message item to the stream.
-// Native Responses requires an output item for badge display; six events are
-// emitted and upstream coordinates shifted accordingly.
+// emitNativeBadgeBeforeOutput prepends a synthetic badge message item, emitting
+// six native events and shifting sequence numbers and output indices accordingly.
 func (t *ResponsesWriter) emitNativeBadgeBeforeOutput(event []byte) error {
 	if t.nativeSyntheticBadgeEmitted || t.nativeBadgeTargetSelected || t.computeBadgeText() == "" {
 		return nil
@@ -1395,13 +1415,18 @@ func (t *ResponsesWriter) writeNativeResponsesEvent(event, delimiter []byte) err
 		itemType = gjson.GetBytes(data, "item.type").Str
 	}
 	toolCall := eventType == "response.function_call_arguments.delta" || eventType == "response.custom_tool_call_input.delta" || (eventType == "response.output_item.added" && (itemType == "function_call" || itemType == "custom_tool_call")) || (eventType == "response.output_item.done" && (itemType == "function_call" || itemType == "custom_tool_call"))
-	if toolCall {
-		t.sawToolCall = true
+	reasoningItem := eventType == "response.output_item.added" && itemType == "reasoning"
+	if toolCall || reasoningItem {
+		if toolCall {
+			t.sawToolCall = true
+		}
 		if err := t.emitNativeBadgeBeforeOutput(event); err != nil {
 			return err
 		}
-		if err := t.flushNativeHeldEvents(false); err != nil {
-			return err
+		if toolCall {
+			if err := t.flushNativeHeldEvents(false); err != nil {
+				return err
+			}
 		}
 	}
 	if (eventType == "response.completed" || eventType == "response.incomplete") && !t.nativeBadgeTargetSelected && !t.nativeSyntheticBadgeEmitted {
@@ -1456,7 +1481,7 @@ func (t *ResponsesWriter) flushNativeHeldEvents(commitFooter bool) error {
 	held := t.nativeHeldEvents
 	t.nativeHeldEvents = nil
 	for _, event := range held {
-		rewritten := t.rewriteNativeResponsesEvent(event)
+		rewritten := t.rewriteNativeHeldEvent(event)
 		if _, err := t.bw.Write(rewritten); err != nil {
 			return err
 		}

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -518,30 +518,33 @@ type ResponsesWriter struct {
 	seq int64
 
 	// Streaming state.
-	headersEmitted             bool
-	completedEmitted           bool
-	badgePrepended             bool
-	badgeText                  string
-	codexBadgeProvenance       bool
-	nativeBadgeTargetSelected  bool
-	nativeBadgeDeltaPrepended  bool
-	nativeBadgeItemID          string
-	nativeBadgeOutputIndex     int64
-	nativeBadgeHasOutputIndex  bool
-	nativeBadgeContentIndex    int64
-	nativeBadgeHasContentIndex bool
-	footerText                 string
-	footerEmitted              bool
-	sawToolCall                bool
-	nativeHeldEvents           [][]byte
-	nativeFooterCommit         bool
-	textItem                   *responsesTextItem
-	toolItems                  map[int]*responsesToolItem
-	finishReason               string
-	usage                      *responsesUsage
-	lifecycle                  *StreamLifecycle
-	toolLedger                 *ToolCallLedger
-	toolMappings               map[string]ResponsesToolMapping
+	headersEmitted              bool
+	completedEmitted            bool
+	badgePrepended              bool
+	badgeText                   string
+	codexBadgeProvenance        bool
+	nativeBadgeTargetSelected   bool
+	nativeBadgeDeltaPrepended   bool
+	nativeBadgeItemID           string
+	nativeBadgeOutputIndex      int64
+	nativeBadgeHasOutputIndex   bool
+	nativeBadgeContentIndex     int64
+	nativeBadgeHasContentIndex  bool
+	nativeSyntheticBadgeEmitted bool
+	nativeOutputIndexShift      int64
+	nativeSequenceShift         int64
+	footerText                  string
+	footerEmitted               bool
+	sawToolCall                 bool
+	nativeHeldEvents            [][]byte
+	nativeFooterCommit          bool
+	textItem                    *responsesTextItem
+	toolItems                   map[int]*responsesToolItem
+	finishReason                string
+	usage                       *responsesUsage
+	lifecycle                   *StreamLifecycle
+	toolLedger                  *ToolCallLedger
+	toolMappings                map[string]ResponsesToolMapping
 }
 
 type responsesTextItem struct {
@@ -667,9 +670,9 @@ func (t *ResponsesWriter) ClearPassthrough() bool {
 }
 
 // SetPassthroughBadge switches to native Responses passthrough while opting
-// into a Codex-visible routed-model badge. It rewrites only existing text
-// fields in the first assistant message; event order, sequence numbers,
-// response/item ids, output indices, reasoning, and tool calls remain native.
+// into a Codex-visible routed-model badge. Existing assistant text is
+// rewritten in place; text-free turns receive a synthetic assistant message
+// before native output so Codex has a visible surface for the badge.
 func (t *ResponsesWriter) SetPassthroughBadge() {
 	t.EnableCodexBadgeProvenance()
 	t.passthrough = true
@@ -713,16 +716,17 @@ func (t *ResponsesWriter) WriteHeader(code int) {
 }
 
 func (t *ResponsesWriter) Write(data []byte) (int, error) {
+	n := len(data)
 	if t.passthrough {
 		if !t.httpHeadersSent {
 			t.streaming = strings.Contains(t.inner.Header().Get("Content-Type"), "text/event-stream")
+			t.statusCode = http.StatusOK
 			t.inner.WriteHeader(http.StatusOK)
 			t.httpHeadersSent = true
 		}
 		// Generic native Responses callers remain byte-for-byte passthrough. Only
 		// the explicitly enabled Codex display path parses native SSE.
 		if t.passthroughBadge && t.streaming {
-			n := len(data)
 			t.buf.Write(data)
 			err := t.processPassthroughSSEBuffer()
 			if err == nil {
@@ -732,6 +736,25 @@ func (t *ResponsesWriter) Write(data []byte) (int, error) {
 				}
 			}
 			return n, err
+		}
+		if t.passthroughBadge {
+			t.buf.Write(data)
+			// Some native Codex upstream responses omit Content-Type when the
+			// proxy has already committed headers. Detect SSE from the buffered
+			// event itself so the native badge path is not mistaken for JSON.
+			if nativeResponsesSSEBuffer(t.buf.Bytes()) {
+				t.streaming = true
+				if err := t.processPassthroughSSEBuffer(); err != nil {
+					return n, err
+				}
+				if err := t.bw.Flush(); err != nil {
+					return n, err
+				}
+				if t.flusher != nil {
+					t.flusher.Flush()
+				}
+			}
+			return n, nil
 		}
 		// Forward verbatim. The upstream emits Responses natively, so there is
 		// nothing to translate for clients that did not opt into the display badge.
@@ -744,7 +767,6 @@ func (t *ResponsesWriter) Write(data []byte) (int, error) {
 		}
 		return written, err
 	}
-	n := len(data)
 	t.buf.Write(data)
 	if !t.streaming {
 		return n, nil
@@ -759,6 +781,15 @@ func (t *ResponsesWriter) Write(data []byte) (int, error) {
 		t.headersEmitted = true
 	}
 	return n, t.processSSEBuffer()
+}
+
+func nativeResponsesSSEBuffer(data []byte) bool {
+	event, n := sse.SplitNext(data)
+	if n == 0 {
+		return false
+	}
+	_, payload := sse.ParseEvent(event)
+	return gjson.ValidBytes(payload) && gjson.GetBytes(payload, "type").Str != ""
 }
 
 // Prelude commits headers and emits response.created immediately so Codex
@@ -804,6 +835,19 @@ func (t *ResponsesWriter) Finalize() error {
 			if err := t.processFinalPassthroughSSETail(); err != nil {
 				return err
 			}
+		}
+		if t.passthroughBadge && !t.streaming {
+			body := t.buf.Bytes()
+			if rewritten, changed := t.rewriteNativeNonStreamingBody(body); changed {
+				body = rewritten
+			}
+			if !t.httpHeadersSent {
+				t.inner.Header().Set("Content-Type", "application/json")
+				t.inner.WriteHeader(t.statusCode)
+				t.httpHeadersSent = true
+			}
+			_, err := t.inner.Write(body)
+			return err
 		}
 		// Nothing is synthesized; the upstream remains the event authority.
 		return t.bw.Flush()
@@ -1140,12 +1184,102 @@ func (t *ResponsesWriter) rewriteNativeResponsesPayload(data []byte) ([]byte, bo
 	return data, false
 }
 
+// rewriteNativePassthroughFields adjusts native coordinates after a synthetic
+// badge item has been inserted ahead of the upstream output. Sequence numbers
+// are shifted so the SSE stream remains strictly monotonic; output indices are
+// shifted so tool/reasoning items retain their identity relative to the badge.
+func (t *ResponsesWriter) rewriteNativePassthroughFields(data []byte) ([]byte, bool) {
+	if !gjson.ValidBytes(data) {
+		return data, false
+	}
+	root := gjson.ParseBytes(data)
+	changed := false
+	if t.nativeSequenceShift != 0 && root.Get("sequence_number").Type == gjson.Number {
+		if rewritten, err := sjson.SetBytes(data, "sequence_number", root.Get("sequence_number").Int()+t.nativeSequenceShift); err == nil {
+			data = rewritten
+			root = gjson.ParseBytes(data)
+			changed = true
+		}
+	}
+	if t.nativeOutputIndexShift != 0 && root.Get("output_index").Type == gjson.Number {
+		if rewritten, err := sjson.SetBytes(data, "output_index", root.Get("output_index").Int()+t.nativeOutputIndexShift); err == nil {
+			data = rewritten
+			root = gjson.ParseBytes(data)
+			changed = true
+		}
+	}
+	if !t.nativeSyntheticBadgeEmitted || (root.Get("type").Str != "response.completed" && root.Get("type").Str != "response.incomplete") {
+		return data, changed
+	}
+	output := root.Get("response.output")
+	if !output.IsArray() {
+		return data, changed
+	}
+	for _, item := range output.Array() {
+		if item.Get("id").Str == t.nativeBadgeItemID {
+			return data, changed
+		}
+	}
+	badgeItem := `{"id":"` + t.nativeBadgeItemID + `","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":` + strconv.Quote(t.computeBadgeText()) + `,"annotations":[]}]}`
+	items := make([]string, 0, len(output.Array())+1)
+	items = append(items, badgeItem)
+	for _, item := range output.Array() {
+		items = append(items, item.Raw)
+	}
+	if rewritten, err := sjson.SetRawBytes(data, "response.output", []byte("["+strings.Join(items, ",")+"]")); err == nil {
+		return rewritten, true
+	}
+	return data, changed
+}
+
+func (t *ResponsesWriter) rewriteNativeNonStreamingBody(data []byte) ([]byte, bool) {
+	if !gjson.ValidBytes(data) {
+		return data, false
+	}
+	root := gjson.ParseBytes(data)
+	output := root.Get("output")
+	if !output.IsArray() || t.computeBadgeText() == "" {
+		return data, false
+	}
+	for index, item := range output.Array() {
+		if !nativeResponsesAssistantMessage(item) {
+			continue
+		}
+		partIndex, ok := firstNativeOutputTextPart(item)
+		if !ok {
+			continue
+		}
+		path := "output." + strconv.Itoa(index) + ".content." + strconv.Itoa(partIndex) + ".text"
+		return t.prefixNativeBadge(data, path)
+	}
+	for _, item := range output.Array() {
+		if item.Get("id").Str != "" && codexResponsesBadgePattern.MatchString(item.Get("content.0.text").Str) {
+			return data, false
+		}
+	}
+	itemID := newResponsesID("msg")
+	badgeItem := `{"id":"` + itemID + `","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":` + strconv.Quote(t.computeBadgeText()) + `,"annotations":[]}]}`
+	items := []string{badgeItem}
+	for _, item := range output.Array() {
+		items = append(items, item.Raw)
+	}
+	rewritten, err := sjson.SetRawBytes(data, "output", []byte("["+strings.Join(items, ",")+"]"))
+	if err != nil {
+		return data, false
+	}
+	return rewritten, true
+}
+
 func (t *ResponsesWriter) rewriteNativeResponsesEvent(raw []byte) []byte {
 	_, data := sse.ParseEvent(raw)
 	if len(data) == 0 {
 		return raw
 	}
 	rewrittenData, changed := t.rewriteNativeResponsesPayload(data)
+	if fields, fieldsChanged := t.rewriteNativePassthroughFields(rewrittenData); fieldsChanged {
+		rewrittenData = fields
+		changed = true
+	}
 	if !changed {
 		return raw
 	}
@@ -1161,6 +1295,88 @@ func (t *ResponsesWriter) rewriteNativeResponsesEvent(raw []byte) []byte {
 	return rewritten
 }
 
+func (t *ResponsesWriter) writeNativeEvent(eventType string, sequence int64, payload map[string]any) error {
+	payload["type"] = eventType
+	payload["sequence_number"] = sequence
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	if _, err := t.bw.WriteString("event: " + eventType + "\ndata: "); err != nil {
+		return err
+	}
+	if _, err := t.bw.Write(body); err != nil {
+		return err
+	}
+	_, err = t.bw.WriteString("\n\n")
+	return err
+}
+
+// emitNativeBadgeBeforeOutput opens a real Responses message item before the
+// first native tool/reasoning item. Native Responses streams cannot display a badge
+// without an output item, so all subsequent tool coordinates are shifted by
+// one and upstream sequence numbers by the six events emitted here.
+func (t *ResponsesWriter) emitNativeBadgeBeforeOutput(event []byte) error {
+	if t.nativeSyntheticBadgeEmitted || t.nativeBadgeTargetSelected || t.computeBadgeText() == "" {
+		return nil
+	}
+	_, data := sse.ParseEvent(event)
+	root := gjson.ParseBytes(data)
+	sequence := root.Get("sequence_number")
+	base := int64(0)
+	if sequence.Type == gjson.Number {
+		base = sequence.Int() + t.nativeSequenceShift
+	}
+	itemID := newResponsesID("msg")
+	text := t.computeBadgeText()
+	item := map[string]any{
+		"id": itemID, "type": "message", "status": "in_progress", "role": "assistant", "content": []any{},
+	}
+	if err := t.writeNativeEvent("response.output_item.added", base, map[string]any{"output_index": 0, "item": item}); err != nil {
+		return err
+	}
+	if err := t.writeNativeEvent("response.content_part.added", base+1, map[string]any{
+		"item_id": itemID, "output_index": 0, "content_index": 0,
+		"part": map[string]any{"type": "output_text", "text": "", "annotations": []any{}},
+	}); err != nil {
+		return err
+	}
+	if err := t.writeNativeEvent("response.output_text.delta", base+2, map[string]any{
+		"item_id": itemID, "output_index": 0, "content_index": 0, "delta": text,
+	}); err != nil {
+		return err
+	}
+	if err := t.writeNativeEvent("response.output_text.done", base+3, map[string]any{
+		"item_id": itemID, "output_index": 0, "content_index": 0, "text": text,
+	}); err != nil {
+		return err
+	}
+	if err := t.writeNativeEvent("response.content_part.done", base+4, map[string]any{
+		"item_id": itemID, "output_index": 0, "content_index": 0,
+		"part": map[string]any{"type": "output_text", "text": text, "annotations": []any{}},
+	}); err != nil {
+		return err
+	}
+	if err := t.writeNativeEvent("response.output_item.done", base+5, map[string]any{
+		"output_index": 0,
+		"item": map[string]any{"id": itemID, "type": "message", "status": "completed", "role": "assistant", "content": []any{
+			map[string]any{"type": "output_text", "text": text, "annotations": []any{}},
+		}},
+	}); err != nil {
+		return err
+	}
+	t.nativeSyntheticBadgeEmitted = true
+	t.nativeBadgeTargetSelected = true
+	t.nativeBadgeItemID = itemID
+	t.nativeBadgeOutputIndex = 0
+	t.nativeBadgeHasOutputIndex = true
+	t.nativeBadgeContentIndex = 0
+	t.nativeBadgeHasContentIndex = true
+	t.nativeOutputIndexShift++
+	t.nativeSequenceShift += 6
+	return nil
+}
+
 func (t *ResponsesWriter) writeNativeResponsesEvent(event, delimiter []byte) error {
 	_, data := sse.ParseEvent(event)
 	eventType := ""
@@ -1169,9 +1385,17 @@ func (t *ResponsesWriter) writeNativeResponsesEvent(event, delimiter []byte) err
 		eventType = gjson.GetBytes(data, "type").Str
 		itemType = gjson.GetBytes(data, "item.type").Str
 	}
-	if eventType == "response.function_call_arguments.delta" || eventType == "response.custom_tool_call_input.delta" || (eventType == "response.output_item.added" && (itemType == "function_call" || itemType == "custom_tool_call")) || (eventType == "response.output_item.done" && (itemType == "function_call" || itemType == "custom_tool_call")) {
+	if eventType == "response.function_call_arguments.delta" || eventType == "response.custom_tool_call_input.delta" || (eventType == "response.output_item.added" && (itemType == "function_call" || itemType == "custom_tool_call" || itemType == "reasoning")) || (eventType == "response.output_item.done" && (itemType == "function_call" || itemType == "custom_tool_call")) {
 		t.sawToolCall = true
+		if err := t.emitNativeBadgeBeforeOutput(event); err != nil {
+			return err
+		}
 		if err := t.flushNativeHeldEvents(false); err != nil {
+			return err
+		}
+	}
+	if (eventType == "response.completed" || eventType == "response.incomplete") && !t.nativeBadgeTargetSelected && !t.nativeSyntheticBadgeEmitted {
+		if err := t.emitNativeBadgeBeforeOutput(event); err != nil {
 			return err
 		}
 	}

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -1184,10 +1184,8 @@ func (t *ResponsesWriter) rewriteNativeResponsesPayload(data []byte) ([]byte, bo
 	return data, false
 }
 
-// rewriteNativePassthroughFields adjusts native coordinates after a synthetic
-// badge item has been inserted ahead of the upstream output. Sequence numbers
-// are shifted so the SSE stream remains strictly monotonic; output indices are
-// shifted so tool/reasoning items retain their identity relative to the badge.
+// rewriteNativePassthroughFields shifts sequence numbers (monotonicity) and
+// output indices (item identity) after a synthetic badge item is prepended.
 func (t *ResponsesWriter) rewriteNativePassthroughFields(data []byte) ([]byte, bool) {
 	if !gjson.ValidBytes(data) {
 		return data, false
@@ -1220,9 +1218,15 @@ func (t *ResponsesWriter) rewriteNativePassthroughFields(data []byte) ([]byte, b
 			return data, changed
 		}
 	}
-	badgeItem := `{"id":"` + t.nativeBadgeItemID + `","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":` + strconv.Quote(t.computeBadgeText()) + `,"annotations":[]}]}`
+	badgeItem, err := json.Marshal(map[string]any{
+		"id": t.nativeBadgeItemID, "type": "message", "status": "completed", "role": "assistant",
+		"content": []any{map[string]any{"type": "output_text", "text": t.computeBadgeText(), "annotations": []any{}}},
+	})
+	if err != nil {
+		return data, changed
+	}
 	items := make([]string, 0, len(output.Array())+1)
-	items = append(items, badgeItem)
+	items = append(items, string(badgeItem))
 	for _, item := range output.Array() {
 		items = append(items, item.Raw)
 	}
@@ -1258,8 +1262,14 @@ func (t *ResponsesWriter) rewriteNativeNonStreamingBody(data []byte) ([]byte, bo
 		}
 	}
 	itemID := newResponsesID("msg")
-	badgeItem := `{"id":"` + itemID + `","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":` + strconv.Quote(t.computeBadgeText()) + `,"annotations":[]}]}`
-	items := []string{badgeItem}
+	badgeItem, err := json.Marshal(map[string]any{
+		"id": itemID, "type": "message", "status": "completed", "role": "assistant",
+		"content": []any{map[string]any{"type": "output_text", "text": t.computeBadgeText(), "annotations": []any{}}},
+	})
+	if err != nil {
+		return data, false
+	}
+	items := []string{string(badgeItem)}
 	for _, item := range output.Array() {
 		items = append(items, item.Raw)
 	}
@@ -1312,10 +1322,9 @@ func (t *ResponsesWriter) writeNativeEvent(eventType string, sequence int64, pay
 	return err
 }
 
-// emitNativeBadgeBeforeOutput opens a real Responses message item before the
-// first native tool/reasoning item. Native Responses streams cannot display a badge
-// without an output item, so all subsequent tool coordinates are shifted by
-// one and upstream sequence numbers by the six events emitted here.
+// emitNativeBadgeBeforeOutput prepends a badge message item to the stream.
+// Native Responses requires an output item for badge display; six events are
+// emitted and upstream coordinates shifted accordingly.
 func (t *ResponsesWriter) emitNativeBadgeBeforeOutput(event []byte) error {
 	if t.nativeSyntheticBadgeEmitted || t.nativeBadgeTargetSelected || t.computeBadgeText() == "" {
 		return nil
@@ -1385,7 +1394,8 @@ func (t *ResponsesWriter) writeNativeResponsesEvent(event, delimiter []byte) err
 		eventType = gjson.GetBytes(data, "type").Str
 		itemType = gjson.GetBytes(data, "item.type").Str
 	}
-	if eventType == "response.function_call_arguments.delta" || eventType == "response.custom_tool_call_input.delta" || (eventType == "response.output_item.added" && (itemType == "function_call" || itemType == "custom_tool_call" || itemType == "reasoning")) || (eventType == "response.output_item.done" && (itemType == "function_call" || itemType == "custom_tool_call")) {
+	toolCall := eventType == "response.function_call_arguments.delta" || eventType == "response.custom_tool_call_input.delta" || (eventType == "response.output_item.added" && (itemType == "function_call" || itemType == "custom_tool_call")) || (eventType == "response.output_item.done" && (itemType == "function_call" || itemType == "custom_tool_call"))
+	if toolCall {
 		t.sawToolCall = true
 		if err := t.emitNativeBadgeBeforeOutput(event); err != nil {
 			return err

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -670,9 +670,8 @@ func (t *ResponsesWriter) ClearPassthrough() bool {
 }
 
 // SetPassthroughBadge switches to native Responses passthrough while opting
-// into a Codex-visible routed-model badge. Existing assistant text is
-// rewritten in place; text-free turns receive a synthetic assistant message
-// before native output so Codex has a visible surface for the badge.
+// into a Codex-visible badge; text-free turns get a synthetic assistant item
+// so Codex has a visible surface for the badge.
 func (t *ResponsesWriter) SetPassthroughBadge() {
 	t.EnableCodexBadgeProvenance()
 	t.passthrough = true
@@ -1292,9 +1291,8 @@ func (t *ResponsesWriter) rewriteNativeResponsesEvent(raw []byte) []byte {
 	return t.rewriteNativeEventWith(raw, true)
 }
 
-// rewriteNativeHeldEvent re-applies badge/footer text to an event that was held
-// back for the footer decision. Coordinates were already shifted when the event
-// was first seen, and the shift is not idempotent.
+// rewriteNativeHeldEvent re-applies badge/footer to a held event without
+// re-shifting coordinates; the shift is applied once on first sight and is not idempotent.
 func (t *ResponsesWriter) rewriteNativeHeldEvent(raw []byte) []byte {
 	return t.rewriteNativeEventWith(raw, false)
 }

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -569,6 +569,66 @@ data: {"type":"response.output_text.delta","item_id":"msg_native","output_index"
 	assert.Equal(t, codexResponsesBadgeSentinelForTest+badge+"\n\nok", events[0]["delta"])
 }
 
+func TestResponsesWriter_PassthroughBadgeEmitsNativeItemForToolOnlyTurn(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5.6-sol")
+	w.SetBadgeText(passthroughTestMarker)
+	w.SetPassthroughBadge()
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(200)
+
+	native := []string{
+		`{"type":"response.created","sequence_number":0,"response":{"id":"resp_native","status":"in_progress","output":[]}}`,
+		`{"type":"response.output_item.added","sequence_number":1,"output_index":0,"item":{"id":"fc_native","type":"function_call","call_id":"call_native","name":"lookup","arguments":"","status":"in_progress"}}`,
+		`{"type":"response.function_call_arguments.delta","sequence_number":2,"item_id":"fc_native","output_index":0,"delta":"{\"x\":1}"}`,
+		`{"type":"response.output_item.done","sequence_number":3,"output_index":0,"item":{"id":"fc_native","type":"function_call","call_id":"call_native","name":"lookup","arguments":"{\"x\":1}","status":"completed"}}`,
+		`{"type":"response.completed","sequence_number":4,"response":{"id":"resp_native","status":"completed","output":[{"id":"fc_native","type":"function_call","call_id":"call_native","name":"lookup","arguments":"{\"x\":1}","status":"completed"}]}}`,
+	}
+	var stream strings.Builder
+	for _, payload := range native {
+		stream.WriteString("event: " + gjson.Get(payload, "type").Str + "\ndata: " + payload + "\n\n")
+	}
+	_, err := w.Write([]byte(stream.String()))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	events := parseSSEEvents(t, rec.Body.Bytes())
+	require.Len(t, events, len(native)+6)
+	for i, event := range events {
+		if i == 0 {
+			assert.EqualValues(t, 0, event["sequence_number"])
+			continue
+		}
+		assert.EqualValues(t, i, event["sequence_number"])
+	}
+	assert.Equal(t, "message", events[1]["item"].(map[string]any)["type"])
+	assert.Equal(t, codexResponsesBadgeSentinelForTest+passthroughTestMarker+"\n\n", events[3]["delta"])
+	assert.EqualValues(t, 0, events[1]["output_index"])
+	assert.EqualValues(t, 1, events[7]["output_index"])
+	completed := events[len(events)-1]["response"].(map[string]any)
+	output := completed["output"].([]any)
+	require.Len(t, output, 2)
+	assert.Equal(t, "message", output[0].(map[string]any)["type"])
+	assert.Equal(t, "function_call", output[1].(map[string]any)["type"])
+}
+
+func TestResponsesWriter_PassthroughBadgeRewritesNonStreamingBody(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5.6-sol")
+	w.SetBadgeText(passthroughTestMarker)
+	w.SetPassthroughBadge()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := w.Write([]byte(`{"id":"resp_native","output":[{"id":"msg_native","type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}]}`))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	output := body["output"].([]any)
+	text := output[0].(map[string]any)["content"].([]any)[0].(map[string]any)["text"]
+	assert.Equal(t, codexResponsesBadgeSentinelForTest+passthroughTestMarker+"\n\nok", text)
+}
+
 func TestResponsesWriter_PrependsRoutingMarkerBadge(t *testing.T) {
 	rec := httptest.NewRecorder()
 	w := translate.NewResponsesWriter(rec, "gpt-5.5")

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -1041,16 +1041,29 @@ func TestResponsesWriter_PassthroughReasoningThenTextKeepsBadgeAndFooter(t *test
 	require.NoError(t, w.Finalize())
 
 	events := parseSSEEvents(t, rec.Body.Bytes())
-	require.Len(t, events, len(payloads))
-	assert.Equal(t, "reasoning", events[1]["item"].(map[string]any)["type"])
+	require.Len(t, events, len(payloads)+6)
+	for i, event := range events {
+		if i == 0 {
+			assert.EqualValues(t, 0, event["sequence_number"])
+			continue
+		}
+		assert.EqualValues(t, i, event["sequence_number"], "sequence at %d", i)
+	}
+	assert.Equal(t, "message", events[1]["item"].(map[string]any)["type"])
 	assert.EqualValues(t, 0, events[1]["output_index"])
 	badge := codexResponsesBadgeSentinelForTest + passthroughTestMarker + "\n\n"
-	assert.Equal(t, badge+"ok", events[5]["delta"])
-	assert.Equal(t, badge+"ok"+footer, events[6]["text"])
+	assert.Equal(t, badge, events[3]["delta"])
+	assert.Equal(t, "reasoning", events[7]["item"].(map[string]any)["type"])
+	assert.EqualValues(t, 1, events[7]["output_index"])
+	assert.EqualValues(t, 2, events[9]["output_index"])
+	assert.Equal(t, "ok", events[11]["delta"])
+	assert.Equal(t, "ok"+footer, events[12]["text"])
 	output := events[len(events)-1]["response"].(map[string]any)["output"].([]any)
-	require.Len(t, output, 2)
-	assert.Equal(t, "reasoning", output[0].(map[string]any)["type"])
-	assert.Equal(t, badge+"ok"+footer, output[1].(map[string]any)["content"].([]any)[0].(map[string]any)["text"])
+	require.Len(t, output, 3)
+	assert.Equal(t, "message", output[0].(map[string]any)["type"])
+	assert.Equal(t, badge, output[0].(map[string]any)["content"].([]any)[0].(map[string]any)["text"])
+	assert.Equal(t, "reasoning", output[1].(map[string]any)["type"])
+	assert.Equal(t, "ok"+footer, output[2].(map[string]any)["content"].([]any)[0].(map[string]any)["text"])
 }
 
 func TestResponsesWriter_PassthroughFooterSkippedOnToolCall(t *testing.T) {

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -1009,6 +1009,50 @@ func TestResponsesWriter_PassthroughAppendsFeedbackFooter(t *testing.T) {
 	assert.Equal(t, "ok"+footer, output[0].(map[string]any)["content"].([]any)[0].(map[string]any)["text"])
 }
 
+func TestResponsesWriter_PassthroughReasoningThenTextKeepsBadgeAndFooter(t *testing.T) {
+	const footer = "\n\n_Weave Router feedback:_ `$rf +` good"
+	payloads := []string{
+		`{"type":"response.created","sequence_number":0,"response":{"id":"resp_native","status":"in_progress","output":[]}}`,
+		`{"type":"response.output_item.added","sequence_number":1,"output_index":0,"item":{"id":"rs_native","type":"reasoning","status":"in_progress","summary":[]}}`,
+		`{"type":"response.output_item.done","sequence_number":2,"output_index":0,"item":{"id":"rs_native","type":"reasoning","status":"completed","summary":[]}}`,
+		`{"type":"response.output_item.added","sequence_number":3,"output_index":1,"item":{"id":"msg_native","type":"message","role":"assistant","status":"in_progress","content":[]}}`,
+		`{"type":"response.content_part.added","sequence_number":4,"item_id":"msg_native","output_index":1,"content_index":0,"part":{"type":"output_text","text":"","annotations":[]}}`,
+		`{"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_native","output_index":1,"content_index":0,"delta":"ok"}`,
+		`{"type":"response.output_text.done","sequence_number":6,"item_id":"msg_native","output_index":1,"content_index":0,"text":"ok"}`,
+		`{"type":"response.content_part.done","sequence_number":7,"item_id":"msg_native","output_index":1,"content_index":0,"part":{"type":"output_text","text":"ok","annotations":[]}}`,
+		`{"type":"response.output_item.done","sequence_number":8,"output_index":1,"item":{"id":"msg_native","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"ok","annotations":[]}]}}`,
+		`{"type":"response.completed","sequence_number":9,"response":{"id":"resp_native","status":"completed","output":[{"id":"rs_native","type":"reasoning","status":"completed","summary":[]},{"id":"msg_native","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"ok","annotations":[]}]}]}}`,
+	}
+	var native strings.Builder
+	for _, payload := range payloads {
+		native.WriteString("event: " + gjson.Get(payload, "type").Str + "\n")
+		native.WriteString("data: " + payload + "\n\n")
+	}
+
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5.6-sol")
+	w.SetBadgeText(passthroughTestMarker)
+	w.SetFooterText(footer)
+	w.SetPassthroughBadge()
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(200)
+	_, err := w.Write([]byte(native.String()))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	events := parseSSEEvents(t, rec.Body.Bytes())
+	require.Len(t, events, len(payloads))
+	assert.Equal(t, "reasoning", events[1]["item"].(map[string]any)["type"])
+	assert.EqualValues(t, 0, events[1]["output_index"])
+	badge := codexResponsesBadgeSentinelForTest + passthroughTestMarker + "\n\n"
+	assert.Equal(t, badge+"ok", events[5]["delta"])
+	assert.Equal(t, badge+"ok"+footer, events[6]["text"])
+	output := events[len(events)-1]["response"].(map[string]any)["output"].([]any)
+	require.Len(t, output, 2)
+	assert.Equal(t, "reasoning", output[0].(map[string]any)["type"])
+	assert.Equal(t, badge+"ok"+footer, output[1].(map[string]any)["content"].([]any)[0].(map[string]any)["text"])
+}
+
 func TestResponsesWriter_PassthroughFooterSkippedOnToolCall(t *testing.T) {
 	const footer = "\n\n_Weave Router feedback:_ `$rf +` good"
 	payloads := []string{


### PR DESCRIPTION
## Summary
- inject a Codex-visible assistant marker item for native tool/reasoning-only Responses turns
- preserve native output ordering by shifting output indices and sequence numbers
- support native non-streaming Responses bodies and detect SSE when upstream omits Content-Type
- add a native Responses mock and document both real-API and deterministic local test workflows
- retain routing_marker in completion logs for passthrough diagnostics

## Verification
- `go test ./...`
- real local Codex OAuth Responses traffic against gpt-5.6-sol, including text-only and tool-only turns