### PR TITLE
Only show marker in Codex when selected model changes

### DIFF
--- a/internal/proxy/marker_internal_test.go
+++ b/internal/proxy/marker_internal_test.go
@@ -398,14 +398,11 @@ func TestHumanReasonFromPlanner_UnknownCodeIsSilenced(t *testing.T) {
 	assert.Empty(t, got)
 }
 
-func TestRoutingMarkerForOpts_AlwaysShowsStickyCodexTurn(t *testing.T) {
+func TestRoutingMarkerFor_SuppressesStickyTurnForAllClients(t *testing.T) {
 	res := turnLoopResult{
 		Decision:         router.Decision{Model: "gpt-5.6-terra", Provider: "openai"},
 		StickyHit:        true,
 		PriorServedModel: "gpt-5.6-terra",
 	}
-	assert.Empty(t, routingMarkerFor(res), "Claude Code keeps same-model suppression")
-	got := routingMarkerForOpts(res, true)
-	assert.Contains(t, got, "✦ **Weave Router** → gpt-5.6-terra")
-	assert.True(t, strings.HasSuffix(got, "\n\n"))
+	assert.Empty(t, routingMarkerFor(res), "same-model suppression applies to Codex as well as Claude Code")
 }

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -534,15 +534,9 @@ func suppressMarkerIfRequested(ctx context.Context, h http.Header, marker string
 	return marker
 }
 
-// routingMarkerFor builds the "brand → model · note" snippet emitted at the
-// start of every cross-format streamed response.
+// routingMarkerFor builds the "brand → model · note" snippet emitted when the
+// selected serving model changes (and on the first routed turn).
 func routingMarkerFor(res turnLoopResult) string {
-	return routingMarkerForOpts(res, false)
-}
-
-// routingMarkerForOpts is routingMarkerFor with an always-on switch for
-// clients (e.g. Codex) that have no persistent statusline.
-func routingMarkerForOpts(res turnLoopResult, always bool) string {
 	decision := res.Decision
 	if decision.Model == "" {
 		return ""
@@ -564,9 +558,7 @@ func routingMarkerForOpts(res turnLoopResult, always bool) string {
 	// for this turn" / "best pick for this turn" repeating each turn would
 	// otherwise be visible even when nothing switched. Hard-pin carve-outs and
 	// first-turn (empty prior) cases still flow to the sidecar marker below.
-	// Codex has no persistent statusline, so always-on keeps the badge even when
-	// the served model did not change.
-	if !always && res.PriorServedModel == res.Decision.ServedIdentity() {
+	if res.PriorServedModel == res.Decision.ServedIdentity() {
 		return ""
 	}
 	// A sidecar-supplied marker is a genuine per-turn status line (e.g.
@@ -5648,7 +5640,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	preludeBuf := newPreludeBuffer(contentSink)
 	var rootSink http.ResponseWriter = preludeBuf
 
-	marker := suppressMarkerIfRequested(ctx, r.Header, routingMarkerForOpts(routeRes, clientID.ClientApp == ClientAppCodex))
+	marker := suppressMarkerIfRequested(ctx, r.Header, routingMarkerFor(routeRes))
 	if billing.SubscriptionOnlyFromContext(ctx) {
 		// Always surface the depleted-credits warning (not gated by the
 		// routing-marker opt-out): a billing state change the caller must see.

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -534,8 +534,9 @@ func TestService_ProxyOpenAIResponses_NativeBadgeIsCodexOnlyAndHonorsSuppression
 	}
 }
 
-// A Codex turn must show the marker even when the action is tool-call-only; both
-// cases were previously invisible (debug-gated marker; badge could only ride text deltas).
+// A first Codex turn must show the marker even when the action is tool-call-only;
+// both cases were previously invisible (debug-gated marker; badge could only
+// ride text deltas).
 func TestService_ProxyOpenAIResponses_EmitsRoutingMarkerForCodex(t *testing.T) {
 	for _, tc := range []struct {
 		name     string


### PR DESCRIPTION
Codex now shares Claude Code’s switch-only routing-marker behavior. Repeated turns served by the same model stay quiet, while first-turn and genuine model-switch markers remain visible.

Tests: go test ./...