### PR TITLE
fix: compact against dispatchable context windows

### DIFF
--- a/internal/proxy/compaction.go
+++ b/internal/proxy/compaction.go
@@ -66,20 +66,20 @@ type compactionResult struct {
 }
 
 // maxEligibleContextWindow returns the largest effective context window among
-// available routing models that are not policy-excluded. A signature-stripping
-// (non-Anthropic) target gets sigSavings added to its window: the translator
-// drops base64 thought-signature blocks before dispatch, so that model can
-// serve sigSavings more of this request's estimated tokens — mirroring the
-// per-model discount in excludeContextOverflowModels, so a signature-heavy
-// session isn't falsely 413'd when a stripping model would still fit. Zero when
-// none are known (availableModels unset), which disables compaction.
+// available routing models that are not policy-excluded. It uses the smallest
+// enabled binding window for each model, matching the overflow pre-filter's
+// conservative dispatch check: compaction must not stop because a fallback
+// binding has more capacity than the binding that can actually serve first.
+// A signature-stripping (non-Anthropic) target gets sigSavings added to its
+// window, mirroring excludeContextOverflowModels. Zero when none are known
+// (availableModels unset), which disables compaction.
 func (s *Service) maxEligibleContextWindow(policyExcluded, enabledProviders map[string]struct{}, sigSavings int) int {
 	maxWindow := 0
 	for model := range s.availableModels {
 		if _, excluded := policyExcluded[model]; excluded {
 			continue
 		}
-		w := maxContextWindowForModel(model, enabledProviders)
+		w := minContextWindowForModel(model, enabledProviders)
 		if sigSavings > 0 && modelStripsAnthropicSignatures(model) {
 			w += sigSavings
 		}
@@ -88,33 +88,6 @@ func (s *Service) maxEligibleContextWindow(policyExcluded, enabledProviders map[
 		}
 	}
 	return maxWindow
-}
-
-// maxContextWindowForModel returns the largest context window any enabled
-// binding of model can serve. Uses MAX (not MIN) because compaction decides
-// when to SHRINK — a 1M fallback justifies holding off even with a 512K primary.
-// Falls back to the model-level window when enabledProviders is nil.
-func maxContextWindowForModel(model string, enabledProviders map[string]struct{}) int {
-	if len(enabledProviders) == 0 {
-		return contextWindowForRequest(model)
-	}
-	m, ok := catalog.ByID(model)
-	if !ok || len(m.Providers) == 0 {
-		return contextWindowForRequest(model)
-	}
-	cw := 0
-	for _, b := range m.Providers {
-		if _, enabled := enabledProviders[b.Provider]; !enabled {
-			continue
-		}
-		if w := contextWindowForRequest(model, b.Provider); w > cw {
-			cw = w
-		}
-	}
-	if cw == 0 {
-		return contextWindowForRequest(model)
-	}
-	return cw
 }
 
 // selectCompactionSummarizer returns the cheapest configured summarizer model

--- a/internal/proxy/compaction_test.go
+++ b/internal/proxy/compaction_test.go
@@ -171,10 +171,11 @@ func TestMaybeCompact_AuthoritativePolicyNeverCallsSummarizer(t *testing.T) {
 	require.NoError(t, err)
 	ctx := router.WithStrategy(context.Background(), strategy)
 
-	result, _ := s.maybeCompact(ctx, env, turntype.MainLoop, 100, 1_000, http.Header{})
+	result, _ := s.maybeCompact(ctx, env, turntype.MainLoop, 100, 700, http.Header{})
 
 	assert.Equal(t, 0, fake.calls)
 	assert.False(t, result.Summarized)
+	assert.Positive(t, result.TrimmedToRecent, "authoritative routing must still rescue-trim when cleanup does not fit")
 }
 
 func TestWithCompaction_ZeroPctDisables(t *testing.T) {


### PR DESCRIPTION
## Summary

- Make proactive compaction use the conservative effective window used by final context-overflow filtering.
- Prevent compaction from stopping after Tier 1 when a fallback binding overstates available capacity.
- Retain rescue trimming for authoritative-per-turn routing and cover it with a regression test.

## Incident context

A Claude Code session reached approximately 987k input tokens plus a 64k output reserve. Compaction cleared tool results but stopped because it calculated a 1,310,720-token theoretical window; final dispatch correctly found the largest eligible model was 1,050,000 tokens and returned no routable model.

## Validation

- `go test ./...`
- `wv router tc`
- Weave Checks preflight was unavailable because the local Claude Code installation is not configured with a router `ANTHROPIC_BASE_URL` and `X-Weave-Router-Key`.
