### PR TITLE
Surface a force-model pin that could not be served

### DIFF
--- a/internal/proxy/marker_internal_test.go
+++ b/internal/proxy/marker_internal_test.go
@@ -225,6 +225,38 @@ func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 			},
 			wantEmpty: true,
 		},
+		{
+			// The bug this guards: a /force-model pin that can't be served
+			// silently reverted to the scorer, so the user kept trusting the
+			// "force-model applied" ack while another model served the turn.
+			name: "dropped forced pin: surfaced even when the model didn't change",
+			res: turnLoopResult{
+				Decision:            router.Decision{Model: "gpt-5.5", Provider: "openai"},
+				PriorServedModel:    "gpt-5.5",
+				ForcedPinDropped:    true,
+				ForcedPinDropReason: "provider_not_enabled",
+				ForcedPinModel:      "claude-opus-5",
+			},
+			wantContains: []string{
+				"✦ **Weave Router** → gpt-5.5",
+				markerReasonForcedPinDropped,
+				"claude-opus-5",
+			},
+			wantNotContain: []string{
+				markerReasonUserForced,
+				"provider_not_enabled",
+			},
+		},
+		{
+			name: "dropped forced pin: suppressed in suggestion mode",
+			res: turnLoopResult{
+				Decision:         router.Decision{Model: "gpt-5.5", Provider: "openai"},
+				SuggestionMode:   true,
+				ForcedPinDropped: true,
+				ForcedPinModel:   "claude-opus-5",
+			},
+			wantEmpty: true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -550,10 +550,9 @@ func routingMarkerFor(res turnLoopResult) string {
 	if res.HardPinned {
 		return ""
 	}
-	// A dropped force-model pin contradicts an acknowledgment the user already
-	// saw, so it prints even when the served model didn't change from the prior
-	// turn — the same-model gate below would otherwise hide exactly the turns
-	// where the pin quietly stopped applying.
+	// A dropped force-model pin contradicts an ack the user already saw, so it
+	// prints even when the model did not change — the same-model gate below would
+	// otherwise hide exactly the turns where the pin stopped applying.
 	if res.ForcedPinDropped {
 		parts := []string{"✦ **Weave Router** → " + decision.Model, markerReasonForcedPinDropped}
 		if res.ForcedPinModel != "" {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -550,6 +550,20 @@ func routingMarkerFor(res turnLoopResult) string {
 	if res.HardPinned {
 		return ""
 	}
+	// A dropped force-model pin contradicts an acknowledgment the user already
+	// saw, so it prints even when the served model didn't change from the prior
+	// turn — the same-model gate below would otherwise hide exactly the turns
+	// where the pin quietly stopped applying.
+	if res.ForcedPinDropped {
+		parts := []string{"✦ **Weave Router** → " + decision.Model, markerReasonForcedPinDropped}
+		if res.ForcedPinModel != "" {
+			parts = []string{
+				"✦ **Weave Router** → " + decision.Model,
+				fmt.Sprintf("%s (%s)", markerReasonForcedPinDropped, res.ForcedPinModel),
+			}
+		}
+		return strings.Join(parts, " · ") + "\n\n"
+	}
 	// Same model as last turn: the user already knows. Empty prior model means
 	// the first turn of this session (or role), which still shows. Applies to
 	// both the planner-style marker and the sidecar-supplied display marker —
@@ -623,6 +637,7 @@ const (
 	markerReasonBestPick          = "best pick for this turn"
 	markerReasonBaseline          = "fell back to baseline after provider outage"
 	markerReasonSibling           = "switched after the picked model was overloaded"
+	markerReasonForcedPinDropped  = "your force-model pin could not be served this turn"
 )
 
 // baselineRoutingMarkerFor renders the routing badge for an in-turn baseline

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -1622,12 +1622,9 @@ func authedCtxWithGatewayKey(installationID, aliasedModel string) context.Contex
 	return context.WithValue(authedCtx(installationID), proxy.ExternalAPIKeysContextKey{}, []*auth.ExternalAPIKey{key})
 }
 
-// A user's /force-model pin that names a provider this request cannot serve
-// used to be dropped silently: the turn fell through to the scorer, served
-// another model, and emitted nothing — so the user kept trusting the
-// "force-model applied: claude-opus-5" acknowledgment from the prior turn.
-// The pin must still be dropped (serving it would 401), but the turn has to
-// say so.
+// A /force-model pin that names an unavailable provider was silently dropped:
+// the turn fell through to the scorer while the user trusted the prior ack.
+// The pin must still be dropped (serving it would 401), but now it surfaces.
 func TestService_SessionPin_ForcedPinDropped_SurfacesInMarker(t *testing.T) {
 	const body = `{"model":"gpt-4o","stream":true,"messages":[{"role":"user","content":"analyze usage"}]}`
 

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -1621,3 +1621,58 @@ func authedCtxWithGatewayKey(installationID, aliasedModel string) context.Contex
 	}
 	return context.WithValue(authedCtx(installationID), proxy.ExternalAPIKeysContextKey{}, []*auth.ExternalAPIKey{key})
 }
+
+// A user's /force-model pin that names a provider this request cannot serve
+// used to be dropped silently: the turn fell through to the scorer, served
+// another model, and emitted nothing — so the user kept trusting the
+// "force-model applied: claude-opus-5" acknowledgment from the prior turn.
+// The pin must still be dropped (serving it would 401), but the turn has to
+// say so.
+func TestService_SessionPin_ForcedPinDropped_SurfacesInMarker(t *testing.T) {
+	const body = `{"model":"gpt-4o","stream":true,"messages":[{"role":"user","content":"analyze usage"}]}`
+
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider:    providers.ProviderAnthropic,
+		Model:       "claude-opus-5",
+		Reason:      translate.ReasonUserForceModel,
+		PinnedUntil: time.Now().Add(time.Hour),
+	}
+	// The scorer's fallback pick once the forced pin is dropped.
+	fr := &fakeRouter{decision: router.Decision{
+		Provider: providers.ProviderOpenAI, Model: "gpt-5.5", Reason: "cluster:v0.2",
+	}}
+	// Only OpenAI is wired, so the Anthropic-bound forced pin cannot be served.
+	openAI := &fakeProvider{proxyResponse: func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		for _, frame := range []string{
+			`{"type":"response.output_text.delta","output_index":0,"delta":"ok"}`,
+			`{"type":"response.completed","response":{"id":"resp_1","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":3,"output_tokens":1}}}`,
+		} {
+			_, _ = io.WriteString(w, "data: "+frame+"\n\n")
+		}
+	}}
+	svc := proxy.NewService(
+		fr,
+		map[string]providers.Client{providers.ProviderOpenAI: openAI},
+		nil, false, nil,
+		store,
+		false, providers.ProviderOpenAI, "gpt-4o-mini",
+		nil,
+	)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+	require.NoError(t, svc.ProxyOpenAIChatCompletion(ctx, []byte(body), rec, httpReq))
+
+	assert.Equal(t, 1, fr.routeCalls, "an unservable forced pin must fall through to routing")
+	assert.Equal(t, "gpt-5.5", rec.Header().Get(proxy.HeaderRouterModel),
+		"the scorer's pick serves the turn")
+	assert.Contains(t, rec.Body.String(), "force-model pin could not be served",
+		"the dropped pin must be surfaced, not silently swallowed")
+	assert.Contains(t, rec.Body.String(), "claude-opus-5",
+		"the marker names the pin that was dropped")
+}

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -174,10 +174,9 @@ type turnLoopResult struct {
 	UsageBypass bool
 	PinTier     string
 	PinAgeSec   int64
-	// ForcedPinDropped records that a user's /force-model pin existed but could
-	// not be served this turn (provider not enabled, model excluded, or not
-	// image-capable). The marker surfaces it so the turn doesn't silently
-	// contradict the "force-model applied" acknowledgment.
+	// ForcedPinDropped records that a /force-model pin existed but could not be
+	// served (provider not enabled, excluded, or not image-capable); surfaced so
+	// the turn does not silently contradict the "force-model applied" ack.
 	ForcedPinDropped    bool
 	ForcedPinDropReason string
 	ForcedPinModel      string
@@ -805,10 +804,8 @@ func (s *Service) runTurnLoop(
 			s.refreshPin(ctx, installationID, res.SessionKey, pin, res.PinRole, pinDecision(pin))
 			return res, nil
 		}
-		// A forced pin is an explicit user instruction, so dropping it is a
-		// user-visible event, not routine routing. Without this the turn
-		// silently reverts to the scorer and the user keeps believing the
-		// ack ("force-model applied: …") still holds.
+		// A forced pin is an explicit user instruction; dropping it silently reverts
+		// to the scorer while the user still trusts the "force-model applied" ack.
 		dropReason := "excluded"
 		switch {
 		case !providerEligible:

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -174,6 +174,13 @@ type turnLoopResult struct {
 	UsageBypass bool
 	PinTier     string
 	PinAgeSec   int64
+	// ForcedPinDropped records that a user's /force-model pin existed but could
+	// not be served this turn (provider not enabled, model excluded, or not
+	// image-capable). The marker surfaces it so the turn doesn't silently
+	// contradict the "force-model applied" acknowledgment.
+	ForcedPinDropped    bool
+	ForcedPinDropReason string
+	ForcedPinModel      string
 	// PinProvider, PrefixBroken, and PriorTurnGapMS preserve the cache-state
 	// evidence used by the planner for span-level shadow analysis.
 	PinProvider    string
@@ -797,6 +804,29 @@ func (s *Service) runTurnLoop(
 			res.StickyHit = true
 			s.refreshPin(ctx, installationID, res.SessionKey, pin, res.PinRole, pinDecision(pin))
 			return res, nil
+		}
+		// A forced pin is an explicit user instruction, so dropping it is a
+		// user-visible event, not routine routing. Without this the turn
+		// silently reverts to the scorer and the user keeps believing the
+		// ack ("force-model applied: …") still holds.
+		dropReason := "excluded"
+		switch {
+		case !providerEligible:
+			dropReason = "provider_not_enabled"
+		case !imageCapable:
+			dropReason = "not_image_capable"
+		}
+		log.Info("Forced session pin dropped for this turn",
+			"pin_model", pin.Model,
+			"pin_provider", pin.Provider,
+			"pin_reason", pin.Reason,
+			"drop_reason", dropReason,
+			"role", res.PinRole,
+		)
+		if isUserForcedReason(pin.Reason) {
+			res.ForcedPinDropped = true
+			res.ForcedPinDropReason = dropReason
+			res.ForcedPinModel = pin.Model
 		}
 		if excluded || !imageCapable {
 			// User still asked for this tier; constrain the fresh decision


### PR DESCRIPTION
## Problem

A user's `/force-model` pin is dropped for the turn when its provider isn't in `EnabledProviders`, the model is excluded, or it can't carry an image ([`turnloop.go`](https://github.com/workweave/router/blob/main/internal/proxy/turnloop.go)). Dropping it is correct — dispatching to a provider the request can't authenticate to would 401. But the drop was **completely silent**: no log line, no marker. The turn fell through to the scorer and served a different model while the user was still looking at `force-model applied: claude-opus-5 (anthropic)` from the previous turn.

Reported from Codex desktop: a coworker pinned an Anthropic model, got the success ack, then checked GCP/router logs and found an OpenAI model serving every subsequent turn.

Two things made this hard to see:

- `forcedModelBinding` validates the org allowlist, installation exclusions, gateway bindings, and policy-excluded providers — but **not** the enabled-provider set the *next* turn applies. So validation and enforcement disagree, and the ack is written a turn before the conflict surfaces.
- The `pinFound = false` reset discards the pin with no trace. The maxed-out guard immediately below it *does* log its drop (`"Session pin maxed out on previous turn"`), which is the precedent this follows.

## Change

- Log the drop with a `drop_reason` (`provider_not_enabled` / `excluded` / `not_image_capable`).
- Record it on `turnLoopResult` and render a routing marker naming the pin that didn't apply: `✦ **Weave Router** → gpt-5.5 · your force-model pin could not be served this turn (claude-opus-5)`.

The marker branch runs **before** the same-model suppression gate. That gate compares against the prior served model, so it would otherwise hide exactly the turns where the pin quietly stopped applying. Suggestion mode and empty decisions still suppress as before.

**No routing behavior changes** — this only makes an existing silent fallback observable.

## Testing

- `TestService_SessionPin_ForcedPinDropped_SurfacesInMarker` — end-to-end: an Anthropic-bound forced pin with only OpenAI wired falls through to the scorer, serves `gpt-5.5`, and surfaces the dropped pin.
- Two `routingMarkerFor` cases: shown even when the served model is unchanged; suppressed in suggestion mode.
- Both fail without the fix (verified by reverting the marker branch), and `go test ./...` passes with it.

## Session-key derivation — investigated, not a live bug

A candidate second cause was `DeriveSessionKey` hashing `FirstUserMessageText()`: if `/fm …` is the *first* user message, the command is stripped from the body, so the next turn would derive a different session key and miss the pin. I wrote the unit test and it does reproduce (two different 16-byte keys for the two turns) — but **production evidence refutes it as the cause here**:

- Pulled the router logs for the reporter's own `/fm opus` Codex-desktop session (`client_session_id 01a049c4…`, 2026-08-28): one stable `session_key` across every turn, `turnloop pin lookup hit … user_forced` on all of them. No drift.
- Scanned a day of prod `turnloop pin lookup hit` lines: exactly one session with two distinct keys for one `client_session_id`, and it was a Claude Code sub-agent boundary (prompt text changes entirely between turns), not a router command.
- Codex (CLI and desktop) goes over the Responses API, where `input` accumulates the first user message on every request — `messages[0]` never changes, so the key can't drift. Claude Code sends `metadata.user_id`, which pins the key independently of message text.

The theoretical gap remains for a hypothetical chat-completions client whose first-ever message is a router command and which does not resend history; that is not any current client. Left unfixed deliberately — changing key derivation moves every pin and prompt-cache slot, which is not justified by a failure mode no client exercises.