### PR TITLE
Improve Codex skill registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,10 @@ matching the Claude Code plugin's model-to-credential dispatch.
 Codex does not load third-party slash-command files, so the installer ships the
 router directives as native Codex skills: `$force-model <model-id>` (alias
 `$fm <model-id>`), `$unforce-model` (alias `$ufm`), and
-`$router-feedback <text>` (alias `$rf <text>`), each of which sends the
-leading-space prompt form (for example, ` /force-model gpt-5.6-terra`) that the
-router parses. You can type that form directly instead. Re-install
+`$router-feedback <text>` (alias `$rf <text>`). Each skill runs a local
+`scripts/emit.sh` that prints the leading-space directive (for example,
+` /force-model gpt-5.6-terra`); the router intercepts that exec output.
+You can type that form directly instead. Re-install
 and `--uninstall --codex` rewrite/remove only the managed block, leaving the
 rest of your Codex config untouched. Invoke `$disable-routing` to switch the
 next Codex session back to its normal provider, or run

--- a/README.md
+++ b/README.md
@@ -178,8 +178,9 @@ sidecar is optional. HMM and forced selections in the native Codex family
 every other selected model uses its WorkWeave deployment or BYOK credential,
 matching the Claude Code plugin's model-to-credential dispatch.
 Codex does not load third-party slash-command files, so the installer ships the
-router directives as native Codex skills: `$force-model <model-id>`,
-`$unforce-model`, and `$router-feedback <text>`, each of which sends the
+router directives as native Codex skills: `$force-model <model-id>` (alias
+`$fm <model-id>`), `$unforce-model` (alias `$ufm`), and
+`$router-feedback <text>` (alias `$rf <text>`), each of which sends the
 leading-space prompt form (for example, ` /force-model gpt-5.6-terra`) that the
 router parses. You can type that form directly instead. Re-install
 and `--uninstall --codex` rewrite/remove only the managed block, leaving the

--- a/install/README.md
+++ b/install/README.md
@@ -147,9 +147,9 @@ native Codex skill, invoked with `$`:
 
 | Skill | Sends |
 | --- | --- |
-| `$force-model <model-id>` | ` /force-model <model-id>` |
-| `$unforce-model` | ` /unforce-model` |
-| `$router-feedback <text>` | ` /router-feedback <text>` |
+| `$force-model <model-id>` / `$fm <model-id>` | ` /force-model <model-id>` |
+| `$unforce-model` / `$ufm` | ` /unforce-model` |
+| `$router-feedback <text>` / `$rf <text>` | ` /router-feedback <text>` |
 
 Each skill submits a normal prompt whose first character is one literal space,
 which is what reaches the router's directive parser. You can always type that

--- a/install/codex-skills/fm/SKILL.md
+++ b/install/codex-skills/fm/SKILL.md
@@ -5,11 +5,8 @@ description: "Alias for force-model — pin this Codex session to a specific mod
 
 <!-- weave-router managed fm skill -->
 
-When the user invokes `$fm <model-id>`, send a normal user message whose first
-character is one literal space, followed by `/force-model ` and the requested
-model id. Do not use a Codex slash command or omit the leading space. Preserve
-the model id exactly, then report the router's response.
-
-```text
- /force-model gpt-5.6-terra
-```
+When the user invokes `$fm <model-id>`, run this skill's `scripts/emit.sh`
+with the model id as arguments. Do not send a user message and do not type a
+Codex slash command. The script prints a leading-space `/force-model` line;
+the Weave Router intercepts that exec output, pins the session, and continues
+this turn. Then report the router's response.

--- a/install/codex-skills/fm/SKILL.md
+++ b/install/codex-skills/fm/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: fm
+description: "Alias for force-model — pin this Codex session to a specific model through the Weave Router."
+---
+
+<!-- weave-router managed fm skill -->
+
+When the user invokes `$fm <model-id>`, send a normal user message whose first
+character is one literal space, followed by `/force-model ` and the requested
+model id. Do not use a Codex slash command or omit the leading space. Preserve
+the model id exactly, then report the router's response.
+
+```text
+ /force-model gpt-5.6-terra
+```

--- a/install/codex-skills/fm/SKILL.md
+++ b/install/codex-skills/fm/SKILL.md
@@ -5,8 +5,11 @@ description: "Alias for force-model — pin this Codex session to a specific mod
 
 <!-- weave-router managed fm skill -->
 
-When the user invokes `$fm <model-id>`, run this skill's `scripts/emit.sh`
-with the model id as arguments. Do not send a user message and do not type a
-Codex slash command. The script prints a leading-space `/force-model` line;
-the Weave Router intercepts that exec output, pins the session, and continues
-this turn. Then report the router's response.
+When the user invokes `$fm <model-id>`, run this skill's `scripts/emit.sh` using the
+absolute path shown in this skill's `<path>` (its directory + `/scripts/emit.sh`).
+Pass the model id as arguments, quoted as a single argument list.
+Do not send a user message and do not type a Codex slash command.
+
+The script prints a leading-space `/force-model` line. The Weave Router reads that
+exec output, pins the session, and continues this turn — so run the script once and
+do not repeat its output as your answer. Then report the router's response.

--- a/install/codex-skills/fm/scripts/emit.sh
+++ b/install/codex-skills/fm/scripts/emit.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Alias of force-model/scripts/emit.sh
+set -euo pipefail
+if [ "$#" -eq 0 ] || [ -z "${1:-}" ]; then
+  echo "usage: emit.sh <model-id>" >&2
+  exit 1
+fi
+printf ' /force-model %s\n' "$*"

--- a/install/codex-skills/force-model/SKILL.md
+++ b/install/codex-skills/force-model/SKILL.md
@@ -5,8 +5,11 @@ description: "Pin this Codex session to a specific model through the Weave Route
 
 <!-- weave-router managed force-model skill -->
 
-When the user invokes `$force-model <model-id>` (or `$fm`), run this skill's
-`scripts/emit.sh` with the model id as arguments. Do not send a user message
-and do not type a Codex slash command. The script prints a leading-space
-`/force-model` line; the Weave Router intercepts that exec output, pins the
-session, and continues this turn. Then report the router's response.
+When the user invokes `$force-model <model-id>` (or `$fm`), run this skill's `scripts/emit.sh` using the
+absolute path shown in this skill's `<path>` (its directory + `/scripts/emit.sh`).
+Pass the model id as arguments, quoted as a single argument list.
+Do not send a user message and do not type a Codex slash command.
+
+The script prints a leading-space `/force-model` line. The Weave Router reads that
+exec output, pins the session, and continues this turn — so run the script once and
+do not repeat its output as your answer. Then report the router's response.

--- a/install/codex-skills/force-model/SKILL.md
+++ b/install/codex-skills/force-model/SKILL.md
@@ -5,10 +5,8 @@ description: "Pin this Codex session to a specific model through the Weave Route
 
 <!-- weave-router managed force-model skill -->
 
-When the user invokes `$force-model <model-id>` (or asks to use the `$fm` alias), send a normal user message whose first character is one literal space, followed by `/force-model ` and the requested model id. Do not use a Codex slash command and do not omit the leading space. For example, send exactly:
-
-```text
- /force-model gpt-5.6-terra
-```
-
-Preserve any model id exactly as provided. Report the router's response after it returns.
+When the user invokes `$force-model <model-id>` (or `$fm`), run this skill's
+`scripts/emit.sh` with the model id as arguments. Do not send a user message
+and do not type a Codex slash command. The script prints a leading-space
+`/force-model` line; the Weave Router intercepts that exec output, pins the
+session, and continues this turn. Then report the router's response.

--- a/install/codex-skills/force-model/scripts/emit.sh
+++ b/install/codex-skills/force-model/scripts/emit.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Print a leading-space /force-model directive. Codex runs this via exec;
+# the Weave Router intercepts the tool output and pins the session.
+set -euo pipefail
+if [ "$#" -eq 0 ] || [ -z "${1:-}" ]; then
+  echo "usage: emit.sh <model-id>" >&2
+  exit 1
+fi
+printf ' /force-model %s\n' "$*"

--- a/install/codex-skills/rf/SKILL.md
+++ b/install/codex-skills/rf/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: rf
+description: "Alias for router-feedback — submit feedback about a Weave Router decision or model performance."
+---
+
+<!-- weave-router managed rf skill -->
+
+When the user invokes `$rf <feedback>`, send a normal user message whose first
+character is one literal space, followed by `/router-feedback ` and the
+feedback text. Do not use a Codex slash command or omit the leading space.
+Preserve the feedback text exactly, then report the router's response.
+
+```text
+ /router-feedback the selected model struggled with this task
+```

--- a/install/codex-skills/rf/SKILL.md
+++ b/install/codex-skills/rf/SKILL.md
@@ -5,9 +5,11 @@ description: "Alias for router-feedback — submit feedback about a Weave Router
 
 <!-- weave-router managed rf skill -->
 
-When the user invokes `$rf <feedback>`, run this skill's `scripts/emit.sh`
-with the feedback text as arguments. Do not send a user message and do not
-type a Codex slash command. The script prints a leading-space
-`/router-feedback` line; the Weave Router intercepts that exec output,
-records the feedback, and continues this turn. Then report the router's
-response.
+When the user invokes `$rf <feedback>`, run this skill's `scripts/emit.sh` using the
+absolute path shown in this skill's `<path>` (its directory + `/scripts/emit.sh`).
+Pass the feedback text as arguments, quoted as a single argument list.
+Do not send a user message and do not type a Codex slash command.
+
+The script prints a leading-space `/router-feedback` line. The Weave Router reads that
+exec output, records the feedback, and continues this turn — so run the script once and
+do not repeat its output as your answer. Then report the router's response.

--- a/install/codex-skills/rf/SKILL.md
+++ b/install/codex-skills/rf/SKILL.md
@@ -5,11 +5,9 @@ description: "Alias for router-feedback — submit feedback about a Weave Router
 
 <!-- weave-router managed rf skill -->
 
-When the user invokes `$rf <feedback>`, send a normal user message whose first
-character is one literal space, followed by `/router-feedback ` and the
-feedback text. Do not use a Codex slash command or omit the leading space.
-Preserve the feedback text exactly, then report the router's response.
-
-```text
- /router-feedback the selected model struggled with this task
-```
+When the user invokes `$rf <feedback>`, run this skill's `scripts/emit.sh`
+with the feedback text as arguments. Do not send a user message and do not
+type a Codex slash command. The script prints a leading-space
+`/router-feedback` line; the Weave Router intercepts that exec output,
+records the feedback, and continues this turn. Then report the router's
+response.

--- a/install/codex-skills/rf/scripts/emit.sh
+++ b/install/codex-skills/rf/scripts/emit.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$#" -eq 0 ] || [ -z "${1:-}" ]; then
+  echo "usage: emit.sh <feedback>" >&2
+  exit 1
+fi
+printf ' /router-feedback %s\n' "$*"

--- a/install/codex-skills/router-feedback/SKILL.md
+++ b/install/codex-skills/router-feedback/SKILL.md
@@ -5,10 +5,9 @@ description: "Submit feedback about a Weave Router decision or model performance
 
 <!-- weave-router managed router-feedback skill -->
 
-When the user invokes `$router-feedback <feedback>` (or asks to use the `$rf` alias), send a normal user message whose first character is one literal space, followed by `/router-feedback ` and the feedback text. Do not use a Codex slash command and do not omit the leading space. Preserve the feedback text exactly. For example:
-
-```text
- /router-feedback the selected model struggled with this task
-```
-
-Report the router's response after it returns.
+When the user invokes `$router-feedback <feedback>` (or `$rf`), run this
+skill's `scripts/emit.sh` with the feedback text as arguments. Do not send a
+user message and do not type a Codex slash command. The script prints a
+leading-space `/router-feedback` line; the Weave Router intercepts that exec
+output, records the feedback, and continues this turn. Then report the
+router's response.

--- a/install/codex-skills/router-feedback/SKILL.md
+++ b/install/codex-skills/router-feedback/SKILL.md
@@ -5,9 +5,11 @@ description: "Submit feedback about a Weave Router decision or model performance
 
 <!-- weave-router managed router-feedback skill -->
 
-When the user invokes `$router-feedback <feedback>` (or `$rf`), run this
-skill's `scripts/emit.sh` with the feedback text as arguments. Do not send a
-user message and do not type a Codex slash command. The script prints a
-leading-space `/router-feedback` line; the Weave Router intercepts that exec
-output, records the feedback, and continues this turn. Then report the
-router's response.
+When the user invokes `$router-feedback <feedback>` (or `$rf`), run this skill's `scripts/emit.sh` using the
+absolute path shown in this skill's `<path>` (its directory + `/scripts/emit.sh`).
+Pass the feedback text as arguments, quoted as a single argument list.
+Do not send a user message and do not type a Codex slash command.
+
+The script prints a leading-space `/router-feedback` line. The Weave Router reads that
+exec output, records the feedback, and continues this turn — so run the script once and
+do not repeat its output as your answer. Then report the router's response.

--- a/install/codex-skills/router-feedback/scripts/emit.sh
+++ b/install/codex-skills/router-feedback/scripts/emit.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Print a leading-space /router-feedback directive. Codex runs this via exec;
+# the Weave Router intercepts the tool output and records the feedback.
+set -euo pipefail
+if [ "$#" -eq 0 ] || [ -z "${1:-}" ]; then
+  echo "usage: emit.sh <feedback>" >&2
+  exit 1
+fi
+printf ' /router-feedback %s\n' "$*"

--- a/install/codex-skills/ufm/SKILL.md
+++ b/install/codex-skills/ufm/SKILL.md
@@ -5,10 +5,8 @@ description: "Alias for unforce-model — clear the active Weave Router model pi
 
 <!-- weave-router managed ufm skill -->
 
-When the user invokes `$ufm`, send a normal user message whose first character
-is one literal space, followed by `/unforce-model`. Do not use a Codex slash
-command or omit the leading space. Then report the router's response.
-
-```text
- /unforce-model
-```
+When the user invokes `$ufm`, run this skill's `scripts/emit.sh`. Do not send
+a user message and do not type a Codex slash command. The script prints a
+leading-space `/unforce-model` line; the Weave Router intercepts that exec
+output, clears the pin, and continues this turn. Then report the router's
+response.

--- a/install/codex-skills/ufm/SKILL.md
+++ b/install/codex-skills/ufm/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: ufm
+description: "Alias for unforce-model — clear the active Weave Router model pin."
+---
+
+<!-- weave-router managed ufm skill -->
+
+When the user invokes `$ufm`, send a normal user message whose first character
+is one literal space, followed by `/unforce-model`. Do not use a Codex slash
+command or omit the leading space. Then report the router's response.
+
+```text
+ /unforce-model
+```

--- a/install/codex-skills/ufm/SKILL.md
+++ b/install/codex-skills/ufm/SKILL.md
@@ -5,8 +5,10 @@ description: "Alias for unforce-model — clear the active Weave Router model pi
 
 <!-- weave-router managed ufm skill -->
 
-When the user invokes `$ufm`, run this skill's `scripts/emit.sh`. Do not send
-a user message and do not type a Codex slash command. The script prints a
-leading-space `/unforce-model` line; the Weave Router intercepts that exec
-output, clears the pin, and continues this turn. Then report the router's
-response.
+When the user invokes `$ufm`, run this skill's `scripts/emit.sh` using the
+absolute path shown in this skill's `<path>` (its directory + `/scripts/emit.sh`).
+Do not send a user message and do not type a Codex slash command.
+
+The script prints a leading-space `/unforce-model` line. The Weave Router reads that
+exec output, clears the pin, and continues this turn — so run the script once and
+do not repeat its output as your answer. Then report the router's response.

--- a/install/codex-skills/ufm/scripts/emit.sh
+++ b/install/codex-skills/ufm/scripts/emit.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+printf ' /unforce-model\n'

--- a/install/codex-skills/unforce-model/SKILL.md
+++ b/install/codex-skills/unforce-model/SKILL.md
@@ -5,8 +5,10 @@ description: "Clear the active Weave Router model pin for this Codex session."
 
 <!-- weave-router managed unforce-model skill -->
 
-When the user invokes `$unforce-model` (or `$ufm`), run this skill's
-`scripts/emit.sh`. Do not send a user message and do not type a Codex slash
-command. The script prints a leading-space `/unforce-model` line; the Weave
-Router intercepts that exec output, clears the pin, and continues this turn.
-Then report the router's response.
+When the user invokes `$unforce-model` (or `$ufm`), run this skill's `scripts/emit.sh` using the
+absolute path shown in this skill's `<path>` (its directory + `/scripts/emit.sh`).
+Do not send a user message and do not type a Codex slash command.
+
+The script prints a leading-space `/unforce-model` line. The Weave Router reads that
+exec output, clears the pin, and continues this turn — so run the script once and
+do not repeat its output as your answer. Then report the router's response.

--- a/install/codex-skills/unforce-model/SKILL.md
+++ b/install/codex-skills/unforce-model/SKILL.md
@@ -5,10 +5,8 @@ description: "Clear the active Weave Router model pin for this Codex session."
 
 <!-- weave-router managed unforce-model skill -->
 
-When the user invokes `$unforce-model` (or asks to use the `$ufm` alias), send a normal user message whose first character is one literal space, followed by `/unforce-model`. Do not use a Codex slash command and do not omit the leading space. Send exactly:
-
-```text
- /unforce-model
-```
-
-Report the router's response after it returns.
+When the user invokes `$unforce-model` (or `$ufm`), run this skill's
+`scripts/emit.sh`. Do not send a user message and do not type a Codex slash
+command. The script prints a leading-space `/unforce-model` line; the Weave
+Router intercepts that exec output, clears the pin, and continues this turn.
+Then report the router's response.

--- a/install/codex-skills/unforce-model/scripts/emit.sh
+++ b/install/codex-skills/unforce-model/scripts/emit.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Print a leading-space /unforce-model directive for the Weave Router.
+set -euo pipefail
+printf ' /unforce-model\n'

--- a/install/install.sh
+++ b/install/install.sh
@@ -2796,11 +2796,12 @@ install_codex_disable_routing_skill() {
   ok "Codex skill installed: \$disable-routing"
 }
 
-# Install prompt directives as Codex-native skills. The skill itself emits a
-# leading-space normal prompt, which is the only portable way to reach the
-# router directive parser without claiming Codex's reserved slash namespace.
+# Install prompt directives as Codex-native skills. Codex cannot append a
+# user message from a skill, so each skill ships scripts/emit.sh. Codex
+# execs that script; the router intercepts the leading-space directive in
+# the tool output without claiming Codex's reserved slash namespace.
 install_codex_prompt_skills() {
-  local canonical skill_src dst_dir dst_file scope_args body
+  local canonical skill_src dst_dir dst_file emit_src emit_dst scope_args body
   while IFS= read -r canonical; do
     skill_src="$script_dir/codex-skills/$canonical/SKILL.md"
     [ -f "$skill_src" ] || continue
@@ -2826,6 +2827,20 @@ install_codex_prompt_skills() {
     body="$(<"$skill_src")"
     body="${body//\{\{SCOPE\}\}/$scope_args}"
     printf '%s\n' "$body" >"$dst_file"
+    emit_src="$script_dir/codex-skills/$canonical/scripts/emit.sh"
+    if [ -f "$emit_src" ]; then
+      mkdir -p "$dst_dir/scripts"
+      emit_dst="$dst_dir/scripts/emit.sh"
+      if [ "$scope" = "project" ] || [ -n "$install_dir" ]; then
+        refuse_if_symlink "$dst_dir/scripts"
+        refuse_if_symlink "$emit_dst"
+      elif [ -L "$dst_dir/scripts" ] || [ -L "$emit_dst" ]; then
+        warn "Codex skill script path contains a symlink; leaving $canonical emit.sh untouched."
+      else
+        cp "$emit_src" "$emit_dst"
+        chmod +x "$emit_dst"
+      fi
+    fi
     ok "Codex skill installed: \$$canonical"
   done <<EOF
 $(weave_registry_skill_names codex)

--- a/install/install.sh
+++ b/install/install.sh
@@ -1429,6 +1429,7 @@ weave_registry_skill_names() {
       cursor) [ "$cursor" = yes ] || continue ;;
     esac
     printf '%s\n' "$canonical"
+    [ -n "$aliases" ] && printf '%s\n' "$aliases" | tr ',' '\n'
   done <<EOF
 $(weave_registry_rows)
 EOF
@@ -1448,6 +1449,7 @@ weave_registry_skill_assets() {
       cursor) [ "$cursor" = yes ] || continue ;;
     esac
     printf '%s\n' "$canonical"
+    [ -n "$aliases" ] && printf '%s\n' "$aliases" | tr ',' '\n'
   done <<EOF
 $(weave_registry_rows)
 EOF

--- a/install/npm/README.md
+++ b/install/npm/README.md
@@ -102,10 +102,13 @@ Four install targets:
   The block lives between begin/end markers
   so re-running the installer rewrites it cleanly and `--uninstall --codex`
   removes it without touching the rest of your config. Codex does not load
-  third-party slash-command files; to send a router directive, type it with
-  one leading space (for example, ` /force-model gpt-5.6-terra`). Its
-  `$disable-routing` skill returns the next Codex session to the default
-  provider without logging out or deleting the router configuration.
+  third-party slash-command files; the installer provides native skills
+  `$force-model` (`$fm`), `$unforce-model` (`$ufm`), and
+  `$router-feedback` (`$rf`). They send the same leading-space directives as
+  Claude Code (for example, ` /force-model gpt-5.6-terra`), and you can type
+  that form directly. Its `$disable-routing` skill returns the next Codex
+  session to the default provider without logging out or deleting the router
+  configuration.
 - **opencode** (`--opencode`) — merges a `provider.weave` entry (backed by
   opencode's built-in `@ai-sdk/anthropic` provider) into
   `~/.config/opencode/opencode.json` (or `<repo>/opencode.json` with

--- a/install/npm/README.md
+++ b/install/npm/README.md
@@ -104,9 +104,10 @@ Four install targets:
   removes it without touching the rest of your config. Codex does not load
   third-party slash-command files; the installer provides native skills
   `$force-model` (`$fm`), `$unforce-model` (`$ufm`), and
-  `$router-feedback` (`$rf`). They send the same leading-space directives as
-  Claude Code (for example, ` /force-model gpt-5.6-terra`), and you can type
-  that form directly. Its `$disable-routing` skill returns the next Codex
+  `$router-feedback` (`$rf`). Each skill execs a local `scripts/emit.sh` that
+  prints the same leading-space directive Claude Code uses (for example,
+  ` /force-model gpt-5.6-terra`); the router intercepts that tool output.
+  You can type that form directly. Its `$disable-routing` skill returns the next Codex
   session to the default provider without logging out or deleting the router
   configuration.
 - **opencode** (`--opencode`) — merges a `provider.weave` entry (backed by

--- a/install/npm/scripts/copy-installer.js
+++ b/install/npm/scripts/copy-installer.js
@@ -44,9 +44,9 @@ for (const f of readdirSync(commandsSrc)) {
   console.log(`Copied commands/${f}.`);
 }
 
-// Codex discovers local skills under $CODEX_HOME/skills. Bundle the one
-// installer-owned template explicitly, refusing a source symlink just as the
-// command-file packaging path above does.
+// Codex discovers local skills under $CODEX_HOME/skills. Bundle the
+// installer-owned local-toggle template explicitly, refusing a source symlink
+// just as the command-file packaging path above does.
 const codexSkillSrc = path.join(installDir, "codex-skills", "disable-routing", "SKILL.md");
 const codexSkillDst = path.join(root, "codex-skills", "disable-routing", "SKILL.md");
 if (lstatSync(codexSkillSrc).isSymbolicLink()) {
@@ -74,13 +74,15 @@ for (const line of registryText.split(/\r?\n/)) {
   if (!line || line.startsWith("#")) continue;
   const fields = line.split("|");
   if (fields[2] !== "prompt" || fields[4] !== "yes") continue;
-  const name = fields[0];
-  const src = path.join(installDir, "codex-skills", name, "SKILL.md");
-  const dst = path.join(root, "codex-skills", name, "SKILL.md");
-  if (!lstatSync(src) || lstatSync(src).isSymbolicLink()) throw new Error(`Invalid Codex skill: ${src}`);
-  mkdirSync(path.dirname(dst), { recursive: true });
-  copyFileSync(src, dst);
-  console.log(`Copied codex-skills/${name}/SKILL.md.`);
+  const names = [fields[0], ...(fields[1] || "").split(",").filter(Boolean)];
+  for (const name of names) {
+    const src = path.join(installDir, "codex-skills", name, "SKILL.md");
+    const dst = path.join(root, "codex-skills", name, "SKILL.md");
+    if (lstatSync(src).isSymbolicLink()) throw new Error(`Invalid Codex skill: ${src}`);
+    mkdirSync(path.dirname(dst), { recursive: true });
+    copyFileSync(src, dst);
+    console.log(`Copied codex-skills/${name}/SKILL.md.`);
+  }
 }
 
 // installer and the pi-router extension: pi loads it via the "pi.extensions"

--- a/install/npm/scripts/copy-installer.js
+++ b/install/npm/scripts/copy-installer.js
@@ -82,6 +82,20 @@ for (const line of registryText.split(/\r?\n/)) {
     mkdirSync(path.dirname(dst), { recursive: true });
     copyFileSync(src, dst);
     console.log(`Copied codex-skills/${name}/SKILL.md.`);
+    const emitSrc = path.join(installDir, "codex-skills", name, "scripts", "emit.sh");
+    const emitDst = path.join(root, "codex-skills", name, "scripts", "emit.sh");
+    try {
+      if (lstatSync(emitSrc).isSymbolicLink()) throw new Error(`Invalid Codex skill script: ${emitSrc}`);
+      mkdirSync(path.dirname(emitDst), { recursive: true });
+      copyFileSync(emitSrc, emitDst);
+      chmodSync(emitDst, 0o755);
+      console.log(`Copied codex-skills/${name}/scripts/emit.sh.`);
+    } catch (err) {
+      if (err && err.code === "ENOENT") {
+        throw new Error(`Codex skill ${name} is missing scripts/emit.sh`);
+      }
+      throw err;
+    }
   }
 }
 

--- a/install/registry.sh
+++ b/install/registry.sh
@@ -58,6 +58,7 @@ weave_registry_skill_names() {
       cursor) [ "$cursor" = yes ] || continue ;;
     esac
     printf '%s\n' "$canonical"
+    [ -n "$aliases" ] && printf '%s\n' "$aliases" | tr ',' '\n'
   done <<EOF
 $(weave_registry_rows)
 EOF
@@ -77,6 +78,7 @@ weave_registry_skill_assets() {
       cursor) [ "$cursor" = yes ] || continue ;;
     esac
     printf '%s\n' "$canonical"
+    [ -n "$aliases" ] && printf '%s\n' "$aliases" | tr ',' '\n'
   done <<EOF
 $(weave_registry_rows)
 EOF

--- a/install/tests/codex_install_test.sh
+++ b/install/tests/codex_install_test.sh
@@ -112,6 +112,10 @@ for alias in fm ufm rf; do
   grep -Fq "<!-- weave-router managed $alias skill -->" "$alias_skill" \
     || fail "Codex \$$alias skill has no ownership marker"
 done
+for name in force-model fm unforce-model ufm router-feedback rf; do
+  emit="$home/.codex/skills/$name/scripts/emit.sh"
+  [ -x "$emit" ] || fail "Codex \$$name skill is missing an executable emit.sh"
+done
 if HOME="$home" PATH="$test_path" NO_COLOR=1 bash "$installer" disable-routing --claude --scope user --quiet >/dev/null 2>&1; then
   fail "disable-routing accepted a non-Codex target"
 fi
@@ -131,6 +135,10 @@ run_hosted_install
 
 run_uninstall
 [ ! -e "$skill" ] || fail "uninstall did not remove the Codex disable-routing skill"
+for name in force-model fm unforce-model ufm router-feedback rf; do
+  [ ! -e "$home/.codex/skills/$name" ] \
+    || fail "uninstall left the Codex \$$name skill directory behind"
+done
 
 # A same-named user skill is not ours to overwrite or remove. This also
 # covers an upgrade on a machine where the name was already taken.

--- a/install/tests/codex_install_test.sh
+++ b/install/tests/codex_install_test.sh
@@ -105,6 +105,13 @@ grep -Fq '<!-- weave-router managed disable-routing skill -->' "$skill" \
   || fail "Codex disable-routing skill has no ownership marker"
 grep -Fq 'weave-router off --codex' "$skill" \
   || fail "Codex disable-routing skill does not use the safe off toggle"
+
+for alias in fm ufm rf; do
+  alias_skill="$home/.codex/skills/$alias/SKILL.md"
+  [ -f "$alias_skill" ] || fail "Codex \$$alias skill was not installed"
+  grep -Fq "<!-- weave-router managed $alias skill -->" "$alias_skill" \
+    || fail "Codex \$$alias skill has no ownership marker"
+done
 if HOME="$home" PATH="$test_path" NO_COLOR=1 bash "$installer" disable-routing --claude --scope user --quiet >/dev/null 2>&1; then
   fail "disable-routing accepted a non-Codex target"
 fi

--- a/install/tests/packaging_test.sh
+++ b/install/tests/packaging_test.sh
@@ -97,7 +97,7 @@ HOME="$home" PATH="$home/bin:$PATH" WEAVE_ROUTER_KEY="rk_test_key" NO_COLOR=1 \
 
 installed="$(cd "$home/.codex/skills" 2>/dev/null && ls -d */ 2>/dev/null | tr -d '/' | sort | tr '\n' ' ' | sed 's/ $//')"
 check "the packed entrypoint installs every Codex skill" \
-  "disable-routing force-model router-feedback unforce-model" "$installed"
+  "disable-routing fm force-model rf router-feedback ufm unforce-model" "$installed"
 
 HOME="$home" PATH="$home/bin:$PATH" WEAVE_ROUTER_KEY="rk_test_key" NO_COLOR=1 \
   node "$root/bin.js" --claude --scope user --quiet --base-url http://127.0.0.1:9 >/dev/null 2>&1 || true

--- a/install/tests/registry_test.sh
+++ b/install/tests/registry_test.sh
@@ -210,17 +210,20 @@ check "codex user install writes a skill per supported directive" \
 check "codex install writes no prompt wrappers" "" \
   "$(ls "$cx_home/.codex/prompts" 2>/dev/null | tr '\n' ' ' | sed 's/ $//')"
 
-# The Codex skills must instruct the leading-space normal prompt: Codex
+# A Codex skill cannot author a user message, so each one execs emit.sh, whose
+# output carries the leading-space directive the router intercepts. Codex
 # reserves `/…` for its own built-ins, so a bare slash never reaches the router.
 for name in force-model unforce-model router-feedback fm ufm rf; do
-  skill="$cx_home/.codex/skills/$name/SKILL.md"
+  emit="$cx_home/.codex/skills/$name/scripts/emit.sh"
   case "$name" in
     fm) command=force-model ;; ufm) command=unforce-model ;; rf) command=router-feedback ;; *) command="$name" ;;
   esac
-  if grep -qF " /$command" "$skill"; then
-    ok "codex \$$name expands to a leading-space directive"
+  if [ -x "$emit" ] && [ "$(bash "$emit" probe-arg)" = " /$command probe-arg" ] 2>/dev/null; then
+    ok "codex \$$name emits a leading-space directive"
+  elif [ -x "$emit" ] && [ "$(bash "$emit")" = " /$command" ] 2>/dev/null; then
+    ok "codex \$$name emits a leading-space directive"
   else
-    no "codex \$$name expands to a leading-space directive" "a literal leading space" "$(grep -m1 "/$name" "$skill")"
+    no "codex \$$name emits a leading-space directive" " /$command" "$( [ -x "$emit" ] && bash "$emit" probe-arg 2>&1 || echo 'no executable emit.sh')"
   fi
 done
 

--- a/install/tests/registry_test.sh
+++ b/install/tests/registry_test.sh
@@ -206,15 +206,18 @@ cx_home="$work/codex-user"; mkdir -p "$cx_home"
 run_install "$cx_home" --codex --scope user
 codex_skills="$(cd "$cx_home/.codex/skills" && ls -d */ 2>/dev/null | tr -d '/' | sort | tr '\n' ' ' | sed 's/ $//')"
 check "codex user install writes a skill per supported directive" \
-  "disable-routing force-model router-feedback unforce-model" "$codex_skills"
+  "disable-routing fm force-model rf router-feedback ufm unforce-model" "$codex_skills"
 check "codex install writes no prompt wrappers" "" \
   "$(ls "$cx_home/.codex/prompts" 2>/dev/null | tr '\n' ' ' | sed 's/ $//')"
 
 # The Codex skills must instruct the leading-space normal prompt: Codex
 # reserves `/…` for its own built-ins, so a bare slash never reaches the router.
-for name in force-model unforce-model router-feedback; do
+for name in force-model unforce-model router-feedback fm ufm rf; do
   skill="$cx_home/.codex/skills/$name/SKILL.md"
-  if grep -qF " /$name" "$skill"; then
+  case "$name" in
+    fm) command=force-model ;; ufm) command=unforce-model ;; rf) command=router-feedback ;; *) command="$name" ;;
+  esac
+  if grep -qF " /$command" "$skill"; then
     ok "codex \$$name expands to a leading-space directive"
   else
     no "codex \$$name expands to a leading-space directive" "a literal leading space" "$(grep -m1 "/$name" "$skill")"

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -582,6 +582,13 @@ EOF
         if grep -Fq "<!-- weave-router managed $canonical skill -->" "$skill_file"; then
           rm -f "$skill_file"
           ok "Removed $skill_file"
+          # The prompt skills also ship scripts/emit.sh; leaving it behind
+          # strands a directory Codex still advertises as a skill.
+          emit_file="$skill_dir/scripts/emit.sh"
+          if [ ! -L "$skill_dir/scripts" ] && [ ! -L "$emit_file" ] && [ -f "$emit_file" ]; then
+            rm -f "$emit_file"
+            rmdir "$skill_dir/scripts" 2>/dev/null || true
+          fi
         else
           warn "Leaving user-owned Codex skill at $skill_file untouched."
         fi

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -96,6 +96,7 @@ weave_registry_skill_names() {
       cursor) [ "$cursor" = yes ] || continue ;;
     esac
     printf '%s\n' "$canonical"
+    [ -n "$aliases" ] && printf '%s\n' "$aliases" | tr ',' '\n'
   done <<EOF
 $(weave_registry_rows)
 EOF
@@ -115,6 +116,7 @@ weave_registry_skill_assets() {
       cursor) [ "$cursor" = yes ] || continue ;;
     esac
     printf '%s\n' "$canonical"
+    [ -n "$aliases" ] && printf '%s\n' "$aliases" | tr ',' '\n'
   done <<EOF
 $(weave_registry_rows)
 EOF

--- a/internal/proxy/router_feedback.go
+++ b/internal/proxy/router_feedback.go
@@ -66,9 +66,9 @@ const (
 	RouterFeedbackSourceAuto = "auto"
 )
 
-// handleRouterFeedbackCommand persists a /router-feedback submission, emits a
-// router.feedback.command span on the standard OTel pipeline, and returns a
-// synthetic acknowledgment without dispatching to any upstream.
+// handleRouterFeedbackCommand persists a /router-feedback submission and emits
+// a router.feedback.command span. User-issued commands receive a synthetic
+// acknowledgment; agent-issued tool-result commands continue through routing.
 func (s *Service) handleRouterFeedbackCommand(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -77,6 +77,7 @@ func (s *Service) handleRouterFeedbackCommand(
 	installationID uuid.UUID,
 	sessionKey [sessionpin.SessionKeyLen]byte,
 	inputTokens int,
+	synthetic bool,
 ) error {
 	log := observability.FromContext(ctx)
 	role := roleForTier(catalog.TierFor(env.Model()))
@@ -90,7 +91,10 @@ func (s *Service) handleRouterFeedbackCommand(
 		if env.SourceFormat() == translate.FormatOpenAI {
 			msg = "Weave Router: router-feedback needs a verdict or a note, e.g. /rf+ or /rf- too slow."
 		}
-		return writeSyntheticCommandResponse(w, env, msg, inputTokens)
+		if synthetic {
+			return writeSyntheticCommandResponse(w, env, msg, inputTokens)
+		}
+		return nil
 	}
 
 	// The model to attribute: pin's last served (or target), overridden by the resolved telemetry turn when a sequence was specified.
@@ -107,7 +111,10 @@ func (s *Service) handleRouterFeedbackCommand(
 				if env.SourceFormat() == translate.FormatOpenAI {
 					msg = "Weave Router: No turn found at that sequence number. Try `/rf` without a number for the last turn."
 				}
-				return writeSyntheticCommandResponse(w, env, msg, inputTokens)
+				if synthetic {
+					return writeSyntheticCommandResponse(w, env, msg, inputTokens)
+				}
+				return nil
 			}
 			// Infrastructure error: log it, fall through to the pin path so the
 			// rating is persisted with the pin's servedModel rather than dropped.
@@ -236,7 +243,10 @@ func (s *Service) handleRouterFeedbackCommand(
 		"route_id", telemetryRouteID,
 	)
 
-	return writeSyntheticCommandResponse(w, env, routerFeedbackAck(env.SourceFormat(), rating), inputTokens)
+	if synthetic {
+		return writeSyntheticCommandResponse(w, env, routerFeedbackAck(env.SourceFormat(), rating), inputTokens)
+	}
+	return nil
 }
 
 func (s *Service) reportRouterFeedback(

--- a/internal/proxy/router_feedback_proxy_test.go
+++ b/internal/proxy/router_feedback_proxy_test.go
@@ -614,6 +614,31 @@ func TestService_RouterFeedbackCommand_OpenAIIngress(t *testing.T) {
 	assert.Contains(t, content, "Feedback recorded")
 }
 
+func TestService_RouterFeedbackCommand_AgentToolResultContinuesRouting(t *testing.T) {
+	const body = `{
+		"model":"claude-sonnet-4-6",
+		"max_tokens":1024,
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","id":"toolu_skill","name":"exec","input":{}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_skill","content":" /router-feedback too slow"}]}
+		]
+	}`
+	store := newFakePinStore()
+	feedback := &fakeFeedbackStore{}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-6", Reason: "cluster"}}
+	svc := newPinSvc(fr, store).WithRouterFeedbackStore(feedback)
+
+	ctx := authedCtx(uuid.NewString())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(body), rec, httpReq))
+
+	assert.Equal(t, 1, fr.routeCalls, "agent-issued feedback must continue into an agent turn")
+	require.Len(t, feedback.events, 1)
+	assert.Equal(t, "too slow", feedback.events[0].Feedback)
+	assert.NotContains(t, rec.Body.String(), "Feedback recorded", "agent-issued feedback must not terminate with a synthetic ack")
+}
+
 func TestService_RouterFeedbackCommand_EmptyFeedbackAsksForText(t *testing.T) {
 	const body = `{
 		"model":"claude-sonnet-4-6",

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2730,11 +2730,14 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	if !agentShadowMode {
 		if cmd, hasCmd := env.ExtractRouterFeedbackCommand(); hasCmd {
 			log.Info("ProxyMessages router-feedback command")
-			if err := s.handleRouterFeedbackCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens); err != nil {
+			if err := s.handleRouterFeedbackCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens, !cmd.FromToolResult); err != nil {
 				return err
 			}
-			s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
-			return nil
+			if !cmd.FromToolResult {
+				s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
+				return nil
+			}
+			requestBodyChanged = true
 		}
 	}
 
@@ -5326,11 +5329,14 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	}
 	if cmd, hasCmd := env.ExtractRouterFeedbackCommand(); hasCmd {
 		log.Info("ProxyOpenAIChatCompletion router-feedback command")
-		if err := s.handleRouterFeedbackCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens); err != nil {
+		if err := s.handleRouterFeedbackCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens, !cmd.FromToolResult); err != nil {
 			return err
 		}
-		s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
-		return nil
+		if !cmd.FromToolResult {
+			s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
+			return nil
+		}
+		requestBodyChanged = true
 	}
 
 	// Sanitize after command extraction: a skill can encode its command as a
@@ -6228,6 +6234,10 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 	codexNativeRequest := codexResponsesRequest(ctx, r.Header)
 	nativeBody := conversion.OriginalBody
 	if clientAppCodex {
+		nativeBody, err = translate.StripRouterCommandsFromResponsesInput(nativeBody)
+		if err != nil {
+			return fmt.Errorf("strip Responses router command: %w", err)
+		}
 		// Codex records response.output_item.done as conversation history and
 		// sends it back in the next native request. Remove only the badge this
 		// client opted into so router text never reaches the selected model.

--- a/internal/translate/force_model.go
+++ b/internal/translate/force_model.go
@@ -236,7 +236,9 @@ func followsAssistantToolUse(messages []gjson.Result, userIdx int) bool {
 }
 
 // parseForceModelCommand scans text for a /force-model (alias /fm) or
-// /unforce-model (alias /ufm) directive on the first non-empty line.
+// /unforce-model (alias /ufm) directive on the first non-empty line. The
+// dollar-prefixed forms are accepted for clients whose native skill namespace
+// is `$` (notably Codex) when they forward the token verbatim.
 // Restricted to the leading line so pasted content (snippets, transcripts)
 // starting with "/" can't silently rewrite session routing. The short
 // aliases are a fallback for clients without local slash-command expansion
@@ -263,7 +265,7 @@ func parseForceModelCommand(text string) (res ForceModelResult, found bool, stri
 		if trimmed == "" {
 			continue
 		}
-		if after, ok := cutAnyPrefix(trimmed, "/force-model ", "/fm "); ok {
+		if after, ok := cutAnyPrefix(trimmed, "/force-model ", "/fm ", "$force-model ", "$fm "); ok {
 			// Fields+Join collapses runs of whitespace so "/fm  qwen   3.8"
 			// and "/fm qwen 3.8" are the same string to the resolver.
 			if name := strings.Join(strings.Fields(after), " "); name != "" {
@@ -271,7 +273,7 @@ func parseForceModelCommand(text string) (res ForceModelResult, found bool, stri
 				found = true
 				cmdIdx = i
 			}
-		} else if trimmed == "/unforce-model" || trimmed == "/ufm" {
+		} else if trimmed == "/unforce-model" || trimmed == "/ufm" || trimmed == "$unforce-model" || trimmed == "$ufm" {
 			res = ForceModelResult{Clear: true}
 			found = true
 			cmdIdx = i
@@ -279,6 +281,32 @@ func parseForceModelCommand(text string) (res ForceModelResult, found bool, stri
 		break
 	}
 	if !found {
+		// Codex's local exec tool returns a two-part result whose first part is
+		// an execution preamble ("Script completed … Output:") and whose second
+		// part is the skill's leading-space directive. The Responses projection
+		// joins those parts, so inspect only the first non-empty output line;
+		// skill documentation printed by exec can contain command examples.
+		if strings.HasPrefix(strings.TrimSpace(text), "Script completed") {
+			lines := strings.Split(text, "\n")
+			for i, line := range lines {
+				if strings.TrimSpace(line) != "Output:" {
+					continue
+				}
+				for i++; i < len(lines); i++ {
+					if strings.TrimSpace(lines[i]) == "" {
+						continue
+					}
+					candidate, ok, _ := parseForceModelCommand(lines[i])
+					if !ok {
+						break
+					}
+					remaining := append([]string{}, lines[:i]...)
+					remaining = append(remaining, lines[i+1:]...)
+					return candidate, true, strings.TrimSpace(strings.Join(remaining, "\n"))
+				}
+				break
+			}
+		}
 		return ForceModelResult{}, false, text
 	}
 	remaining := make([]string, 0, len(lines))

--- a/internal/translate/force_model.go
+++ b/internal/translate/force_model.go
@@ -281,11 +281,9 @@ func parseForceModelCommand(text string) (res ForceModelResult, found bool, stri
 		break
 	}
 	if !found {
-		// Codex's local exec tool returns a two-part result whose first part is
-		// an execution preamble ("Script completed … Output:") and whose second
-		// part is the skill's leading-space directive. The Responses projection
-		// joins those parts, so inspect only the first non-empty output line;
-		// skill documentation printed by exec can contain command examples.
+		// Codex's exec tool joins a "Script completed … Output:" preamble with
+		// the skill directive; check only the first non-empty output line so
+		// command examples in skill docs don't trigger parsing.
 		if strings.HasPrefix(strings.TrimSpace(text), "Script completed") {
 			lines := strings.Split(text, "\n")
 			for i, line := range lines {

--- a/internal/translate/force_model_test.go
+++ b/internal/translate/force_model_test.go
@@ -168,7 +168,7 @@ func TestParseForceModelCommand_ForceModel(t *testing.T) {
 }
 
 func TestParseForceModelCommand_UnforceModel(t *testing.T) {
-	for _, input := range []string{"/unforce-model", "/ufm"} {
+	for _, input := range []string{"/unforce-model", "/ufm", "$unforce-model", "$ufm"} {
 		t.Run(input, func(t *testing.T) {
 			env, err := translate.ParseAnthropic(buildAnthropicBody(t, input))
 			require.NoError(t, err)
@@ -179,6 +179,52 @@ func TestParseForceModelCommand_UnforceModel(t *testing.T) {
 			assert.Empty(t, res.Model)
 		})
 	}
+}
+
+func TestExtractForceModelCommand_DollarAliases(t *testing.T) {
+	for _, input := range []string{"$force-model gpt-5", "$fm gpt-5"} {
+		t.Run(input, func(t *testing.T) {
+			env, err := translate.ParseAnthropic(buildAnthropicBody(t, input))
+			require.NoError(t, err)
+			res, found := env.ExtractForceModelCommand()
+			require.True(t, found)
+			assert.Equal(t, "gpt-5", res.Model)
+		})
+	}
+}
+
+func TestExtractForceModelCommand_CodexExecPreamble(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "gpt-5.6-sol",
+		"messages": []any{
+			map[string]any{"role": "assistant", "tool_calls": []any{map[string]any{
+				"id": "call_skill", "type": "function", "function": map[string]any{"name": "exec", "arguments": "{}"},
+			}}},
+			map[string]any{"role": "tool", "tool_call_id": "call_skill", "content": "Script completed\nWall time: 0.0 seconds\nOutput:\n /force-model gpt-5"},
+		},
+	})
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	res, found := env.ExtractForceModelCommand()
+	require.True(t, found)
+	assert.True(t, res.FromToolResult)
+	assert.Equal(t, "gpt-5", res.Model)
+}
+
+func TestExtractForceModelCommand_CodexExecDocumentationIsNotCommand(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "gpt-5.6-sol",
+		"messages": []any{
+			map[string]any{"role": "assistant", "tool_calls": []any{map[string]any{
+				"id": "call_skill", "type": "function", "function": map[string]any{"name": "exec", "arguments": "{}"},
+			}}},
+			map[string]any{"role": "tool", "tool_call_id": "call_skill", "content": "Script completed\nOutput:\n---\nname: force-model\n```text\n /force-model gpt-5\n```"},
+		},
+	})
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	_, found := env.ExtractForceModelCommand()
+	assert.False(t, found, "a command example in exec output must not pin the session")
 }
 
 func TestExtractForceModelCommand_OpenAIFormat(t *testing.T) {

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -432,6 +432,72 @@ func StripFeedbackFooterFromResponsesInput(body []byte) ([]byte, error) {
 	return out, nil
 }
 
+// StripRouterCommandsFromResponsesInput removes router directives emitted by a
+// local agent tool from function-call output items. Codex executes its skills
+// through a tool and returns the resulting leading-space command as the tool
+// output; forwarding that text verbatim makes the upstream repeat the command
+// instead of continuing the agent turn.
+func StripRouterCommandsFromResponsesInput(body []byte) ([]byte, error) {
+	input := gjson.GetBytes(body, "input")
+	if !input.IsArray() {
+		return body, nil
+	}
+	out := body
+	changed := false
+	for itemIndex, item := range input.Array() {
+		typ := item.Get("type").Str
+		if typ != "function_call_output" && typ != "custom_tool_call_output" {
+			continue
+		}
+		output := item.Get("output")
+		if output.Type == gjson.String {
+			stripped, found := stripRouterCommandText(output.Str)
+			if !found {
+				continue
+			}
+			var err error
+			out, err = sjson.SetBytes(out, "input."+strconv.Itoa(itemIndex)+".output", stripped)
+			if err != nil {
+				return nil, fmt.Errorf("strip router command from Responses tool output: %w", err)
+			}
+			changed = true
+			continue
+		}
+		if !output.IsArray() {
+			continue
+		}
+		for partIndex, part := range output.Array() {
+			if part.Get("type").Str != "input_text" {
+				continue
+			}
+			stripped, found := stripRouterCommandText(part.Get("text").Str)
+			if !found {
+				continue
+			}
+			var err error
+			out, err = sjson.SetBytes(out, "input."+strconv.Itoa(itemIndex)+".output."+strconv.Itoa(partIndex)+".text", stripped)
+			if err != nil {
+				return nil, fmt.Errorf("strip router command from Responses tool output part: %w", err)
+			}
+			changed = true
+		}
+	}
+	if !changed {
+		return body, nil
+	}
+	return out, nil
+}
+
+func stripRouterCommandText(text string) (string, bool) {
+	if _, found, stripped := parseForceModelCommand(text); found {
+		return stripped, true
+	}
+	if _, found, stripped := parseRouterFeedbackCommand(text); found {
+		return stripped, true
+	}
+	return text, false
+}
+
 // responsesContentHasBody reports whether a content array carries anything
 // beyond the (now stripped) part at skipIndex. Non-text parts always count.
 func responsesContentHasBody(content gjson.Result, skipIndex int) bool {

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -432,10 +432,8 @@ func StripFeedbackFooterFromResponsesInput(body []byte) ([]byte, error) {
 	return out, nil
 }
 
-// StripRouterCommandsFromResponsesInput removes router directives emitted by a
-// local agent tool from function-call output items. Codex executes its skills
-// through a tool and returns the resulting leading-space command as the tool
-// output; forwarding that text verbatim makes the upstream repeat the command
+// StripRouterCommandsFromResponsesInput removes router directives from
+// function-call output items so the upstream doesn't repeat them verbatim
 // instead of continuing the agent turn.
 func StripRouterCommandsFromResponsesInput(body []byte) ([]byte, error) {
 	input := gjson.GetBytes(body, "input")

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -240,6 +240,21 @@ func TestStripRoutingBadgeFromResponsesInput_PreservesNativeFields(t *testing.T)
 	assert.True(t, root.Get("metadata.keep").Bool())
 }
 
+func TestStripRouterCommandsFromResponsesInput_RemovesAgentToolCommand(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","input":[{"type":"custom_tool_call_output","call_id":"call_skill","output":" /router-feedback too slow"},{"type":"function_call_output","call_id":"call_fm","output":[{"type":"input_text","text":" /force-model gpt-5"}]}]}`)
+	out, err := translate.StripRouterCommandsFromResponsesInput(body)
+	require.NoError(t, err)
+	assert.Equal(t, "", gjson.GetBytes(out, "input.0.output").String())
+	assert.Equal(t, "", gjson.GetBytes(out, "input.1.output.0.text").String())
+}
+
+func TestStripRouterCommandsFromResponsesInput_RemovesCollapsedExecCommand(t *testing.T) {
+	body := []byte(`{"input":[{"type":"function_call_output","call_id":"call_skill","output":"Script completed\nOutput:\n /force-model gpt-5"}]}`)
+	out, err := translate.StripRouterCommandsFromResponsesInput(body)
+	require.NoError(t, err)
+	assert.Equal(t, "Script completed\nOutput:", gjson.GetBytes(out, "input.0.output").String())
+}
+
 // A tool-call-only or reasoning-only turn ships a badge-only assistant message.
 // Stripping it in place would leave a blank assistant shell ahead of the real
 // function_call, which providers reject.

--- a/internal/translate/router_feedback.go
+++ b/internal/translate/router_feedback.go
@@ -126,10 +126,8 @@ func parseRouterFeedbackCommand(text string) (res RouterFeedbackResult, found bo
 
 	rating, inline, ok := matchRouterFeedbackCommand(first)
 	if !ok {
-		// Codex's exec tool prefixes a second output part with execution
-		// metadata ("Script completed … Output:"). Responses conversion joins
-		// those parts, so inspect only the first non-empty output line; skill
-		// documentation printed by exec can contain command examples.
+		// Codex's exec tool joins a "Script completed … Output:" preamble with
+		// the skill directive; check only the first non-empty output line.
 		if strings.HasPrefix(strings.TrimSpace(text), "Script completed") {
 			lines := strings.Split(text, "\n")
 			for i, line := range lines {

--- a/internal/translate/router_feedback.go
+++ b/internal/translate/router_feedback.go
@@ -20,6 +20,10 @@ type RouterFeedbackResult struct {
 	// Sequence is an optional leading turn-selector: 0 = last turn (default),
 	// positive = absolute 1-based index, negative = relative offset from last (e.g. -3).
 	Sequence int
+	// FromToolResult is true when an agent emitted the directive through a tool
+	// result. Those commands should continue the agent turn after recording
+	// feedback instead of ending it with a synthetic response.
+	FromToolResult bool
 }
 
 // RouterFeedbackRatingUp and RouterFeedbackRatingDown are the canonical
@@ -39,21 +43,21 @@ var RouterFeedbackLabels = map[string]struct{}{
 	"maximum":  {},
 }
 
-// ExtractRouterFeedbackCommand scans the last user-role message in env for a
-// /router-feedback <text> directive. When found, it strips the command line
-// from env.body and returns the feedback text. A bare /router-feedback with
-// no text still matches (found=true, empty Feedback) so the handler can ack
-// with usage guidance instead of forwarding the command to an upstream model.
-// Returns (zero, false) when no command is present.
+// ExtractRouterFeedbackCommand scans the trailing user/tool-result message in
+// env for a /router-feedback <text> directive. When found, it strips the
+// command from env.body and returns the feedback text. A bare command still
+// matches (found=true, empty Feedback) so user-issued commands can receive
+// usage guidance. Returns (zero, false) when no command is present.
 func (env *RequestEnvelope) ExtractRouterFeedbackCommand() (RouterFeedbackResult, bool) {
 	var res RouterFeedbackResult
-	found := env.extractLeadingCommand(func(text string) (bool, string) {
+	found, fromToolResult := env.extractLeadingCommandWithSource(func(text string) (bool, string) {
 		r, ok, stripped := parseRouterFeedbackCommand(text)
 		if ok {
 			res = r
 		}
 		return ok, stripped
 	})
+	res.FromToolResult = found && fromToolResult
 	return res, found
 }
 
@@ -106,9 +110,11 @@ func (env *RequestEnvelope) StripRouterFeedbackArtifacts() int {
 // directive on the first non-empty line, applying the same leading-line +
 // injected-prefix guards as parseForceModelCommand (see that function for the
 // rationale; the router-side alias serves clients without local slash-command
-// expansion). Unlike /force-model, everything after the command — same line
-// AND following lines — is the feedback payload, so the whole body is
-// consumed and the stripped output keeps only the injected prefix.
+// expansion). Codex exec results get a narrow exception for their known
+// "Script completed" preamble. Unlike /force-model, everything after the
+// command — same line AND following lines — is the feedback payload, so the
+// whole body is consumed and the stripped output keeps only the injected
+// prefix.
 func parseRouterFeedbackCommand(text string) (res RouterFeedbackResult, found bool, stripped string) {
 	prefixEnd := leadingInjectedPrefixEnd(text)
 	prefix := text[:prefixEnd]
@@ -120,6 +126,32 @@ func parseRouterFeedbackCommand(text string) (res RouterFeedbackResult, found bo
 
 	rating, inline, ok := matchRouterFeedbackCommand(first)
 	if !ok {
+		// Codex's exec tool prefixes a second output part with execution
+		// metadata ("Script completed … Output:"). Responses conversion joins
+		// those parts, so inspect only the first non-empty output line; skill
+		// documentation printed by exec can contain command examples.
+		if strings.HasPrefix(strings.TrimSpace(text), "Script completed") {
+			lines := strings.Split(text, "\n")
+			for i, line := range lines {
+				if strings.TrimSpace(line) != "Output:" {
+					continue
+				}
+				for i++; i < len(lines); i++ {
+					if strings.TrimSpace(lines[i]) == "" {
+						continue
+					}
+					candidate, found, _ := parseRouterFeedbackCommand(lines[i])
+					if !found {
+						break
+					}
+					remaining := append([]string{}, lines[:i]...)
+					remaining = append(remaining, lines[i+1:]...)
+					candidate.FromToolResult = false
+					return candidate, true, strings.TrimSpace(strings.Join(remaining, "\n"))
+				}
+				break
+			}
+		}
 		return RouterFeedbackResult{}, false, text
 	}
 

--- a/internal/translate/router_feedback_test.go
+++ b/internal/translate/router_feedback_test.go
@@ -346,6 +346,60 @@ func TestExtractRouterFeedbackCommand_OpenAIFormat(t *testing.T) {
 	assert.Equal(t, "", lastOpenAIUserMessageText(t, env))
 }
 
+func TestExtractRouterFeedbackCommand_ToolResultContinuesAgentTurn(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "gpt-5.6-sol",
+		"messages": []any{
+			map[string]any{"role": "assistant", "tool_calls": []any{map[string]any{
+				"id": "call_skill", "type": "function", "function": map[string]any{"name": "exec", "arguments": "{}"},
+			}}},
+			map[string]any{"role": "tool", "tool_call_id": "call_skill", "content": " /router-feedback too slow"},
+		},
+	})
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+
+	res, found := env.ExtractRouterFeedbackCommand()
+	require.True(t, found)
+	assert.True(t, res.FromToolResult)
+	assert.Equal(t, "too slow", res.Feedback)
+	assert.Equal(t, "", lastOpenAIUserMessageText(t, env))
+}
+
+func TestExtractRouterFeedbackCommand_CodexExecPreamble(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "gpt-5.6-sol",
+		"messages": []any{
+			map[string]any{"role": "assistant", "tool_calls": []any{map[string]any{
+				"id": "call_skill", "type": "function", "function": map[string]any{"name": "exec", "arguments": "{}"},
+			}}},
+			map[string]any{"role": "tool", "tool_call_id": "call_skill", "content": "Script completed\nWall time: 0.0 seconds\nOutput:\n /router-feedback too slow"},
+		},
+	})
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	res, found := env.ExtractRouterFeedbackCommand()
+	require.True(t, found)
+	assert.True(t, res.FromToolResult)
+	assert.Equal(t, "too slow", res.Feedback)
+}
+
+func TestExtractRouterFeedbackCommand_CodexExecDocumentationIsNotCommand(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "gpt-5.6-sol",
+		"messages": []any{
+			map[string]any{"role": "assistant", "tool_calls": []any{map[string]any{
+				"id": "call_skill", "type": "function", "function": map[string]any{"name": "exec", "arguments": "{}"},
+			}}},
+			map[string]any{"role": "tool", "tool_call_id": "call_skill", "content": "Script completed\nOutput:\n---\nname: router-feedback\n```text\n /router-feedback too slow\n```"},
+		},
+	})
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	_, found := env.ExtractRouterFeedbackCommand()
+	assert.False(t, found, "a command example in exec output must not record feedback")
+}
+
 func TestExtractRouterFeedbackCommand_ArrayContentMultipleTextBlocks(t *testing.T) {
 	// Claude Code splits slash-command turns into an injected-tags block plus
 	// the typed directive; the parser must scan every text block.


### PR DESCRIPTION
## Summary

Bring Codex's router-directive UX to parity with Claude Code's.

- Register Codex aliases `$fm`, `$ufm`, and `$rf` alongside the canonical skills.
- **Emit directives from a skill script instead of asking Codex to fake a user message.** A Codex skill is prompt text — it cannot append a `role: user` message or restart the turn. The old skills instructed Codex to "send a normal user message whose first character is one literal space", which has no corresponding capability. In session `01a046f1` the model improvised `text(" /router-feedback …")`, producing a `custom_tool_call_output` that was never parsed as a command; it eventually returned the directive as its final answer. Each prompt skill now ships `scripts/emit.sh`, which Codex execs and which prints the leading-space directive; the router's exec-output parser picks the command out of the tool result.
- Handle agent-issued force-model and router-feedback tool results without terminating the agent turn.
- Sanitize router directives from native Codex Responses passthrough.
- Installer copies and `chmod +x`es the emit scripts; uninstall removes them so a skill dir isn't left without its `SKILL.md`.
- Add installer, packaging, parser, proxy, and regression coverage.

## Verification

- `go test ./...` — pass
- `bash install/tests/registry_test.sh` — 45 passed, 0 failed
- `bash install/tests/packaging_test.sh` — 16 passed, 0 failed
- `bash install/tests/codex_install_test.sh` — pass
- `git diff --check` — clean

Not yet verified against a live Codex CLI session; the emit-script path is covered by the parser/installer tests only.