### PR TITLE
Allow non-Anthropic models to use ToolSearch

### DIFF
--- a/internal/translate/claudecode_tool_filter.go
+++ b/internal/translate/claudecode_tool_filter.go
@@ -7,19 +7,17 @@ import (
 
 // claudeCodeOnlyToolNames is the set of tools Claude Code (the client)
 // implements internally — Task subagent dispatch, plan-mode toggles, Skill
-// invocation, etc. They have no corresponding server-side behavior in any
-// upstream provider, so emitting their schemas to non-Anthropic models is
-// pure noise; worse, non-Anthropic models routinely hallucinate calls to
-// them. On the v0.57 SWE-bench Verified eval, 224 phantom tool_use blocks
-// for these names were observed across 150 router shards routed to
-// non-Anthropic upstreams — 96% of them in the Task* family — with 27%
-// clustering on the empty-patch failure subset.
+// invocation, deferred tool loading, etc. Most have no useful behavior for a
+// non-Anthropic model unless explicitly allowed by one of the subsets below.
+// Emitting the rest is noise; worse, non-Anthropic models routinely
+// hallucinate calls to them. On the v0.57 SWE-bench Verified eval, 224 phantom
+// tool_use blocks for these names were observed across 150 router shards
+// routed to non-Anthropic upstreams — 96% of them in the Task* family — with
+// 27% clustering on the empty-patch failure subset.
 //
-// Anthropic models recognize these as native sub-tools and dispatch them
-// correctly via the client; non-Anthropic models cannot. The filter applies
-// only on Anthropic→non-Anthropic emit paths (buildOpenAIFromAnthropic and
-// the Anthropic case of PrepareGemini). The Anthropic→Anthropic passthrough
-// preserves them.
+// The filter applies only on Anthropic→non-Anthropic emit paths
+// (buildOpenAIFromAnthropic and the Anthropic case of PrepareGemini). The
+// Anthropic→Anthropic passthrough preserves them.
 //
 // Scheduling / wake-up tools (ScheduleWakeup, CronCreate/Delete/List, Monitor)
 // and shell-session tools (BashOutput, KillShell) are client-executed like
@@ -44,8 +42,8 @@ var claudeCodeOnlyToolNames = map[string]struct{}{
 	"Skill":           {},
 	"Workflow":        {},
 	"AskUserQuestion": {},
-	// Tool registry / deferred-loading discovery (Anthropic-native protocol;
-	// non-Anthropic emit drops defer_loading anyway, so ToolSearch is noise).
+	// Client-side deferred MCP schema loader. Claude Code sends deferred tool
+	// names in the prompt and exposes ToolSearch as the only way to load one.
 	"ToolSearch": {},
 	// Todo bookkeeping that non-Anthropic models invent.
 	"TodoWrite": {},
@@ -64,9 +62,9 @@ var claudeCodeOnlyToolNames = map[string]struct{}{
 }
 
 // isClaudeCodeOnlyTool reports whether name is one of the tools Claude Code
-// dispatches internally and that should not be forwarded to non-Anthropic
-// upstreams. Names are compared case-sensitively because Claude Code emits
-// them in PascalCase verbatim.
+// dispatches internally and that requires an explicit cross-vendor policy.
+// Names are compared case-sensitively because Claude Code emits them in
+// PascalCase verbatim.
 func isClaudeCodeOnlyTool(name string) bool {
 	_, ok := claudeCodeOnlyToolNames[name]
 	return ok
@@ -98,11 +96,27 @@ func isCrossVendorOrchestrationTool(name string) bool {
 	return ok
 }
 
+// claudeCodeAlwaysKeptToolNames is the subset of claudeCodeOnlyToolNames that
+// must survive every cross-vendor emit. These tools are executed by the client
+// and are required for capabilities advertised in the request itself.
+var claudeCodeAlwaysKeptToolNames = map[string]struct{}{
+	"ToolSearch": {},
+}
+
+func isAlwaysKeptCrossVendorTool(name string) bool {
+	_, ok := claudeCodeAlwaysKeptToolNames[name]
+	return ok
+}
+
 // shouldStripCCTool reports whether a tool must be dropped from a cross-vendor
-// emit. Non-CC-only tools are always kept. CC-only tools are dropped, except
-// that orchestration tools are retained when keepOrchestration is set.
+// emit. Non-CC-only tools and the always-kept client tools are retained.
+// Other CC-only tools are dropped, except that orchestration tools are
+// retained when keepOrchestration is set.
 func shouldStripCCTool(name string, keepOrchestration bool) bool {
 	if !isClaudeCodeOnlyTool(name) {
+		return false
+	}
+	if isAlwaysKeptCrossVendorTool(name) {
 		return false
 	}
 	if keepOrchestration && isCrossVendorOrchestrationTool(name) {
@@ -116,8 +130,10 @@ func shouldStripCCTool(name string, keepOrchestration bool) bool {
 // body unchanged when none match, so callers can apply this unconditionally
 // without paying a re-serialize cost on the common case.
 //
-// When keepOrchestration is set, the orchestration subset (Task*, Workflow,
-// Skill, plan-mode) is retained; other CC-only tools are still dropped.
+// ToolSearch is always retained because it is Claude Code's client-side
+// loader for deferred MCP schemas. When keepOrchestration is set, the
+// orchestration subset (Task*, Workflow, Skill, plan-mode) is also retained;
+// other CC-only tools are still dropped.
 //
 // Only the tools array is rewritten; tool_choice and message content are
 // left alone. tool_choice is rare and Anthropic only honors "any"/"auto"/

--- a/internal/translate/claudecode_tool_filter_internal_test.go
+++ b/internal/translate/claudecode_tool_filter_internal_test.go
@@ -13,6 +13,14 @@ func TestOrchestrationToolsAreSubsetOfCCOnly(t *testing.T) {
 	}
 }
 
+func TestAlwaysKeptToolsAreSubsetOfCCOnly(t *testing.T) {
+	for name := range claudeCodeAlwaysKeptToolNames {
+		if !isClaudeCodeOnlyTool(name) {
+			t.Errorf("always-kept tool %q is not in claudeCodeOnlyToolNames; the subset invariant is broken", name)
+		}
+	}
+}
+
 func TestShouldStripCCTool(t *testing.T) {
 	cases := []struct {
 		name              string
@@ -24,6 +32,8 @@ func TestShouldStripCCTool(t *testing.T) {
 		{"NotebookEdit", false, false},   // coding tool: never stripped
 		{"ScheduleWakeup", false, false}, // scheduling: never stripped
 		{"CronCreate", false, false},     // scheduling: never stripped
+		{"CronDelete", false, false},     // scheduling: never stripped
+		{"CronList", false, false},       // scheduling: never stripped
 		{"Monitor", true, false},         // scheduling: never stripped
 		{"BashOutput", false, false},     // shell session: never stripped
 		{"KillShell", true, false},       // shell session: never stripped
@@ -34,7 +44,8 @@ func TestShouldStripCCTool(t *testing.T) {
 		{"ExitPlanMode", true, false},    // orchestration: kept when flag on
 		{"UpdatePlan", true, false},      // orchestration: kept when flag on
 		{"AskUserQuestion", true, true},  // CC-only non-orchestration: stripped even when flag on
-		{"ToolSearch", true, true},       // CC-only non-orchestration: stripped even when flag on
+		{"ToolSearch", false, false},     // deferred MCP loader: always kept
+		{"ToolSearch", true, false},      // independent of the orchestration flag
 		{"TodoWrite", false, true},       // CC-only non-orchestration: stripped
 		{"SendMessage", true, true},      // CC-only subagent messaging: stripped even when flag on
 	}

--- a/internal/translate/claudecode_tool_filter_test.go
+++ b/internal/translate/claudecode_tool_filter_test.go
@@ -3,6 +3,7 @@ package translate_test
 import (
 	"encoding/json"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -71,6 +72,23 @@ func emittedGeminiToolNames(t *testing.T, body []byte) []string {
 	return out
 }
 
+// emittedResponsesToolNames extracts flat function-tool names from an OpenAI
+// Responses request body.
+func emittedResponsesToolNames(t *testing.T, body []byte) []string {
+	t.Helper()
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(body, &doc))
+	raw, _ := doc["tools"].([]any)
+	out := make([]string, 0, len(raw))
+	for _, r := range raw {
+		tool, _ := r.(map[string]any)
+		if name, _ := tool["name"].(string); name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
 // claudeCodeMixedToolBody is a representative Anthropic request body carrying
 // coding + scheduling tools interleaved with CC-only control-plane tools.
 const claudeCodeMixedToolBody = `{
@@ -85,6 +103,8 @@ const claudeCodeMixedToolBody = `{
 		{"name":"NotebookEdit","description":"nb","input_schema":{"type":"object"}},
 		{"name":"ScheduleWakeup","description":"loop wake","input_schema":{"type":"object"}},
 		{"name":"CronCreate","description":"cron","input_schema":{"type":"object"}},
+		{"name":"CronDelete","description":"cron","input_schema":{"type":"object"}},
+		{"name":"CronList","description":"cron","input_schema":{"type":"object"}},
 		{"name":"Monitor","description":"watch","input_schema":{"type":"object"}},
 		{"name":"BashOutput","description":"bg out","input_schema":{"type":"object"}},
 		{"name":"KillShell","description":"bg kill","input_schema":{"type":"object"}},
@@ -101,16 +121,28 @@ const claudeCodeMixedToolBody = `{
 		{"name":"Workflow","description":"","input_schema":{"type":"object"}},
 		{"name":"AskUserQuestion","description":"","input_schema":{"type":"object"}},
 		{"name":"ToolSearch","description":"","input_schema":{"type":"object"}},
-		{"name":"TodoWrite","description":"","input_schema":{"type":"object"}}
+		{"name":"TodoWrite","description":"","input_schema":{"type":"object"}},
+		{"name":"PushNotification","description":"","input_schema":{"type":"object"}},
+		{"name":"RemoteTrigger","description":"","input_schema":{"type":"object"}},
+		{"name":"EnterWorktree","description":"","input_schema":{"type":"object"}},
+		{"name":"ExitWorktree","description":"","input_schema":{"type":"object"}},
+		{"name":"LSP","description":"","input_schema":{"type":"object"}},
+		{"name":"ListMcpResourcesTool","description":"","input_schema":{"type":"object"}},
+		{"name":"ReadMcpResourceTool","description":"","input_schema":{"type":"object"}},
+		{"name":"ListMcpResources","description":"","input_schema":{"type":"object"}},
+		{"name":"ListMcpResourceTemplates","description":"","input_schema":{"type":"object"}},
+		{"name":"ReadMcpResource","description":"","input_schema":{"type":"object"}}
 	],
 	"max_tokens":256
 }`
 
 // keptOnNonAnthropicDefault are tools that survive Anthropic→non-Anthropic emit
-// when KeepCrossVendorOrchestrationTools is off: coding + scheduling + shell session.
+// when KeepCrossVendorOrchestrationTools is off: coding, scheduling, shell
+// session, and the client-side deferred-tool loader.
 var keptOnNonAnthropicDefault = []string{
 	"Read", "Edit", "Write", "Bash", "NotebookEdit",
-	"ScheduleWakeup", "CronCreate", "Monitor", "BashOutput", "KillShell",
+	"ScheduleWakeup", "CronCreate", "CronDelete", "CronList", "Monitor", "BashOutput", "KillShell",
+	"ToolSearch",
 }
 
 func TestStripCCTools_AnthropicSourceOpenAITarget_DropsCCOnlyKeepsReal(t *testing.T) {
@@ -126,7 +158,14 @@ func TestStripCCTools_AnthropicSourceOpenAITarget_DropsCCOnlyKeepsReal(t *testin
 	assert.NotContains(t, names, "Task")
 	assert.NotContains(t, names, "Agent")
 	assert.NotContains(t, names, "SendMessage")
-	assert.NotContains(t, names, "ToolSearch")
+	assert.Contains(t, names, "ToolSearch")
+	for _, name := range []string{
+		"AskUserQuestion", "PushNotification", "RemoteTrigger", "EnterWorktree",
+		"ExitWorktree", "LSP", "ListMcpResourcesTool", "ReadMcpResourceTool",
+		"ListMcpResources", "ListMcpResourceTemplates", "ReadMcpResource", "TodoWrite",
+	} {
+		assert.NotContains(t, names, name)
+	}
 }
 
 func TestStripCCTools_AnthropicSourceGeminiTarget_DropsCCOnlyKeepsReal(t *testing.T) {
@@ -170,12 +209,14 @@ func TestStripCCTools_AnthropicSourceAnthropicTarget_KeepsCCOnly(t *testing.T) {
 	assert.Contains(t, got, "ScheduleWakeup")
 	assert.Contains(t, got, "CronCreate")
 	assert.Contains(t, got, "NotebookEdit")
+	assert.Contains(t, got, "ToolSearch", "Anthropic passthrough must preserve the deferred-tool loader")
 	assert.Contains(t, got, "Read", "real coding tools must also survive on passthrough")
 }
 
 func TestKeepOrchestrationTools_OpenAITarget_KeepsOrchestrationDropsRest(t *testing.T) {
-	// Flag on: orchestration tools survive; other CC-only tools (AskUserQuestion,
-	// ToolSearch) are still stripped. Scheduling/NotebookEdit are not CC-only.
+	// Flag on: orchestration tools survive; ToolSearch survives independently;
+	// other CC-only tools are still stripped. Scheduling/NotebookEdit are not
+	// CC-only.
 	env, err := translate.ParseAnthropic([]byte(claudeCodeMixedToolBody))
 	require.NoError(t, err)
 
@@ -188,13 +229,14 @@ func TestKeepOrchestrationTools_OpenAITarget_KeepsOrchestrationDropsRest(t *test
 	names := emittedToolNames(t, out.Body)
 	assert.ElementsMatch(t, []string{
 		"Read", "Edit", "Write", "Bash", "NotebookEdit",
-		"ScheduleWakeup", "CronCreate", "Monitor", "BashOutput", "KillShell",
+		"ScheduleWakeup", "CronCreate", "CronDelete", "CronList", "Monitor", "BashOutput", "KillShell",
 		"Task", "Agent", "TaskCreate", "TaskUpdate", "TaskList",
 		"EnterPlanMode", "ExitPlanMode", "UpdatePlan", "Skill", "Workflow",
+		"ToolSearch",
 	}, names, "orchestration + scheduling tools survive when the flag is on")
 	assert.NotContains(t, names, "SendMessage", "non-orchestration CC-only tools stay stripped")
 	assert.NotContains(t, names, "AskUserQuestion", "non-orchestration CC-only tools stay stripped")
-	assert.NotContains(t, names, "ToolSearch")
+	assert.Contains(t, names, "ToolSearch")
 	assert.NotContains(t, names, "TodoWrite")
 }
 
@@ -240,13 +282,58 @@ func TestKeepOrchestrationTools_GeminiTarget_KeepsOrchestrationDropsRest(t *test
 	names := emittedGeminiToolNames(t, out.Body)
 	assert.ElementsMatch(t, []string{
 		"Read", "Edit", "Write", "Bash", "NotebookEdit",
-		"ScheduleWakeup", "CronCreate", "Monitor", "BashOutput", "KillShell",
+		"ScheduleWakeup", "CronCreate", "CronDelete", "CronList", "Monitor", "BashOutput", "KillShell",
 		"Task", "Agent", "TaskCreate", "TaskUpdate", "TaskList",
 		"EnterPlanMode", "ExitPlanMode", "UpdatePlan", "Skill", "Workflow",
+		"ToolSearch",
 	}, names, "Anthropic→Gemini keeps orchestration + scheduling tools when the flag is on")
 	assert.NotContains(t, names, "SendMessage")
 	assert.NotContains(t, names, "AskUserQuestion")
-	assert.NotContains(t, names, "ToolSearch")
+	assert.Contains(t, names, "ToolSearch")
+}
+
+func TestDeferredMCPToolSearchSurvivesCrossVendorEmit(t *testing.T) {
+	src, err := os.ReadFile("testdata/anthropic_deferred_mcp_tool_search.json")
+	require.NoError(t, err)
+	env, err := translate.ParseAnthropic(src)
+	require.NoError(t, err)
+
+	t.Run("OpenAI chat", func(t *testing.T) {
+		out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "gpt-5.6-luna"})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"Read", "Bash", "ToolSearch"}, emittedToolNames(t, out.Body))
+		assert.Equal(t, 1, out.Stats.CCOnlyToolsStripped, "Skill is stripped but ToolSearch is not counted")
+
+		var doc map[string]any
+		require.NoError(t, json.Unmarshal(out.Body, &doc))
+		var toolSearch map[string]any
+		for _, raw := range doc["tools"].([]any) {
+			fn := raw.(map[string]any)["function"].(map[string]any)
+			if fn["name"] == "ToolSearch" {
+				toolSearch = fn
+				break
+			}
+		}
+		require.NotNil(t, toolSearch)
+		assert.Equal(t, "Load a deferred tool schema by name", toolSearch["description"])
+		params := toolSearch["parameters"].(map[string]any)
+		query := params["properties"].(map[string]any)["query"].(map[string]any)
+		assert.Equal(t, "string", query["type"], "ToolSearch input_schema must survive as OpenAI parameters")
+	})
+
+	t.Run("OpenAI Responses", func(t *testing.T) {
+		out, err := env.PrepareOpenAIResponses(nil, translate.EmitOptions{TargetModel: "gpt-5.6-luna"})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"Read", "Bash", "ToolSearch"}, emittedResponsesToolNames(t, out.Body))
+		assert.Equal(t, 1, out.Stats.CCOnlyToolsStripped, "Skill is stripped but ToolSearch is not counted")
+	})
+
+	t.Run("Gemini", func(t *testing.T) {
+		out, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{TargetModel: "gemini-3.1-pro-preview"})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"Read", "Bash", "ToolSearch"}, emittedGeminiToolNames(t, out.Body))
+		assert.Equal(t, 1, out.Stats.CCOnlyToolsStripped, "Skill is stripped but ToolSearch is not counted")
+	})
 }
 
 func TestKeepOrchestrationTools_EmitOptionsZeroValue_StripsAll(t *testing.T) {

--- a/internal/translate/testdata/anthropic_deferred_mcp_tool_search.json
+++ b/internal/translate/testdata/anthropic_deferred_mcp_tool_search.json
@@ -1,0 +1,49 @@
+{
+  "model": "claude-opus-4-7",
+  "system": "The following deferred tools are now available via ToolSearch: mcp__postgres-prod__query",
+  "messages": [
+    {
+      "role": "user",
+      "content": "How many accounts do we have in prod?"
+    }
+  ],
+  "tools": [
+    {
+      "name": "Read",
+      "description": "Read a file",
+      "input_schema": {
+        "type": "object"
+      }
+    },
+    {
+      "name": "Bash",
+      "description": "Run a command",
+      "input_schema": {
+        "type": "object"
+      }
+    },
+    {
+      "name": "Skill",
+      "description": "Run a skill",
+      "input_schema": {
+        "type": "object"
+      }
+    },
+    {
+      "name": "ToolSearch",
+      "description": "Load a deferred tool schema by name",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ]
+      }
+    }
+  ],
+  "max_tokens": 256
+}


### PR DESCRIPTION
## Summary
- preserve Claude Code `ToolSearch` when translating Anthropic requests to OpenAI and Gemini
- keep other client-only tools filtered, while preserving ToolSearch schemas and accounting
- add deferred-MCP fixture coverage for chat, Responses, Gemini, and passthrough behavior

## Tests
- `go test ./...`