### PR TITLE
Handle upstream errors from OpenAI correctly

### DIFF
--- a/internal/proxy/dispatch_error.go
+++ b/internal/proxy/dispatch_error.go
@@ -84,6 +84,7 @@ type DispatchErrorClass struct {
 // themselves before falling through here.
 func ClassifyDispatchError(err error) (DispatchErrorClass, bool) {
 	var statusErr *providers.UpstreamStatusError
+	var bufferedErr *providers.UpstreamErrorResponse
 	var forcedExcluded *ForcedModelExcludedError
 	var forcedUnknown *ForcedModelUnknownError
 	var forcedClusterStrategy *ForcedClusterUnsupportedStrategyError
@@ -127,6 +128,15 @@ func ClassifyDispatchError(err error) (DispatchErrorClass, bool) {
 		return DispatchErrorClass{
 			Kind:    DispatchErrorUpstreamStatus,
 			Status:  statusErr.Status,
+			Message: "Upstream call failed.",
+		}, true
+	case errors.As(err, &bufferedErr):
+		// Same as UpstreamStatusError: preserve the upstream status so a
+		// buffered 429/5xx is not rewritten as a generic 502 by handlers
+		// that fall through when ClassifyDispatchError does not match.
+		return DispatchErrorClass{
+			Kind:    DispatchErrorUpstreamStatus,
+			Status:  bufferedErr.Status,
 			Message: "Upstream call failed.",
 		}, true
 	case errors.Is(err, providers.ErrNotImplemented):

--- a/internal/proxy/dispatch_error_test.go
+++ b/internal/proxy/dispatch_error_test.go
@@ -49,6 +49,16 @@ func TestClassifyDispatchError_UpstreamStatusErrorPreservesStatus(t *testing.T) 
 	assert.Equal(t, http.StatusTooManyRequests, cls.Status)
 }
 
+func TestClassifyDispatchError_UpstreamErrorResponsePreservesStatus(t *testing.T) {
+	err := &providers.UpstreamErrorResponse{Status: http.StatusTooManyRequests, Body: []byte(`{"error":{"message":"rate limited"}}`)}
+
+	cls, ok := proxy.ClassifyDispatchError(err)
+
+	require.True(t, ok)
+	assert.Equal(t, proxy.DispatchErrorUpstreamStatus, cls.Kind)
+	assert.Equal(t, http.StatusTooManyRequests, cls.Status)
+}
+
 func TestClassifyDispatchError_ClusterUnavailableRetriesAndLogsError(t *testing.T) {
 	cls, ok := proxy.ClassifyDispatchError(cluster.ErrClusterUnavailable)
 


### PR DESCRIPTION
## Summary
- preserve buffered OpenAI upstream error status codes
- return upstream 429 responses as 429 instead of rewriting them as 502
- add regression coverage for buffered rate-limit errors

## Tests
- go test ./internal/proxy ./internal/api/openai

🤖 Generated with [Weave Router](https://router.workweave.ai)