### PR TITLE
Codex directive parity: aliases, toggles, and models

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,9 @@ sidecar is optional. HMM and forced selections in the native Codex family
 every other selected model uses its WorkWeave deployment or BYOK credential,
 matching the Claude Code plugin's model-to-credential dispatch.
 Codex does not load third-party slash-command files, so the installer ships the
-router directives as native Codex skills: `$force-model <model-id>`,
-`$unforce-model`, and `$router-feedback <text>`, each of which sends the
+router directives as native Codex skills: `$force-model <model-id>` (alias
+`$fm <model-id>`), `$unforce-model` (alias `$ufm`), and
+`$router-feedback <text>` (alias `$rf <text>`), each of which sends the
 leading-space prompt form (for example, ` /force-model gpt-5.6-terra`) that the
 router parses. You can type that form directly instead. Re-install
 and `--uninstall --codex` rewrite/remove only the managed block, leaving the

--- a/README.md
+++ b/README.md
@@ -180,9 +180,10 @@ matching the Claude Code plugin's model-to-credential dispatch.
 Codex does not load third-party slash-command files, so the installer ships the
 router directives as native Codex skills: `$force-model <model-id>` (alias
 `$fm <model-id>`), `$unforce-model` (alias `$ufm`), and
-`$router-feedback <text>` (alias `$rf <text>`), each of which sends the
-leading-space prompt form (for example, ` /force-model gpt-5.6-terra`) that the
-router parses. You can type that form directly instead. Re-install
+`$router-feedback <text>` (alias `$rf <text>`). Each skill runs a local
+`scripts/emit.sh` that prints the leading-space directive (for example,
+` /force-model gpt-5.6-terra`); the router intercepts that exec output.
+You can type that form directly instead. Re-install
 and `--uninstall --codex` rewrite/remove only the managed block, leaving the
 rest of your Codex config untouched. Codex also gets `$router-status`,
 `$router-off`, `$router-on`, and `$router-models` as skills that call this

--- a/README.md
+++ b/README.md
@@ -183,7 +183,9 @@ router directives as native Codex skills: `$force-model <model-id>`,
 leading-space prompt form (for example, ` /force-model gpt-5.6-terra`) that the
 router parses. You can type that form directly instead. Re-install
 and `--uninstall --codex` rewrite/remove only the managed block, leaving the
-rest of your Codex config untouched. Invoke `$disable-routing` to switch the
+rest of your Codex config untouched. Codex also gets `$router-status`,
+`$router-off`, `$router-on`, and `$router-models` as skills that call this
+installer's own verbs. Invoke `$disable-routing` (or `$router-off`) to switch the
 next Codex session back to its normal provider, or run
 `npx @workweave/router disable-routing` in a shell; a literal
 `/disable-routing` is not a third-party extension point in Codex.

--- a/install/README.md
+++ b/install/README.md
@@ -152,9 +152,9 @@ native Codex skill, invoked with `$`:
 
 | Skill | Sends |
 | --- | --- |
-| `$force-model <model-id>` | ` /force-model <model-id>` |
-| `$unforce-model` | ` /unforce-model` |
-| `$router-feedback <text>` | ` /router-feedback <text>` |
+| `$force-model <model-id>` / `$fm <model-id>` | ` /force-model <model-id>` |
+| `$unforce-model` / `$ufm` | ` /unforce-model` |
+| `$router-feedback <text>` / `$rf <text>` | ` /router-feedback <text>` |
 
 Each skill submits a normal prompt whose first character is one literal space,
 which is what reaches the router's directive parser. You can always type that

--- a/install/README.md
+++ b/install/README.md
@@ -344,8 +344,8 @@ installer owns the config file.
 | unforce-model (`ufm`) | `/unforce-model` | `$unforce-model` | `/unforce-model` | `/ufm` (native) | manual |
 | router-feedback (`rf`) | `/router-feedback` | `$router-feedback` | `/router-feedback` | — | manual |
 | router-session | `/router-session` | — | — | — | — |
-| router-off / on / status | `/router-off` … | `$disable-routing` (off only) | — | — | — |
-| router-models (`models`) | `/router-models` | — | — | — | — |
+| router-off / on / status | `/router-off` … | `$router-off` … (plus `$disable-routing`) | — | — | — |
+| router-models (`models`) | `/router-models` | `$router-models` | — | — | — |
 
 - **Codex** uses `$name` skills because Codex reserves `/…` for built-ins; each
   skill sends the leading-space prompt form.
@@ -354,8 +354,12 @@ installer owns the config file.
 - **Cursor** exposes no command or skill file this installer owns, so its
   directives are manual: type the leading-space form ( `/force-model …`)
   yourself. The base-URL toggle lives in Cursor's own settings UI.
-- The local toggles are Claude Code-only (plus Codex's `$disable-routing`)
-  because no other client has a config file this installer writes.
+- The local toggles reach Claude Code and Codex, the two clients with a config
+  file this installer writes. Codex's skills shell out to the same
+  `weave-router off|on|status|models --codex` verbs the CLI exposes;
+  `$disable-routing` predates `$router-off` and remains as an alias for it.
+- `models` resolves one install's endpoint and key, so it needs a client that
+  stores both: `--claude` or `--codex` (opencode and pi are not wired yet).
 
 What each `off` does (and `on` reverses byte-for-byte):
 
@@ -384,6 +388,7 @@ as a command-line argument.
 
 ```bash
 npx @workweave/router models --claude                          # every model, with its on/off state
+npx @workweave/router models --codex                           # same, for a Codex install
 npx @workweave/router models disable gpt-5.6 --claude          # take a model out of rotation
 npx @workweave/router models enable gpt-5.6 --claude           # put it back
 npx @workweave/router models providers --claude                # same, one row per provider

--- a/install/codex-skills/fm/SKILL.md
+++ b/install/codex-skills/fm/SKILL.md
@@ -5,11 +5,8 @@ description: "Alias for force-model — pin this Codex session to a specific mod
 
 <!-- weave-router managed fm skill -->
 
-When the user invokes `$fm <model-id>`, send a normal user message whose first
-character is one literal space, followed by `/force-model ` and the requested
-model id. Do not use a Codex slash command or omit the leading space. Preserve
-the model id exactly, then report the router's response.
-
-```text
- /force-model gpt-5.6-terra
-```
+When the user invokes `$fm <model-id>`, run this skill's `scripts/emit.sh`
+with the model id as arguments. Do not send a user message and do not type a
+Codex slash command. The script prints a leading-space `/force-model` line;
+the Weave Router intercepts that exec output, pins the session, and continues
+this turn. Then report the router's response.

--- a/install/codex-skills/fm/SKILL.md
+++ b/install/codex-skills/fm/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: fm
+description: "Alias for force-model — pin this Codex session to a specific model through the Weave Router."
+---
+
+<!-- weave-router managed fm skill -->
+
+When the user invokes `$fm <model-id>`, send a normal user message whose first
+character is one literal space, followed by `/force-model ` and the requested
+model id. Do not use a Codex slash command or omit the leading space. Preserve
+the model id exactly, then report the router's response.
+
+```text
+ /force-model gpt-5.6-terra
+```

--- a/install/codex-skills/fm/SKILL.md
+++ b/install/codex-skills/fm/SKILL.md
@@ -5,8 +5,11 @@ description: "Alias for force-model — pin this Codex session to a specific mod
 
 <!-- weave-router managed fm skill -->
 
-When the user invokes `$fm <model-id>`, run this skill's `scripts/emit.sh`
-with the model id as arguments. Do not send a user message and do not type a
-Codex slash command. The script prints a leading-space `/force-model` line;
-the Weave Router intercepts that exec output, pins the session, and continues
-this turn. Then report the router's response.
+When the user invokes `$fm <model-id>`, run this skill's `scripts/emit.sh` using the
+absolute path shown in this skill's `<path>` (its directory + `/scripts/emit.sh`).
+Pass the model id as arguments, quoted as a single argument list.
+Do not send a user message and do not type a Codex slash command.
+
+The script prints a leading-space `/force-model` line. The Weave Router reads that
+exec output, pins the session, and continues this turn — so run the script once and
+do not repeat its output as your answer. Then report the router's response.

--- a/install/codex-skills/fm/scripts/emit.sh
+++ b/install/codex-skills/fm/scripts/emit.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Alias of force-model/scripts/emit.sh
+set -euo pipefail
+if [ "$#" -eq 0 ] || [ -z "${1:-}" ]; then
+  echo "usage: emit.sh <model-id>" >&2
+  exit 1
+fi
+printf ' /force-model %s\n' "$*"

--- a/install/codex-skills/force-model/SKILL.md
+++ b/install/codex-skills/force-model/SKILL.md
@@ -5,8 +5,11 @@ description: "Pin this Codex session to a specific model through the Weave Route
 
 <!-- weave-router managed force-model skill -->
 
-When the user invokes `$force-model <model-id>` (or `$fm`), run this skill's
-`scripts/emit.sh` with the model id as arguments. Do not send a user message
-and do not type a Codex slash command. The script prints a leading-space
-`/force-model` line; the Weave Router intercepts that exec output, pins the
-session, and continues this turn. Then report the router's response.
+When the user invokes `$force-model <model-id>` (or `$fm`), run this skill's `scripts/emit.sh` using the
+absolute path shown in this skill's `<path>` (its directory + `/scripts/emit.sh`).
+Pass the model id as arguments, quoted as a single argument list.
+Do not send a user message and do not type a Codex slash command.
+
+The script prints a leading-space `/force-model` line. The Weave Router reads that
+exec output, pins the session, and continues this turn — so run the script once and
+do not repeat its output as your answer. Then report the router's response.

--- a/install/codex-skills/force-model/SKILL.md
+++ b/install/codex-skills/force-model/SKILL.md
@@ -5,10 +5,8 @@ description: "Pin this Codex session to a specific model through the Weave Route
 
 <!-- weave-router managed force-model skill -->
 
-When the user invokes `$force-model <model-id>` (or asks to use the `$fm` alias), send a normal user message whose first character is one literal space, followed by `/force-model ` and the requested model id. Do not use a Codex slash command and do not omit the leading space. For example, send exactly:
-
-```text
- /force-model gpt-5.6-terra
-```
-
-Preserve any model id exactly as provided. Report the router's response after it returns.
+When the user invokes `$force-model <model-id>` (or `$fm`), run this skill's
+`scripts/emit.sh` with the model id as arguments. Do not send a user message
+and do not type a Codex slash command. The script prints a leading-space
+`/force-model` line; the Weave Router intercepts that exec output, pins the
+session, and continues this turn. Then report the router's response.

--- a/install/codex-skills/force-model/scripts/emit.sh
+++ b/install/codex-skills/force-model/scripts/emit.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Print a leading-space /force-model directive. Codex runs this via exec;
+# the Weave Router intercepts the tool output and pins the session.
+set -euo pipefail
+if [ "$#" -eq 0 ] || [ -z "${1:-}" ]; then
+  echo "usage: emit.sh <model-id>" >&2
+  exit 1
+fi
+printf ' /force-model %s\n' "$*"

--- a/install/codex-skills/rf/SKILL.md
+++ b/install/codex-skills/rf/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: rf
+description: "Alias for router-feedback — submit feedback about a Weave Router decision or model performance."
+---
+
+<!-- weave-router managed rf skill -->
+
+When the user invokes `$rf <feedback>`, send a normal user message whose first
+character is one literal space, followed by `/router-feedback ` and the
+feedback text. Do not use a Codex slash command or omit the leading space.
+Preserve the feedback text exactly, then report the router's response.
+
+```text
+ /router-feedback the selected model struggled with this task
+```

--- a/install/codex-skills/rf/SKILL.md
+++ b/install/codex-skills/rf/SKILL.md
@@ -5,9 +5,11 @@ description: "Alias for router-feedback — submit feedback about a Weave Router
 
 <!-- weave-router managed rf skill -->
 
-When the user invokes `$rf <feedback>`, run this skill's `scripts/emit.sh`
-with the feedback text as arguments. Do not send a user message and do not
-type a Codex slash command. The script prints a leading-space
-`/router-feedback` line; the Weave Router intercepts that exec output,
-records the feedback, and continues this turn. Then report the router's
-response.
+When the user invokes `$rf <feedback>`, run this skill's `scripts/emit.sh` using the
+absolute path shown in this skill's `<path>` (its directory + `/scripts/emit.sh`).
+Pass the feedback text as arguments, quoted as a single argument list.
+Do not send a user message and do not type a Codex slash command.
+
+The script prints a leading-space `/router-feedback` line. The Weave Router reads that
+exec output, records the feedback, and continues this turn — so run the script once and
+do not repeat its output as your answer. Then report the router's response.

--- a/install/codex-skills/rf/SKILL.md
+++ b/install/codex-skills/rf/SKILL.md
@@ -5,11 +5,9 @@ description: "Alias for router-feedback — submit feedback about a Weave Router
 
 <!-- weave-router managed rf skill -->
 
-When the user invokes `$rf <feedback>`, send a normal user message whose first
-character is one literal space, followed by `/router-feedback ` and the
-feedback text. Do not use a Codex slash command or omit the leading space.
-Preserve the feedback text exactly, then report the router's response.
-
-```text
- /router-feedback the selected model struggled with this task
-```
+When the user invokes `$rf <feedback>`, run this skill's `scripts/emit.sh`
+with the feedback text as arguments. Do not send a user message and do not
+type a Codex slash command. The script prints a leading-space
+`/router-feedback` line; the Weave Router intercepts that exec output,
+records the feedback, and continues this turn. Then report the router's
+response.

--- a/install/codex-skills/rf/scripts/emit.sh
+++ b/install/codex-skills/rf/scripts/emit.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$#" -eq 0 ] || [ -z "${1:-}" ]; then
+  echo "usage: emit.sh <feedback>" >&2
+  exit 1
+fi
+printf ' /router-feedback %s\n' "$*"

--- a/install/codex-skills/router-feedback/SKILL.md
+++ b/install/codex-skills/router-feedback/SKILL.md
@@ -5,10 +5,9 @@ description: "Submit feedback about a Weave Router decision or model performance
 
 <!-- weave-router managed router-feedback skill -->
 
-When the user invokes `$router-feedback <feedback>` (or asks to use the `$rf` alias), send a normal user message whose first character is one literal space, followed by `/router-feedback ` and the feedback text. Do not use a Codex slash command and do not omit the leading space. Preserve the feedback text exactly. For example:
-
-```text
- /router-feedback the selected model struggled with this task
-```
-
-Report the router's response after it returns.
+When the user invokes `$router-feedback <feedback>` (or `$rf`), run this
+skill's `scripts/emit.sh` with the feedback text as arguments. Do not send a
+user message and do not type a Codex slash command. The script prints a
+leading-space `/router-feedback` line; the Weave Router intercepts that exec
+output, records the feedback, and continues this turn. Then report the
+router's response.

--- a/install/codex-skills/router-feedback/SKILL.md
+++ b/install/codex-skills/router-feedback/SKILL.md
@@ -5,9 +5,11 @@ description: "Submit feedback about a Weave Router decision or model performance
 
 <!-- weave-router managed router-feedback skill -->
 
-When the user invokes `$router-feedback <feedback>` (or `$rf`), run this
-skill's `scripts/emit.sh` with the feedback text as arguments. Do not send a
-user message and do not type a Codex slash command. The script prints a
-leading-space `/router-feedback` line; the Weave Router intercepts that exec
-output, records the feedback, and continues this turn. Then report the
-router's response.
+When the user invokes `$router-feedback <feedback>` (or `$rf`), run this skill's `scripts/emit.sh` using the
+absolute path shown in this skill's `<path>` (its directory + `/scripts/emit.sh`).
+Pass the feedback text as arguments, quoted as a single argument list.
+Do not send a user message and do not type a Codex slash command.
+
+The script prints a leading-space `/router-feedback` line. The Weave Router reads that
+exec output, records the feedback, and continues this turn — so run the script once and
+do not repeat its output as your answer. Then report the router's response.

--- a/install/codex-skills/router-feedback/scripts/emit.sh
+++ b/install/codex-skills/router-feedback/scripts/emit.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Print a leading-space /router-feedback directive. Codex runs this via exec;
+# the Weave Router intercepts the tool output and records the feedback.
+set -euo pipefail
+if [ "$#" -eq 0 ] || [ -z "${1:-}" ]; then
+  echo "usage: emit.sh <feedback>" >&2
+  exit 1
+fi
+printf ' /router-feedback %s\n' "$*"

--- a/install/codex-skills/router-models/SKILL.md
+++ b/install/codex-skills/router-models/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: router-models
+description: "List the models the Weave Router may route to, and turn them on or off."
+---
+
+<!-- weave-router managed router-models skill -->
+
+# Weave Router model selection
+
+When the user invokes `$router-models` (or `$models`), show which models this
+installation lets the router pick from, and change that selection when asked.
+This is the same list — and the same stored setting — as the checkboxes on the
+router dashboard's settings page.
+
+Start by running:
+
+```bash
+npx --package @workweave/router -y -- weave-router models --codex{{SCOPE}}
+```
+
+That prints every deployed model grouped by provider, with `[x]` for models the
+router may pick and `[ ]` for models it may not. Present it back as a compact
+checklist in that same `[x]` / `[ ]` form, keeping the provider grouping and the
+exact model ids — the user selects models by id.
+
+Then:
+
+- If the user named models or providers, work out whether they want them on or
+  off from how they phrased it, and apply it with
+  `weave-router models enable <id>... --codex{{SCOPE}}` or
+  `weave-router models disable <id>... --codex{{SCOPE}}` (add `providers` before
+  `enable`/`disable` to switch a whole provider). Several ids can go in one
+  call. Then re-run the list and show the result.
+- If they named nothing, stop after the list and ask which ones to change.
+  Never change anything they did not ask for.
+
+Other things they might ask for:
+
+- Rank models by preference:
+  `weave-router models prefer <id> <id>... --codex{{SCOPE}}` (order matters), or
+  `weave-router models prefer clear --codex{{SCOPE}}` to drop the ranking.
+- Providers only: `weave-router models providers --codex{{SCOPE}}`.
+
+If the command reports that this router doesn't expose model selection, that's a
+Weave-hosted router: model selection belongs to the whole organization there, so
+tell the user to change it at https://router.workweave.ai/dashboard/settings —
+don't try to work around it. Its listing carries no on/off state, so present it
+as a plain list; don't infer which models are enabled.
+
+Disabling a model takes effect on the router's next routing decision; no restart
+is needed.

--- a/install/codex-skills/router-models/SKILL.md
+++ b/install/codex-skills/router-models/SKILL.md
@@ -7,7 +7,7 @@ description: "List the models the Weave Router may route to, and turn them on or
 
 # Weave Router model selection
 
-When the user invokes `$router-models` (or `$models`), show which models this
+When the user invokes `$router-models`, show which models this
 installation lets the router pick from, and change that selection when asked.
 This is the same list — and the same stored setting — as the checkboxes on the
 router dashboard's settings page.

--- a/install/codex-skills/router-off/SKILL.md
+++ b/install/codex-skills/router-off/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: router-off
+description: "Route Codex to its default provider again (turn the Weave Router off)."
+---
+
+<!-- weave-router managed router-off skill -->
+
+# Turn Weave routing off
+
+When the user invokes `$router-off`, switch this Codex installation off the
+Weave Router without logging out or deleting its router configuration.
+
+Run exactly:
+
+```bash
+npx --package @workweave/router -y -- weave-router off --codex{{SCOPE}}
+```
+
+Then report the result and tell the user the change takes effect on their next
+`codex` launch — Codex reads its provider config at startup, so the current
+session keeps routing as it already was. It can be reversed with
+`$router-on`. Do not uninstall the router or alter any other Codex settings.

--- a/install/codex-skills/router-on/SKILL.md
+++ b/install/codex-skills/router-on/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: router-on
+description: "Route Codex through the Weave Router again (turn it back on)."
+---
+
+<!-- weave-router managed router-on skill -->
+
+# Turn Weave routing on
+
+When the user invokes `$router-on`, switch this Codex installation back onto
+the Weave Router using the managed configuration already on disk.
+
+Run exactly:
+
+```bash
+npx --package @workweave/router -y -- weave-router on --codex{{SCOPE}}
+```
+
+Then report the result and tell the user the change takes effect on their next
+`codex` launch — Codex reads its provider config at startup, so the current
+session keeps routing as it already was. Do not re-run the installer or alter
+any other Codex settings.

--- a/install/codex-skills/router-status/SKILL.md
+++ b/install/codex-skills/router-status/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: router-status
+description: "Show whether Codex is routing through the Weave Router or using its default provider."
+---
+
+<!-- weave-router managed router-status skill -->
+
+# Weave Router status
+
+When the user invokes `$router-status`, report whether this Codex installation
+routes through the Weave Router.
+
+Run exactly:
+
+```bash
+npx --package @workweave/router -y -- weave-router status --codex{{SCOPE}}
+```
+
+Then summarize the result in one line. Do not change any configuration.

--- a/install/codex-skills/ufm/SKILL.md
+++ b/install/codex-skills/ufm/SKILL.md
@@ -5,10 +5,8 @@ description: "Alias for unforce-model — clear the active Weave Router model pi
 
 <!-- weave-router managed ufm skill -->
 
-When the user invokes `$ufm`, send a normal user message whose first character
-is one literal space, followed by `/unforce-model`. Do not use a Codex slash
-command or omit the leading space. Then report the router's response.
-
-```text
- /unforce-model
-```
+When the user invokes `$ufm`, run this skill's `scripts/emit.sh`. Do not send
+a user message and do not type a Codex slash command. The script prints a
+leading-space `/unforce-model` line; the Weave Router intercepts that exec
+output, clears the pin, and continues this turn. Then report the router's
+response.

--- a/install/codex-skills/ufm/SKILL.md
+++ b/install/codex-skills/ufm/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: ufm
+description: "Alias for unforce-model — clear the active Weave Router model pin."
+---
+
+<!-- weave-router managed ufm skill -->
+
+When the user invokes `$ufm`, send a normal user message whose first character
+is one literal space, followed by `/unforce-model`. Do not use a Codex slash
+command or omit the leading space. Then report the router's response.
+
+```text
+ /unforce-model
+```

--- a/install/codex-skills/ufm/SKILL.md
+++ b/install/codex-skills/ufm/SKILL.md
@@ -5,8 +5,10 @@ description: "Alias for unforce-model — clear the active Weave Router model pi
 
 <!-- weave-router managed ufm skill -->
 
-When the user invokes `$ufm`, run this skill's `scripts/emit.sh`. Do not send
-a user message and do not type a Codex slash command. The script prints a
-leading-space `/unforce-model` line; the Weave Router intercepts that exec
-output, clears the pin, and continues this turn. Then report the router's
-response.
+When the user invokes `$ufm`, run this skill's `scripts/emit.sh` using the
+absolute path shown in this skill's `<path>` (its directory + `/scripts/emit.sh`).
+Do not send a user message and do not type a Codex slash command.
+
+The script prints a leading-space `/unforce-model` line. The Weave Router reads that
+exec output, clears the pin, and continues this turn — so run the script once and
+do not repeat its output as your answer. Then report the router's response.

--- a/install/codex-skills/ufm/scripts/emit.sh
+++ b/install/codex-skills/ufm/scripts/emit.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+printf ' /unforce-model\n'

--- a/install/codex-skills/unforce-model/SKILL.md
+++ b/install/codex-skills/unforce-model/SKILL.md
@@ -5,8 +5,10 @@ description: "Clear the active Weave Router model pin for this Codex session."
 
 <!-- weave-router managed unforce-model skill -->
 
-When the user invokes `$unforce-model` (or `$ufm`), run this skill's
-`scripts/emit.sh`. Do not send a user message and do not type a Codex slash
-command. The script prints a leading-space `/unforce-model` line; the Weave
-Router intercepts that exec output, clears the pin, and continues this turn.
-Then report the router's response.
+When the user invokes `$unforce-model` (or `$ufm`), run this skill's `scripts/emit.sh` using the
+absolute path shown in this skill's `<path>` (its directory + `/scripts/emit.sh`).
+Do not send a user message and do not type a Codex slash command.
+
+The script prints a leading-space `/unforce-model` line. The Weave Router reads that
+exec output, clears the pin, and continues this turn — so run the script once and
+do not repeat its output as your answer. Then report the router's response.

--- a/install/codex-skills/unforce-model/SKILL.md
+++ b/install/codex-skills/unforce-model/SKILL.md
@@ -5,10 +5,8 @@ description: "Clear the active Weave Router model pin for this Codex session."
 
 <!-- weave-router managed unforce-model skill -->
 
-When the user invokes `$unforce-model` (or asks to use the `$ufm` alias), send a normal user message whose first character is one literal space, followed by `/unforce-model`. Do not use a Codex slash command and do not omit the leading space. Send exactly:
-
-```text
- /unforce-model
-```
-
-Report the router's response after it returns.
+When the user invokes `$unforce-model` (or `$ufm`), run this skill's
+`scripts/emit.sh`. Do not send a user message and do not type a Codex slash
+command. The script prints a leading-space `/unforce-model` line; the Weave
+Router intercepts that exec output, clears the pin, and continues this turn.
+Then report the router's response.

--- a/install/codex-skills/unforce-model/scripts/emit.sh
+++ b/install/codex-skills/unforce-model/scripts/emit.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Print a leading-space /unforce-model directive for the Weave Router.
+set -euo pipefail
+printf ' /unforce-model\n'

--- a/install/directives.tsv
+++ b/install/directives.tsv
@@ -4,9 +4,9 @@
 force-model|fm|prompt|yes|yes|yes|yes|manual|command,skill
 unforce-model|ufm|prompt|yes|yes|yes|yes|manual|command,skill
 router-feedback|rf|prompt|yes|yes|yes|no|manual|command,skill
-router-off||local-toggle|yes|no|no|no|manual|command
-router-on||local-toggle|yes|no|no|no|manual|command
-router-status||local-toggle|yes|no|no|no|manual|command
+router-off||local-toggle|yes|yes|no|no|manual|command,skill
+router-on||local-toggle|yes|yes|no|no|manual|command,skill
+router-status||local-toggle|yes|yes|no|no|manual|command,skill
 router-session||prompt|yes|no|no|no|manual|command
-router-models|models|local-toggle|yes|no|no|no|manual|command
+router-models|models|local-toggle|yes|yes|no|no|manual|command,skill
 disable-routing||local-toggle|no|yes|no|no|manual|skill

--- a/install/install.sh
+++ b/install/install.sh
@@ -2990,54 +2990,8 @@ install_codex_prompt_skills() {
       [ -f "$candidate" ] || continue
       skill_src="$candidate"
       break
-<<<<<<< HEAD
     done
     [ -n "$skill_src" ] || continue
-=======
-    fi
-  done
-  [ -n "$skill_src" ] || { warn "Codex disable-routing skill template is missing; router configuration is still installed."; return 0; }
-  grep -Fq "$WEAVE_CODEX_SKILL_MARKER" "$skill_src" \
-    || { warn "Codex disable-routing skill template has no ownership marker; leaving skills unchanged."; return 0; }
-
-  dst_dir="$codex_dir/skills/disable-routing"
-  dst_file="$dst_dir/SKILL.md"
-  if [ "$scope" = "project" ] || [ -n "$install_dir" ]; then
-    refuse_if_symlink "$codex_dir/skills"
-    refuse_if_symlink "$dst_dir"
-    refuse_if_symlink "$dst_file"
-  elif [ -L "$codex_dir/skills" ] || [ -L "$dst_dir" ] || [ -L "$dst_file" ]; then
-    warn "Codex disable-routing skill path contains a symlink; leaving it untouched."
-    return 0
-  fi
-  if [ -e "$dst_file" ] && { [ ! -f "$dst_file" ] || ! grep -Fq "$WEAVE_CODEX_SKILL_MARKER" "$dst_file"; }; then
-    warn "A user-owned Codex disable-routing skill already exists at $dst_file; leaving it untouched."
-    return 0
-  fi
-  mkdir -p "$dst_dir"
-
-  scope_args=""
-  if [ -n "$install_dir" ]; then
-    scope_args=" --dir $(printf '%q' "$install_dir")"
-  elif [ "$scope" = "project" ]; then
-    scope_args=" --scope project"
-  fi
-  body="$(<"$skill_src")"
-  body="${body//\{\{SCOPE\}\}/$scope_args}"
-  printf '%s\n' "$body" >"$dst_file"
-  ok "Codex skill installed: \$disable-routing"
-}
-
-# Install prompt directives as Codex-native skills. Codex cannot append a
-# user message from a skill, so each skill ships scripts/emit.sh. Codex
-# execs that script; the router intercepts the leading-space directive in
-# the tool output without claiming Codex's reserved slash namespace.
-install_codex_prompt_skills() {
-  local canonical skill_src dst_dir dst_file emit_src emit_dst scope_args body
-  while IFS= read -r canonical; do
-    skill_src="$script_dir/codex-skills/$canonical/SKILL.md"
-    [ -f "$skill_src" ] || continue
->>>>>>> a8113add (Emit Codex router directives from a skill script)
     grep -Fq "<!-- weave-router managed $canonical skill -->" "$skill_src" || continue
     dst_dir="$codex_dir/skills/$canonical"
     dst_file="$dst_dir/SKILL.md"
@@ -3060,13 +3014,9 @@ install_codex_prompt_skills() {
     body="$(<"$skill_src")"
     body="${body//\{\{SCOPE\}\}/$scope_args}"
     printf '%s\n' "$body" >"$dst_file"
-<<<<<<< HEAD
     # Prompt skills emit their directive through a script Codex execs; toggles
     # shell out to the installer's own verbs and ship none.
     emit_src="${skill_src%/SKILL.md}/scripts/emit.sh"
-=======
-    emit_src="$script_dir/codex-skills/$canonical/scripts/emit.sh"
->>>>>>> a8113add (Emit Codex router directives from a skill script)
     if [ -f "$emit_src" ]; then
       mkdir -p "$dst_dir/scripts"
       emit_dst="$dst_dir/scripts/emit.sh"

--- a/install/install.sh
+++ b/install/install.sh
@@ -354,7 +354,6 @@ refuse_if_symlink() {
 # --codex) can find and replace the block instead of duplicating it.
 WEAVE_CODEX_BEGIN_MARKER="# >>> weave-router managed (do not edit between markers) >>>"
 WEAVE_CODEX_END_MARKER="# <<< weave-router managed <<<"
-WEAVE_CODEX_SKILL_MARKER="<!-- weave-router managed disable-routing skill -->"
 
 # ---------- identity helpers ----------
 #
@@ -1204,7 +1203,7 @@ if [ "$mode" != "install" ] && [ "$mode" != "update" ]; then
   non_interactive="true"
   if [ "$target_explicit" != "true" ]; then
     if [ "$mode" = "models" ]; then
-      err "'models' requires an explicit client: --claude."
+      err "'models' requires an explicit client: --claude or --codex."
     else
       err "'$mode' requires an explicit client: --claude, --codex, or --opencode."
     fi
@@ -1212,13 +1211,13 @@ if [ "$mode" != "install" ] && [ "$mode" != "update" ]; then
   fi
 fi
 
-# `models` resolves the endpoint and the trust decision out of Claude Code's
-# settings files specifically (resolve_installed_base_url +
-# models_endpoint_is_trusted), so it can't yet address another client's install.
-# Fail fast here rather than falling through to the toggle dispatch, which would
-# flip config nobody asked to change.
-if [ "$mode" = "models" ] && [ "$target" != "claude" ]; then
-  err "'models' currently supports --claude only (it resolves the router endpoint from Claude Code's settings)."
+# `models` needs to resolve one install's endpoint + key. Claude Code and Codex
+# both expose readers for that (resolve_installed_endpoint / read_installed_key);
+# opencode and pi do not have the endpoint-trust story worked out yet, so they
+# still fail fast here rather than falling through to the toggle dispatch, which
+# would flip config nobody asked to change.
+if [ "$mode" = "models" ] && [ "$target" != "claude" ] && [ "$target" != "codex" ]; then
+  err "'models' supports --claude and --codex only (it resolves the router endpoint from that client's config)."
   exit 2
 fi
 
@@ -1429,11 +1428,11 @@ WEAVE_REGISTRY_DATA=$(cat <<'WEAVE_REGISTRY_EOF'
 force-model|fm|prompt|yes|yes|yes|yes|manual|command,skill
 unforce-model|ufm|prompt|yes|yes|yes|yes|manual|command,skill
 router-feedback|rf|prompt|yes|yes|yes|no|manual|command,skill
-router-off||local-toggle|yes|no|no|no|manual|command
-router-on||local-toggle|yes|no|no|no|manual|command
-router-status||local-toggle|yes|no|no|no|manual|command
+router-off||local-toggle|yes|yes|no|no|manual|command,skill
+router-on||local-toggle|yes|yes|no|no|manual|command,skill
+router-status||local-toggle|yes|yes|no|no|manual|command,skill
 router-session||prompt|yes|no|no|no|manual|command
-router-models|models|local-toggle|yes|no|no|no|manual|command
+router-models|models|local-toggle|yes|yes|no|no|manual|command,skill
 disable-routing||local-toggle|no|yes|no|no|manual|skill
 WEAVE_REGISTRY_EOF
 )
@@ -1801,6 +1800,18 @@ read_pi_key() {
 # models_key_file_order echoes the precedence the Claude reader uses, so a caller
 # that needs to know *which* file the key came from can walk the same list (a
 # command substitution around this function would discard any global it set).
+# models_config_file_for_target names the single managed config that holds both
+# the endpoint and the key for a non-Claude client. Endpoint and credential from
+# the same file are self-consistent, which is exactly the case
+# models_endpoint_is_trusted already treats as always-safe.
+models_config_file_for_target() {
+  case "$target" in
+    codex)    printf '%s' "$codex_config_file" ;;
+    opencode) printf '%s' "$opencode_config_file" ;;
+    pi)       printf '%s' "$pi_models_file" ;;
+  esac
+}
+
 models_key_file_order() {
   if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
     printf '%s\n%s\n%s\n' "$local_settings_file" "$settings_file" "$settings_dir/.weave-parked.json"
@@ -2585,23 +2596,30 @@ if [ "$mode" = "models" ]; then
   # never the hosted defaults: a self-hosted user pointing at their own router
   # would otherwise silently edit the hosted one's installation.
   if [ "$base_url_explicit" != "true" ]; then
-    models_base="$(resolve_installed_base_url)"
+    models_base="$(resolve_installed_endpoint)"
     if [ -z "$models_base" ]; then
-      err "No Weave Router install found for Claude Code in this scope. Run 'npx @workweave/router --claude' first, or pass --base-url."
+      err "No Weave Router install found for $target in this scope. Run 'npx @workweave/router --$target' first, or pass --base-url."
       exit 1
     fi
     base_url="$models_base"
-    # resolve_installed_base_url ran in a command substitution, so any global it
+    # resolve_installed_endpoint ran in a command substitution, so any global it
     # set died with that subshell. Recover the source by walking the same
-    # precedence to find which file holds the endpoint we just adopted.
-    while IFS= read -r models_src_candidate; do
-      [ -n "$models_src_candidate" ] || continue
-      models_src_url="$(json_get "$models_src_candidate" '.env.ANTHROPIC_BASE_URL')"
-      if [ "${models_src_url%/}" = "$models_base" ]; then
-        models_base_source="$models_src_candidate"
-        break
-      fi
-    done <<<"$(models_base_file_order)"
+    # precedence to find which file holds the endpoint we just adopted. Only
+    # Claude Code spreads its endpoint across several files; every other client
+    # keeps endpoint and key in one managed config, which is self-consistent by
+    # construction (see models_endpoint_is_trusted's same-file rule).
+    if [ "$target" = "claude" ]; then
+      while IFS= read -r models_src_candidate; do
+        [ -n "$models_src_candidate" ] || continue
+        models_src_url="$(json_get "$models_src_candidate" '.env.ANTHROPIC_BASE_URL')"
+        if [ "${models_src_url%/}" = "$models_base" ]; then
+          models_base_source="$models_src_candidate"
+          break
+        fi
+      done <<<"$(models_base_file_order)"
+    else
+      models_base_source="$(models_config_file_for_target)"
+    fi
   fi
   # WEAVE_ROUTER_KEY is the user's own choice, so it pairs with any endpoint.
   if [ -n "${WEAVE_ROUTER_KEY:-}" ]; then
@@ -2612,16 +2630,20 @@ if [ "$mode" = "models" ]; then
     # Same subshell caveat as the endpoint above: recover which file the key
     # came from by re-reading them in read_installed_key's own precedence.
     models_key_source=""
-    while IFS= read -r models_src_candidate; do
-      [ -n "$models_src_candidate" ] || continue
-      if [ -n "$(read_claude_key "$models_src_candidate")" ]; then
-        models_key_source="$models_src_candidate"
-        break
-      fi
-    done <<<"$(models_key_file_order)"
+    if [ "$target" = "claude" ]; then
+      while IFS= read -r models_src_candidate; do
+        [ -n "$models_src_candidate" ] || continue
+        if [ -n "$(read_claude_key "$models_src_candidate")" ]; then
+          models_key_source="$models_src_candidate"
+          break
+        fi
+      done <<<"$(models_key_file_order)"
+    else
+      models_key_source="$(models_config_file_for_target)"
+    fi
   fi
   if [ -z "$api_key" ]; then
-    err "No router key found for Claude Code in this scope. Re-run 'npx @workweave/router --claude', or export WEAVE_ROUTER_KEY."
+    err "No router key found for $target in this scope. Re-run 'npx @workweave/router --$target', or export WEAVE_ROUTER_KEY."
     exit 1
   fi
   # Never send a key to an endpoint the checkout supplied. See
@@ -2936,63 +2958,25 @@ EOF
   rmdir "$dst_dir" 2>/dev/null || true
 }
 
-# Codex skills are the supported local extension surface for an action that
-# must edit Codex's configuration. A literal third-party slash command cannot
-# do this because Codex reserves `/…` for built-ins. The skill is invoked as
-# `$disable-routing`, asks Codex to run the existing safe toggle, and leaves
-# the managed router block in place for a later re-enable.
-install_codex_disable_routing_skill() {
-  local skill_src=""
-  local candidate dst_dir dst_file scope_args body
-  for candidate in \
-    "$script_dir/codex-skills/disable-routing/SKILL.md" \
-    "$script_dir/../codex-skills/disable-routing/SKILL.md"
-  do
-    if [ -f "$candidate" ]; then
+
+# Install every Codex-native skill the registry declares for this client:
+# prompt directives (which emit the leading-space form the router parses — the
+# only portable way to reach it without claiming Codex's reserved slash
+# namespace) and local-config toggles like $router-off, which shell out to this
+# installer's own verbs. weave_registry_skill_assets is the union of both.
+install_codex_prompt_skills() {
+  local canonical candidate skill_src dst_dir dst_file scope_args body
+  while IFS= read -r canonical; do
+    skill_src=""
+    for candidate in \
+      "$script_dir/codex-skills/$canonical/SKILL.md" \
+      "$script_dir/../codex-skills/$canonical/SKILL.md"
+    do
+      [ -f "$candidate" ] || continue
       skill_src="$candidate"
       break
-    fi
-  done
-  [ -n "$skill_src" ] || { warn "Codex disable-routing skill template is missing; router configuration is still installed."; return 0; }
-  grep -Fq "$WEAVE_CODEX_SKILL_MARKER" "$skill_src" \
-    || { warn "Codex disable-routing skill template has no ownership marker; leaving skills unchanged."; return 0; }
-
-  dst_dir="$codex_dir/skills/disable-routing"
-  dst_file="$dst_dir/SKILL.md"
-  if [ "$scope" = "project" ] || [ -n "$install_dir" ]; then
-    refuse_if_symlink "$codex_dir/skills"
-    refuse_if_symlink "$dst_dir"
-    refuse_if_symlink "$dst_file"
-  elif [ -L "$codex_dir/skills" ] || [ -L "$dst_dir" ] || [ -L "$dst_file" ]; then
-    warn "Codex disable-routing skill path contains a symlink; leaving it untouched."
-    return 0
-  fi
-  if [ -e "$dst_file" ] && { [ ! -f "$dst_file" ] || ! grep -Fq "$WEAVE_CODEX_SKILL_MARKER" "$dst_file"; }; then
-    warn "A user-owned Codex disable-routing skill already exists at $dst_file; leaving it untouched."
-    return 0
-  fi
-  mkdir -p "$dst_dir"
-
-  scope_args=""
-  if [ -n "$install_dir" ]; then
-    scope_args=" --dir $(printf '%q' "$install_dir")"
-  elif [ "$scope" = "project" ]; then
-    scope_args=" --scope project"
-  fi
-  body="$(<"$skill_src")"
-  body="${body//\{\{SCOPE\}\}/$scope_args}"
-  printf '%s\n' "$body" >"$dst_file"
-  ok "Codex skill installed: \$disable-routing"
-}
-
-# Install prompt directives as Codex-native skills. The skill itself emits a
-# leading-space normal prompt, which is the only portable way to reach the
-# router directive parser without claiming Codex's reserved slash namespace.
-install_codex_prompt_skills() {
-  local canonical skill_src dst_dir dst_file scope_args body
-  while IFS= read -r canonical; do
-    skill_src="$script_dir/codex-skills/$canonical/SKILL.md"
-    [ -f "$skill_src" ] || continue
+    done
+    [ -n "$skill_src" ] || continue
     grep -Fq "<!-- weave-router managed $canonical skill -->" "$skill_src" || continue
     dst_dir="$codex_dir/skills/$canonical"
     dst_file="$dst_dir/SKILL.md"
@@ -3017,7 +3001,7 @@ install_codex_prompt_skills() {
     printf '%s\n' "$body" >"$dst_file"
     ok "Codex skill installed: \$$canonical"
   done <<EOF
-$(weave_registry_skill_names codex)
+$(weave_registry_skill_assets codex)
 EOF
 }
 
@@ -3324,7 +3308,6 @@ if [ "$target" = "codex" ]; then
   write_codex_config "$codex_config_file" "$base_url" "$api_key" "$user_email" "$user_name"
   ok "Codex config written to $codex_config_file"
   remove_obsolete_codex_prompt_wrappers "$codex_dir/prompts"
-  install_codex_disable_routing_skill
   install_codex_prompt_skills
   info "Codex router directives: begin the message with one space, e.g. ' /force-model gpt-5.6-terra'."
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -1488,6 +1488,7 @@ weave_registry_skill_names() {
       cursor) [ "$cursor" = yes ] || continue ;;
     esac
     printf '%s\n' "$canonical"
+    [ -n "$aliases" ] && printf '%s\n' "$aliases" | tr ',' '\n'
   done <<EOF
 $(weave_registry_rows)
 EOF
@@ -1507,6 +1508,7 @@ weave_registry_skill_assets() {
       cursor) [ "$cursor" = yes ] || continue ;;
     esac
     printf '%s\n' "$canonical"
+    [ -n "$aliases" ] && printf '%s\n' "$aliases" | tr ',' '\n'
   done <<EOF
 $(weave_registry_rows)
 EOF
@@ -2969,12 +2971,16 @@ EOF
 
 
 # Install every Codex-native skill the registry declares for this client:
-# prompt directives (which emit the leading-space form the router parses — the
-# only portable way to reach it without claiming Codex's reserved slash
-# namespace) and local-config toggles like $router-off, which shell out to this
-# installer's own verbs. weave_registry_skill_assets is the union of both.
+# prompt directives, their aliases, and local-config toggles like $router-off
+# that shell out to this installer's own verbs. weave_registry_skill_assets is
+# the union, canonical names plus aliases — Codex discovers skills by directory
+# name, so an advertised $fm needs its own installed skill rather than a
+# pointer to $force-model.
+#
+# A name with no SKILL.md is skipped: an alias may exist for the Claude command
+# surface without a Codex skill behind it (registry_test.sh pins which ones do).
 install_codex_prompt_skills() {
-  local canonical candidate skill_src dst_dir dst_file scope_args body
+  local canonical candidate skill_src dst_dir dst_file emit_src emit_dst scope_args body
   while IFS= read -r canonical; do
     skill_src=""
     for candidate in \
@@ -3008,6 +3014,22 @@ install_codex_prompt_skills() {
     body="$(<"$skill_src")"
     body="${body//\{\{SCOPE\}\}/$scope_args}"
     printf '%s\n' "$body" >"$dst_file"
+    # Prompt skills emit their directive through a script Codex execs; toggles
+    # shell out to the installer's own verbs and ship none.
+    emit_src="${skill_src%/SKILL.md}/scripts/emit.sh"
+    if [ -f "$emit_src" ]; then
+      mkdir -p "$dst_dir/scripts"
+      emit_dst="$dst_dir/scripts/emit.sh"
+      if [ "$scope" = "project" ] || [ -n "$install_dir" ]; then
+        refuse_if_symlink "$dst_dir/scripts"
+        refuse_if_symlink "$emit_dst"
+      elif [ -L "$dst_dir/scripts" ] || [ -L "$emit_dst" ]; then
+        warn "Codex skill script path contains a symlink; leaving $canonical emit.sh untouched."
+      else
+        cp "$emit_src" "$emit_dst"
+        chmod +x "$emit_dst"
+      fi
+    fi
     ok "Codex skill installed: \$$canonical"
   done <<EOF
 $(weave_registry_skill_assets codex)

--- a/install/install.sh
+++ b/install/install.sh
@@ -1371,7 +1371,13 @@ fi
 # Claude Code's settings.json and opencode's opencode.json patching both use
 # jq to deep-merge / structurally rewrite JSON. Toggling those clients reads
 # and rewrites the same JSON, so jq is required there too.
-if [ "$target" = "claude" ] || [ "$target" = "opencode" ] || [ "$target" = "pi" ]; then
+#
+# `models` is the exception for Codex: it renders and edits the router's JSON
+# payloads with jq regardless of which client's config supplied the endpoint,
+# so require it there too rather than dying mid-render on `jq: command not
+# found`. Installing Codex itself still needs no jq.
+if [ "$target" = "claude" ] || [ "$target" = "opencode" ] || [ "$target" = "pi" ] \
+   || { [ "$mode" = "models" ] && [ "$target" = "codex" ]; }; then
   require_cmd jq    "macOS: 'brew install jq' · Debian/Ubuntu: 'sudo apt install jq'"
 fi
 # curl is used by the install/update paths' health/validate probes and by every
@@ -2336,7 +2342,7 @@ models_fail() {
       if [ -n "$detail" ]; then
         err "$detail"
       else
-        err "The router rejected this installation's key. Re-run 'npx @workweave/router --claude --rotate-key' to install a current one."
+        err "The router rejected this installation's key. Re-run 'npx @workweave/router --$target --rotate-key' to install a current one."
       fi
       ;;
     404)
@@ -2448,8 +2454,8 @@ models_list() {
   fi
   models_render_list "$models_http_body"
   models_print_preferred
-  printf "\n%sEnable a model:%s  npx @workweave/router models enable <id> --claude\n" "$C_DIM" "$C_RESET"
-  printf "%sDisable a model:%s npx @workweave/router models disable <id> --claude\n" "$C_DIM" "$C_RESET"
+  printf "\n%sEnable a model:%s  npx @workweave/router models enable <id> --%s\n" "$C_DIM" "$C_RESET" "$target"
+  printf "%sDisable a model:%s npx @workweave/router models disable <id> --%s\n" "$C_DIM" "$C_RESET" "$target"
 }
 
 models_providers_list() {
@@ -2533,14 +2539,17 @@ models_prefer() {
 }
 
 models_usage() {
+  # Echo back the client the caller actually named, so a Codex user is never
+  # told to run a command that would target (or create) a Claude Code install.
+  local c="--${target}"
   err "$1"
   printf '%s\n' \
-    "  npx @workweave/router models --claude                          # list models" \
-    "  npx @workweave/router models enable  <id> [<id>…] --claude" \
-    "  npx @workweave/router models disable <id> [<id>…] --claude" \
-    "  npx @workweave/router models providers --claude                # list providers" \
-    "  npx @workweave/router models providers disable <name> --claude" \
-    "  npx @workweave/router models prefer <id> [<id>…] --claude      # ranking ('clear' to drop)" >&2
+    "  npx @workweave/router models $c                          # list models" \
+    "  npx @workweave/router models enable  <id> [<id>…] $c" \
+    "  npx @workweave/router models disable <id> [<id>…] $c" \
+    "  npx @workweave/router models providers $c                # list providers" \
+    "  npx @workweave/router models providers disable <name> $c" \
+    "  npx @workweave/router models prefer <id> [<id>…] $c      # ranking ('clear' to drop)" >&2
   exit 2
 }
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -2990,8 +2990,54 @@ install_codex_prompt_skills() {
       [ -f "$candidate" ] || continue
       skill_src="$candidate"
       break
+<<<<<<< HEAD
     done
     [ -n "$skill_src" ] || continue
+=======
+    fi
+  done
+  [ -n "$skill_src" ] || { warn "Codex disable-routing skill template is missing; router configuration is still installed."; return 0; }
+  grep -Fq "$WEAVE_CODEX_SKILL_MARKER" "$skill_src" \
+    || { warn "Codex disable-routing skill template has no ownership marker; leaving skills unchanged."; return 0; }
+
+  dst_dir="$codex_dir/skills/disable-routing"
+  dst_file="$dst_dir/SKILL.md"
+  if [ "$scope" = "project" ] || [ -n "$install_dir" ]; then
+    refuse_if_symlink "$codex_dir/skills"
+    refuse_if_symlink "$dst_dir"
+    refuse_if_symlink "$dst_file"
+  elif [ -L "$codex_dir/skills" ] || [ -L "$dst_dir" ] || [ -L "$dst_file" ]; then
+    warn "Codex disable-routing skill path contains a symlink; leaving it untouched."
+    return 0
+  fi
+  if [ -e "$dst_file" ] && { [ ! -f "$dst_file" ] || ! grep -Fq "$WEAVE_CODEX_SKILL_MARKER" "$dst_file"; }; then
+    warn "A user-owned Codex disable-routing skill already exists at $dst_file; leaving it untouched."
+    return 0
+  fi
+  mkdir -p "$dst_dir"
+
+  scope_args=""
+  if [ -n "$install_dir" ]; then
+    scope_args=" --dir $(printf '%q' "$install_dir")"
+  elif [ "$scope" = "project" ]; then
+    scope_args=" --scope project"
+  fi
+  body="$(<"$skill_src")"
+  body="${body//\{\{SCOPE\}\}/$scope_args}"
+  printf '%s\n' "$body" >"$dst_file"
+  ok "Codex skill installed: \$disable-routing"
+}
+
+# Install prompt directives as Codex-native skills. Codex cannot append a
+# user message from a skill, so each skill ships scripts/emit.sh. Codex
+# execs that script; the router intercepts the leading-space directive in
+# the tool output without claiming Codex's reserved slash namespace.
+install_codex_prompt_skills() {
+  local canonical skill_src dst_dir dst_file emit_src emit_dst scope_args body
+  while IFS= read -r canonical; do
+    skill_src="$script_dir/codex-skills/$canonical/SKILL.md"
+    [ -f "$skill_src" ] || continue
+>>>>>>> a8113add (Emit Codex router directives from a skill script)
     grep -Fq "<!-- weave-router managed $canonical skill -->" "$skill_src" || continue
     dst_dir="$codex_dir/skills/$canonical"
     dst_file="$dst_dir/SKILL.md"
@@ -3014,9 +3060,13 @@ install_codex_prompt_skills() {
     body="$(<"$skill_src")"
     body="${body//\{\{SCOPE\}\}/$scope_args}"
     printf '%s\n' "$body" >"$dst_file"
+<<<<<<< HEAD
     # Prompt skills emit their directive through a script Codex execs; toggles
     # shell out to the installer's own verbs and ship none.
     emit_src="${skill_src%/SKILL.md}/scripts/emit.sh"
+=======
+    emit_src="$script_dir/codex-skills/$canonical/scripts/emit.sh"
+>>>>>>> a8113add (Emit Codex router directives from a skill script)
     if [ -f "$emit_src" ]; then
       mkdir -p "$dst_dir/scripts"
       emit_dst="$dst_dir/scripts/emit.sh"

--- a/install/npm/README.md
+++ b/install/npm/README.md
@@ -53,7 +53,9 @@ npx @workweave/router status --codex    # is Codex on the router or direct?
 Claude Code reads its router setting at launch, so quit and reopen it after an
 on/off. Codex and opencode pick it up on their next run. Inside Claude Code the
 slash commands `/router-off`, `/router-on`, and `/router-status` do the same.
-Codex installs a `$disable-routing` skill that switches its next session back
+Codex installs `$router-status`, `$router-off`, `$router-on`, and
+`$router-models` skills that call the same CLI verbs, plus a
+`$disable-routing` skill that switches its next session back
 to the normal provider; Codex does not support third-party `/disable-routing`
 slash commands. The shell equivalent is `npx @workweave/router disable-routing`.
 Cursor has no config file we own — toggle its base URL override in **Settings →
@@ -63,6 +65,7 @@ Pick which models the router is allowed to route to:
 
 ```bash
 npx @workweave/router models --claude                  # list every model, with its on/off state
+npx @workweave/router models --codex                   # same, for a Codex install
 npx @workweave/router models disable gpt-5.6 --claude  # take one out of rotation
 npx @workweave/router models enable gpt-5.6 --claude   # put it back
 ```

--- a/install/npm/README.md
+++ b/install/npm/README.md
@@ -110,9 +110,14 @@ Four install targets:
   The block lives between begin/end markers
   so re-running the installer rewrites it cleanly and `--uninstall --codex`
   removes it without touching the rest of your config. Codex does not load
-  third-party slash-command files; to send a router directive, type it with
-  one leading space (for example, ` /force-model gpt-5.6-terra`). Its
-  `$disable-routing` skill returns the next Codex session to the default
+  third-party slash-command files; the installer provides native skills
+  `$force-model` (`$fm`), `$unforce-model` (`$ufm`), and `$router-feedback`
+  (`$rf`), each of which execs a local `scripts/emit.sh` that prints the same
+  leading-space directive Claude Code uses (for example,
+  ` /force-model gpt-5.6-terra`) — you can also type that form directly. It
+  also installs `$router-status`, `$router-off`, `$router-on`, and
+  `$router-models`, which call this installer's own verbs, plus a
+  `$disable-routing` skill that returns the next Codex session to the default
   provider without logging out or deleting the router configuration. The
   managed lifecycle hooks also keep the latest routed model in the terminal
   title and emit a compact status message when the router reports a new route.

--- a/install/npm/README.md
+++ b/install/npm/README.md
@@ -111,7 +111,6 @@ Four install targets:
   so re-running the installer rewrites it cleanly and `--uninstall --codex`
   removes it without touching the rest of your config. Codex does not load
   third-party slash-command files; the installer provides native skills
-<<<<<<< HEAD
   `$force-model` (`$fm`), `$unforce-model` (`$ufm`), and `$router-feedback`
   (`$rf`), each of which execs a local `scripts/emit.sh` that prints the same
   leading-space directive Claude Code uses (for example,
@@ -122,15 +121,6 @@ Four install targets:
   provider without logging out or deleting the router configuration. The
   managed lifecycle hooks also keep the latest routed model in the terminal
   title and emit a compact status message when the router reports a new route.
-=======
-  `$force-model` (`$fm`), `$unforce-model` (`$ufm`), and
-  `$router-feedback` (`$rf`). Each skill execs a local `scripts/emit.sh` that
-  prints the same leading-space directive Claude Code uses (for example,
-  ` /force-model gpt-5.6-terra`); the router intercepts that tool output.
-  You can type that form directly. Its `$disable-routing` skill returns the next Codex
-  session to the default provider without logging out or deleting the router
-  configuration.
->>>>>>> a8113add (Emit Codex router directives from a skill script)
 - **opencode** (`--opencode`) — merges a `provider.weave` entry (backed by
   opencode's built-in `@ai-sdk/anthropic` provider) into
   `~/.config/opencode/opencode.json` (or `<repo>/opencode.json` with

--- a/install/npm/README.md
+++ b/install/npm/README.md
@@ -111,6 +111,7 @@ Four install targets:
   so re-running the installer rewrites it cleanly and `--uninstall --codex`
   removes it without touching the rest of your config. Codex does not load
   third-party slash-command files; the installer provides native skills
+<<<<<<< HEAD
   `$force-model` (`$fm`), `$unforce-model` (`$ufm`), and `$router-feedback`
   (`$rf`), each of which execs a local `scripts/emit.sh` that prints the same
   leading-space directive Claude Code uses (for example,
@@ -121,6 +122,15 @@ Four install targets:
   provider without logging out or deleting the router configuration. The
   managed lifecycle hooks also keep the latest routed model in the terminal
   title and emit a compact status message when the router reports a new route.
+=======
+  `$force-model` (`$fm`), `$unforce-model` (`$ufm`), and
+  `$router-feedback` (`$rf`). Each skill execs a local `scripts/emit.sh` that
+  prints the same leading-space directive Claude Code uses (for example,
+  ` /force-model gpt-5.6-terra`); the router intercepts that tool output.
+  You can type that form directly. Its `$disable-routing` skill returns the next Codex
+  session to the default provider without logging out or deleting the router
+  configuration.
+>>>>>>> a8113add (Emit Codex router directives from a skill script)
 - **opencode** (`--opencode`) — merges a `provider.weave` entry (backed by
   opencode's built-in `@ai-sdk/anthropic` provider) into
   `~/.config/opencode/opencode.json` (or `<repo>/opencode.json` with

--- a/install/npm/scripts/copy-installer.js
+++ b/install/npm/scripts/copy-installer.js
@@ -76,6 +76,7 @@ for (const line of registryText.split(/\r?\n/)) {
     mkdirSync(path.dirname(dst), { recursive: true });
     copyFileSync(src, dst);
     console.log(`Copied codex-skills/${name}/SKILL.md.`);
+<<<<<<< HEAD
     // Prompt skills emit their directive through a script; toggles shell out to
     // the installer's own verbs and ship no script.
     const emitSrc = path.join(installDir, "codex-skills", name, "scripts", "emit.sh");
@@ -86,6 +87,22 @@ for (const line of registryText.split(/\r?\n/)) {
     copyFileSync(emitSrc, emitDst);
     chmodSync(emitDst, 0o755);
     console.log(`Copied codex-skills/${name}/scripts/emit.sh.`);
+=======
+    const emitSrc = path.join(installDir, "codex-skills", name, "scripts", "emit.sh");
+    const emitDst = path.join(root, "codex-skills", name, "scripts", "emit.sh");
+    try {
+      if (lstatSync(emitSrc).isSymbolicLink()) throw new Error(`Invalid Codex skill script: ${emitSrc}`);
+      mkdirSync(path.dirname(emitDst), { recursive: true });
+      copyFileSync(emitSrc, emitDst);
+      chmodSync(emitDst, 0o755);
+      console.log(`Copied codex-skills/${name}/scripts/emit.sh.`);
+    } catch (err) {
+      if (err && err.code === "ENOENT") {
+        throw new Error(`Codex skill ${name} is missing scripts/emit.sh`);
+      }
+      throw err;
+    }
+>>>>>>> a8113add (Emit Codex router directives from a skill script)
   }
 }
 

--- a/install/npm/scripts/copy-installer.js
+++ b/install/npm/scripts/copy-installer.js
@@ -72,11 +72,17 @@ for (const line of registryText.split(/\r?\n/)) {
   for (const name of names) {
     const src = path.join(installDir, "codex-skills", name, "SKILL.md");
     const dst = path.join(root, "codex-skills", name, "SKILL.md");
+    // An alias may exist for the Claude command surface without a Codex skill
+    // behind it (e.g. `models`), so a missing alias asset is not an error — but
+    // a missing canonical one means the registry declared a skill we don't ship.
+    if (!existsSync(src)) {
+      if (name === fields[0]) throw new Error(`Codex skill ${name} is declared in directives.tsv but missing`);
+      continue;
+    }
     if (lstatSync(src).isSymbolicLink()) throw new Error(`Invalid Codex skill: ${src}`);
     mkdirSync(path.dirname(dst), { recursive: true });
     copyFileSync(src, dst);
     console.log(`Copied codex-skills/${name}/SKILL.md.`);
-<<<<<<< HEAD
     // Prompt skills emit their directive through a script; toggles shell out to
     // the installer's own verbs and ship no script.
     const emitSrc = path.join(installDir, "codex-skills", name, "scripts", "emit.sh");
@@ -87,22 +93,6 @@ for (const line of registryText.split(/\r?\n/)) {
     copyFileSync(emitSrc, emitDst);
     chmodSync(emitDst, 0o755);
     console.log(`Copied codex-skills/${name}/scripts/emit.sh.`);
-=======
-    const emitSrc = path.join(installDir, "codex-skills", name, "scripts", "emit.sh");
-    const emitDst = path.join(root, "codex-skills", name, "scripts", "emit.sh");
-    try {
-      if (lstatSync(emitSrc).isSymbolicLink()) throw new Error(`Invalid Codex skill script: ${emitSrc}`);
-      mkdirSync(path.dirname(emitDst), { recursive: true });
-      copyFileSync(emitSrc, emitDst);
-      chmodSync(emitDst, 0o755);
-      console.log(`Copied codex-skills/${name}/scripts/emit.sh.`);
-    } catch (err) {
-      if (err && err.code === "ENOENT") {
-        throw new Error(`Codex skill ${name} is missing scripts/emit.sh`);
-      }
-      throw err;
-    }
->>>>>>> a8113add (Emit Codex router directives from a skill script)
   }
 }
 

--- a/install/npm/scripts/copy-installer.js
+++ b/install/npm/scripts/copy-installer.js
@@ -44,18 +44,7 @@ for (const f of readdirSync(commandsSrc)) {
   console.log(`Copied commands/${f}.`);
 }
 
-// Codex discovers local skills under $CODEX_HOME/skills. Bundle the one
-// installer-owned template explicitly, refusing a source symlink just as the
-// command-file packaging path above does.
-const codexSkillSrc = path.join(installDir, "codex-skills", "disable-routing", "SKILL.md");
-const codexSkillDst = path.join(root, "codex-skills", "disable-routing", "SKILL.md");
-if (lstatSync(codexSkillSrc).isSymbolicLink()) {
-  throw new Error(`Refusing to package symlinked Codex skill: ${codexSkillSrc}`);
-}
-mkdirSync(path.dirname(codexSkillDst), { recursive: true });
-copyFileSync(codexSkillSrc, codexSkillDst);
-console.log("Copied codex-skills/disable-routing/SKILL.md.");
-
+// Codex discovers local skills under $CODEX_HOME/skills.
 const registryNames = new Set();
 for (const line of registryText.split(/\r?\n/)) {
   if (!line || line.startsWith("#")) continue;
@@ -70,10 +59,13 @@ for (const file of readdirSync(commandsSrc)) {
 }
 
 // registry prevents a newly supported directive from being omitted at publish time.
+// Keyed on the skill adapter, not capability: Codex ships local-config toggles
+// ($router-off/$router-on/$router-status/$disable-routing) as skills too.
 for (const line of registryText.split(/\r?\n/)) {
   if (!line || line.startsWith("#")) continue;
   const fields = line.split("|");
-  if (fields[2] !== "prompt" || fields[4] !== "yes") continue;
+  if (fields[4] !== "yes") continue;
+  if (!(fields[8] || "").split(",").includes("skill")) continue;
   const name = fields[0];
   const src = path.join(installDir, "codex-skills", name, "SKILL.md");
   const dst = path.join(root, "codex-skills", name, "SKILL.md");

--- a/install/npm/scripts/copy-installer.js
+++ b/install/npm/scripts/copy-installer.js
@@ -4,7 +4,7 @@
 // published tarball is self-contained. Keeps a single source of truth for
 // the shell installer.
 
-const { copyFileSync, cpSync, chmodSync, mkdirSync, readdirSync, lstatSync, realpathSync } = require("node:fs");
+const { copyFileSync, cpSync, chmodSync, existsSync, mkdirSync, readdirSync, lstatSync, realpathSync } = require("node:fs");
 const path = require("node:path");
 
 const root = path.resolve(__dirname, "..");
@@ -66,13 +66,27 @@ for (const line of registryText.split(/\r?\n/)) {
   const fields = line.split("|");
   if (fields[4] !== "yes") continue;
   if (!(fields[8] || "").split(",").includes("skill")) continue;
-  const name = fields[0];
-  const src = path.join(installDir, "codex-skills", name, "SKILL.md");
-  const dst = path.join(root, "codex-skills", name, "SKILL.md");
-  if (!lstatSync(src) || lstatSync(src).isSymbolicLink()) throw new Error(`Invalid Codex skill: ${src}`);
-  mkdirSync(path.dirname(dst), { recursive: true });
-  copyFileSync(src, dst);
-  console.log(`Copied codex-skills/${name}/SKILL.md.`);
+  // Canonical name plus every alias: Codex discovers skills by directory name,
+  // so an advertised $fm needs its own installed skill.
+  const names = [fields[0], ...(fields[1] || "").split(",").filter(Boolean)];
+  for (const name of names) {
+    const src = path.join(installDir, "codex-skills", name, "SKILL.md");
+    const dst = path.join(root, "codex-skills", name, "SKILL.md");
+    if (lstatSync(src).isSymbolicLink()) throw new Error(`Invalid Codex skill: ${src}`);
+    mkdirSync(path.dirname(dst), { recursive: true });
+    copyFileSync(src, dst);
+    console.log(`Copied codex-skills/${name}/SKILL.md.`);
+    // Prompt skills emit their directive through a script; toggles shell out to
+    // the installer's own verbs and ship no script.
+    const emitSrc = path.join(installDir, "codex-skills", name, "scripts", "emit.sh");
+    if (!existsSync(emitSrc)) continue;
+    const emitDst = path.join(root, "codex-skills", name, "scripts", "emit.sh");
+    if (lstatSync(emitSrc).isSymbolicLink()) throw new Error(`Invalid Codex skill script: ${emitSrc}`);
+    mkdirSync(path.dirname(emitDst), { recursive: true });
+    copyFileSync(emitSrc, emitDst);
+    chmodSync(emitDst, 0o755);
+    console.log(`Copied codex-skills/${name}/scripts/emit.sh.`);
+  }
 }
 
 // installer and the pi-router extension: pi loads it via the "pi.extensions"

--- a/install/registry.sh
+++ b/install/registry.sh
@@ -58,6 +58,7 @@ weave_registry_skill_names() {
       cursor) [ "$cursor" = yes ] || continue ;;
     esac
     printf '%s\n' "$canonical"
+    [ -n "$aliases" ] && printf '%s\n' "$aliases" | tr ',' '\n'
   done <<EOF
 $(weave_registry_rows)
 EOF
@@ -77,6 +78,7 @@ weave_registry_skill_assets() {
       cursor) [ "$cursor" = yes ] || continue ;;
     esac
     printf '%s\n' "$canonical"
+    [ -n "$aliases" ] && printf '%s\n' "$aliases" | tr ',' '\n'
   done <<EOF
 $(weave_registry_rows)
 EOF

--- a/install/tests/codex_install_test.sh
+++ b/install/tests/codex_install_test.sh
@@ -117,6 +117,13 @@ grep -Fq '<!-- weave-router managed disable-routing skill -->' "$skill" \
   || fail "Codex disable-routing skill has no ownership marker"
 grep -Fq 'weave-router off --codex' "$skill" \
   || fail "Codex disable-routing skill does not use the safe off toggle"
+
+for alias in fm ufm rf; do
+  alias_skill="$home/.codex/skills/$alias/SKILL.md"
+  [ -f "$alias_skill" ] || fail "Codex \$$alias skill was not installed"
+  grep -Fq "<!-- weave-router managed $alias skill -->" "$alias_skill" \
+    || fail "Codex \$$alias skill has no ownership marker"
+done
 if HOME="$home" PATH="$test_path" NO_COLOR=1 bash "$installer" disable-routing --claude --scope user --quiet >/dev/null 2>&1; then
   fail "disable-routing accepted a non-Codex target"
 fi

--- a/install/tests/codex_install_test.sh
+++ b/install/tests/codex_install_test.sh
@@ -124,6 +124,10 @@ for alias in fm ufm rf; do
   grep -Fq "<!-- weave-router managed $alias skill -->" "$alias_skill" \
     || fail "Codex \$$alias skill has no ownership marker"
 done
+for name in force-model fm unforce-model ufm router-feedback rf; do
+  emit="$home/.codex/skills/$name/scripts/emit.sh"
+  [ -x "$emit" ] || fail "Codex \$$name skill is missing an executable emit.sh"
+done
 if HOME="$home" PATH="$test_path" NO_COLOR=1 bash "$installer" disable-routing --claude --scope user --quiet >/dev/null 2>&1; then
   fail "disable-routing accepted a non-Codex target"
 fi
@@ -144,6 +148,12 @@ run_hosted_install
 run_uninstall
 [ ! -e "$skill" ] || fail "uninstall did not remove the Codex disable-routing skill"
 [ ! -e "$status_helper" ] || fail "uninstall did not remove the Codex status helper"
+
+for name in force-model fm unforce-model ufm router-feedback rf \
+            router-off router-on router-status router-models; do
+  [ ! -e "$home/.codex/skills/$name" ] \
+    || fail "uninstall left the Codex \$$name skill directory behind"
+done
 
 # A pre-existing hooks scalar or table is incompatible with inline lifecycle
 # arrays. Preserve either user shape and install routing without managed hooks.

--- a/install/tests/models_test.sh
+++ b/install/tests/models_test.sh
@@ -42,7 +42,13 @@ while [ $# -gt 0 ]; do
     *) shift ;;
   esac
 done
-cat >/dev/null 2>&1 || true   # drain the key header on stdin
+# The key rides in on stdin (curl --header @-). Normally just drained; when
+# KEY_LOG is set, record it so a test can assert which install's key was sent.
+if [ -n "${KEY_LOG:-}" ]; then
+  cat >>"$KEY_LOG" 2>/dev/null || true
+else
+  cat >/dev/null 2>&1 || true
+fi
 path="${url#http://}"; path="${path#https://}"; path="/${path#*/}"
 [ -n "${REQUEST_LOG:-}" ] && printf '%s %s %s\n' "$method" "$path" "$body" >>"$REQUEST_LOG"
 
@@ -114,6 +120,25 @@ seed_install() { # seed_install <home> <base-url> <key>
 EOF
 }
 
+# seed_codex_install writes the managed config.toml block a Codex install
+# leaves behind. Codex keeps the endpoint and the key in one file, which is why
+# `models --codex` needs no endpoint-trust split (see models_endpoint_is_trusted).
+seed_codex_install() { # seed_codex_install <home> <base-url> <key>
+  mkdir -p "$1/.codex"
+  cat >"$1/.codex/config.toml" <<EOF
+# >>> weave-router managed (do not edit between markers) >>>
+model_provider = "weave"
+
+[model_providers.weave]
+name = "Weave Router"
+base_url = "$2/v1"
+wire_api = "responses"
+requires_openai_auth = true
+http_headers = { "X-Weave-Router-Key" = "$3", "X-App" = "codex" }
+# <<< weave-router managed <<<
+EOF
+}
+
 # run_models <home> -- <installer args...>. Sets $out (stdout+stderr) and $rc.
 # Deliberately not a command substitution at the call site: that would run the
 # function in a subshell and throw the exit status away.
@@ -124,6 +149,7 @@ run_models() {
   [ "${1:-}" = "--" ] && shift
   HOME="$home" XDG_CACHE_HOME="$home/.cache" PATH="$test_path" NO_COLOR=1 \
     ROUTER_MODE="${ROUTER_MODE:-full}" REQUEST_LOG="${REQUEST_LOG:-}" \
+    KEY_LOG="${KEY_LOG:-}" \
     bash "$installer" models "$@" </dev/null >"$work/out" 2>&1
   rc=$?
   out="$(cat "$work/out")"
@@ -418,13 +444,29 @@ check "the explicit endpoint is the one called" \
 
 # ---------- argument handling ----------
 
-run_models "$home" -- --codex
-check "models rejects a non-Claude client" "$rc" "2"
-contains "models says which client it supports" "$out" "supports --claude only"
+# Codex is a supported client: it resolves the endpoint and key out of its own
+# managed config.toml, so the command reaches the router instead of refusing.
+codex_home="$work/codex-home"
+mkdir -p "$codex_home"
+seed_codex_install "$codex_home" "http://127.0.0.1:8080" "rk_codex"
+export REQUEST_LOG="$work/codex.log"
+export KEY_LOG="$work/codex.key"
+: >"$REQUEST_LOG"; : >"$KEY_LOG"
+run_models "$codex_home" -- --codex
+check "models accepts a Codex install" "$rc" "0"
+check "the Codex install's endpoint is the one called" \
+  "$(grep -c '^GET /admin/v1/models ' "$REQUEST_LOG")" "1"
+contains "the Codex install's key is the one sent" "$(cat "$KEY_LOG")" "rk_codex"
+unset REQUEST_LOG KEY_LOG
+
+# opencode and pi have no endpoint-trust story yet, so they stay refused.
+run_models "$home" -- --opencode
+check "models rejects an unsupported client" "$rc" "2"
+contains "models says which clients it supports" "$out" "supports --claude and --codex only"
 
 HOME="$home" PATH="$test_path" NO_COLOR=1 bash "$installer" models </dev/null >"$work/out" 2>&1
 check "models without a client flag is refused" "$?" "2"
-contains "models without a client flag names --claude" "$(cat "$work/out")" "requires an explicit client"
+contains "models without a client flag names its clients" "$(cat "$work/out")" "requires an explicit client"
 
 run_models "$home" -- enable --claude
 check "enable with no model id is refused" "$rc" "2"

--- a/install/tests/packaging_test.sh
+++ b/install/tests/packaging_test.sh
@@ -97,7 +97,7 @@ HOME="$home" PATH="$home/bin:$PATH" WEAVE_ROUTER_KEY="rk_test_key" NO_COLOR=1 \
 
 installed="$(cd "$home/.codex/skills" 2>/dev/null && ls -d */ 2>/dev/null | tr -d '/' | sort | tr '\n' ' ' | sed 's/ $//')"
 check "the packed entrypoint installs every Codex skill" \
-  "disable-routing force-model router-feedback router-models router-off router-on router-status unforce-model" "$installed"
+  "disable-routing fm force-model rf router-feedback router-models router-off router-on router-status ufm unforce-model" "$installed"
 
 HOME="$home" PATH="$home/bin:$PATH" WEAVE_ROUTER_KEY="rk_test_key" NO_COLOR=1 \
   node "$root/bin.js" --claude --scope user --quiet --base-url http://127.0.0.1:9 >/dev/null 2>&1 || true

--- a/install/tests/packaging_test.sh
+++ b/install/tests/packaging_test.sh
@@ -97,7 +97,7 @@ HOME="$home" PATH="$home/bin:$PATH" WEAVE_ROUTER_KEY="rk_test_key" NO_COLOR=1 \
 
 installed="$(cd "$home/.codex/skills" 2>/dev/null && ls -d */ 2>/dev/null | tr -d '/' | sort | tr '\n' ' ' | sed 's/ $//')"
 check "the packed entrypoint installs every Codex skill" \
-  "disable-routing force-model router-feedback unforce-model" "$installed"
+  "disable-routing force-model router-feedback router-models router-off router-on router-status unforce-model" "$installed"
 
 HOME="$home" PATH="$home/bin:$PATH" WEAVE_ROUTER_KEY="rk_test_key" NO_COLOR=1 \
   node "$root/bin.js" --claude --scope user --quiet --base-url http://127.0.0.1:9 >/dev/null 2>&1 || true

--- a/install/tests/registry_test.sh
+++ b/install/tests/registry_test.sh
@@ -53,12 +53,14 @@ while IFS='|' read -r canonical aliases capability claude codex opencode pi curs
 done < <(weave_registry_rows)
 check "every row declares a known capability and client support" "" "$bad_rows"
 
-# Aliases must be unique across the whole registry, otherwise two directives
-# would fight over one filename.
+# Names repeated across clients are the same directive installed for each of
+# them (Codex ships most of Claude Code's set as skills). Pinning the exact
+# overlap catches a genuine collision — two *different* directives claiming one
+# filename — which would otherwise hide in this list.
 dupes="$(weave_registry_names claude; weave_registry_names codex; weave_registry_names opencode)"
 dupes="$(printf '%s\n' "$dupes" | sort | uniq -d | tr '\n' ' ' | sed 's/ $//')"
-check "no name collides across clients' installed sets" \
-  "fm force-model rf router-feedback ufm unforce-model" "$dupes"
+check "names shared across clients are the expected shared directives" \
+  "fm force-model models rf router-feedback router-models router-off router-on router-status ufm unforce-model" "$dupes"
 
 check "an alias resolves to its canonical directive" "force-model" "$(weave_registry_canonical_for fm)"
 check "a canonical name resolves to itself" "router-feedback" "$(weave_registry_canonical_for router-feedback)"
@@ -206,7 +208,7 @@ cx_home="$work/codex-user"; mkdir -p "$cx_home"
 run_install "$cx_home" --codex --scope user
 codex_skills="$(cd "$cx_home/.codex/skills" && ls -d */ 2>/dev/null | tr -d '/' | sort | tr '\n' ' ' | sed 's/ $//')"
 check "codex user install writes a skill per supported directive" \
-  "disable-routing force-model router-feedback unforce-model" "$codex_skills"
+  "disable-routing force-model router-feedback router-models router-off router-on router-status unforce-model" "$codex_skills"
 check "codex install writes no prompt wrappers" "" \
   "$(ls "$cx_home/.codex/prompts" 2>/dev/null | tr '\n' ' ' | sed 's/ $//')"
 
@@ -218,6 +220,20 @@ for name in force-model unforce-model router-feedback; do
     ok "codex \$$name expands to a leading-space directive"
   else
     no "codex \$$name expands to a leading-space directive" "a literal leading space" "$(grep -m1 "/$name" "$skill")"
+  fi
+done
+
+# Local-config toggles reach the installer's own verbs. A skill that names the
+# wrong verb (or the wrong client) silently edits the wrong install, so pin the
+# command each one shells out to.
+for name in router-off:off router-on:on router-status:status router-models:models; do
+  skill_name="${name%%:*}"; verb="${name##*:}"
+  skill="$cx_home/.codex/skills/$skill_name/SKILL.md"
+  if grep -Fq "weave-router $verb --codex" "$skill"; then
+    ok "codex \$$skill_name shells out to '$verb --codex'"
+  else
+    no "codex \$$skill_name shells out to '$verb --codex'" \
+      "weave-router $verb --codex" "$(grep -m1 'weave-router' "$skill" || echo 'no weave-router call')"
   fi
 done
 

--- a/install/tests/registry_test.sh
+++ b/install/tests/registry_test.sh
@@ -243,6 +243,21 @@ for name in router-off:off router-on:on router-status:status router-models:model
   fi
 done
 
+# A skill may only advertise a $name the installer actually creates. Codex
+# discovers skills by directory name, so telling the user to invoke an alias
+# that was never installed advertises a command that cannot run.
+bad_alias=""
+for dir in "$cx_home"/.codex/skills/*/; do
+  skill="$dir/SKILL.md"
+  [ -f "$skill" ] || continue
+  while IFS= read -r advertised; do
+    [ -n "$advertised" ] || continue
+    [ -d "$cx_home/.codex/skills/$advertised" ] \
+      || bad_alias="$bad_alias $(basename "$dir"):\$$advertised"
+  done < <(grep -oE '\$[a-z][a-z-]+' "$skill" | tr -d '$' | sort -u)
+done
+check "every \$name a Codex skill advertises is installed" "" "$bad_alias"
+
 # jq is a hard requirement for the Claude/opencode/pi JSON merges, but Codex
 # writes TOML and plain files — installing skills must not start needing it.
 nojq_bin="$work/nojq"; mkdir -p "$nojq_bin"

--- a/install/tests/registry_test.sh
+++ b/install/tests/registry_test.sh
@@ -212,17 +212,20 @@ check "codex user install writes a skill per supported directive" \
 check "codex install writes no prompt wrappers" "" \
   "$(ls "$cx_home/.codex/prompts" 2>/dev/null | tr '\n' ' ' | sed 's/ $//')"
 
-# The Codex skills must instruct the leading-space normal prompt: Codex
+# A Codex skill cannot author a user message, so each one execs emit.sh, whose
+# output carries the leading-space directive the router intercepts. Codex
 # reserves `/…` for its own built-ins, so a bare slash never reaches the router.
 for name in force-model unforce-model router-feedback fm ufm rf; do
-  skill="$cx_home/.codex/skills/$name/SKILL.md"
+  emit="$cx_home/.codex/skills/$name/scripts/emit.sh"
   case "$name" in
     fm) command=force-model ;; ufm) command=unforce-model ;; rf) command=router-feedback ;; *) command="$name" ;;
   esac
-  if grep -qF " /$command" "$skill"; then
-    ok "codex \$$name expands to a leading-space directive"
+  if [ -x "$emit" ] && [ "$(bash "$emit" probe-arg)" = " /$command probe-arg" ] 2>/dev/null; then
+    ok "codex \$$name emits a leading-space directive"
+  elif [ -x "$emit" ] && [ "$(bash "$emit")" = " /$command" ] 2>/dev/null; then
+    ok "codex \$$name emits a leading-space directive"
   else
-    no "codex \$$name expands to a leading-space directive" "a literal leading space" "$(grep -m1 "/$name" "$skill")"
+    no "codex \$$name emits a leading-space directive" " /$command" "$( [ -x "$emit" ] && bash "$emit" probe-arg 2>&1 || echo 'no executable emit.sh')"
   fi
 done
 

--- a/install/tests/registry_test.sh
+++ b/install/tests/registry_test.sh
@@ -208,15 +208,18 @@ cx_home="$work/codex-user"; mkdir -p "$cx_home"
 run_install "$cx_home" --codex --scope user
 codex_skills="$(cd "$cx_home/.codex/skills" && ls -d */ 2>/dev/null | tr -d '/' | sort | tr '\n' ' ' | sed 's/ $//')"
 check "codex user install writes a skill per supported directive" \
-  "disable-routing force-model router-feedback router-models router-off router-on router-status unforce-model" "$codex_skills"
+  "disable-routing fm force-model rf router-feedback router-models router-off router-on router-status ufm unforce-model" "$codex_skills"
 check "codex install writes no prompt wrappers" "" \
   "$(ls "$cx_home/.codex/prompts" 2>/dev/null | tr '\n' ' ' | sed 's/ $//')"
 
 # The Codex skills must instruct the leading-space normal prompt: Codex
 # reserves `/…` for its own built-ins, so a bare slash never reaches the router.
-for name in force-model unforce-model router-feedback; do
+for name in force-model unforce-model router-feedback fm ufm rf; do
   skill="$cx_home/.codex/skills/$name/SKILL.md"
-  if grep -qF " /$name" "$skill"; then
+  case "$name" in
+    fm) command=force-model ;; ufm) command=unforce-model ;; rf) command=router-feedback ;; *) command="$name" ;;
+  esac
+  if grep -qF " /$command" "$skill"; then
     ok "codex \$$name expands to a leading-space directive"
   else
     no "codex \$$name expands to a leading-space directive" "a literal leading space" "$(grep -m1 "/$name" "$skill")"

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -608,6 +608,13 @@ EOF
         if grep -Fq "<!-- weave-router managed $canonical skill -->" "$skill_file"; then
           rm -f "$skill_file"
           ok "Removed $skill_file"
+          # The prompt skills also ship scripts/emit.sh; leaving it behind
+          # strands a directory Codex still advertises as a skill.
+          emit_file="$skill_dir/scripts/emit.sh"
+          if [ ! -L "$skill_dir/scripts" ] && [ ! -L "$emit_file" ] && [ -f "$emit_file" ]; then
+            rm -f "$emit_file"
+            rmdir "$skill_dir/scripts" 2>/dev/null || true
+          fi
         else
           warn "Leaving user-owned Codex skill at $skill_file untouched."
         fi

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -42,11 +42,11 @@ WEAVE_REGISTRY_DATA=$(cat <<'WEAVE_REGISTRY_EOF'
 force-model|fm|prompt|yes|yes|yes|yes|manual|command,skill
 unforce-model|ufm|prompt|yes|yes|yes|yes|manual|command,skill
 router-feedback|rf|prompt|yes|yes|yes|no|manual|command,skill
-router-off||local-toggle|yes|no|no|no|manual|command
-router-on||local-toggle|yes|no|no|no|manual|command
-router-status||local-toggle|yes|no|no|no|manual|command
+router-off||local-toggle|yes|yes|no|no|manual|command,skill
+router-on||local-toggle|yes|yes|no|no|manual|command,skill
+router-status||local-toggle|yes|yes|no|no|manual|command,skill
 router-session||prompt|yes|no|no|no|manual|command
-router-models|models|local-toggle|yes|no|no|no|manual|command
+router-models|models|local-toggle|yes|yes|no|no|manual|command,skill
 disable-routing||local-toggle|no|yes|no|no|manual|skill
 WEAVE_REGISTRY_EOF
 )
@@ -202,7 +202,6 @@ fi
 # Markers must stay in sync with install.sh. Keep verbatim.
 WEAVE_CODEX_BEGIN_MARKER="# >>> weave-router managed (do not edit between markers) >>>"
 WEAVE_CODEX_END_MARKER="# <<< weave-router managed <<<"
-WEAVE_CODEX_SKILL_MARKER="<!-- weave-router managed disable-routing skill -->"
 
 # strip_codex_block rewrites config.toml without the managed block and any
 # top-level `model_provider = "weave"` that lived outside the markers (which

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -96,6 +96,7 @@ weave_registry_skill_names() {
       cursor) [ "$cursor" = yes ] || continue ;;
     esac
     printf '%s\n' "$canonical"
+    [ -n "$aliases" ] && printf '%s\n' "$aliases" | tr ',' '\n'
   done <<EOF
 $(weave_registry_rows)
 EOF
@@ -115,6 +116,7 @@ weave_registry_skill_assets() {
       cursor) [ "$cursor" = yes ] || continue ;;
     esac
     printf '%s\n' "$canonical"
+    [ -n "$aliases" ] && printf '%s\n' "$aliases" | tr ',' '\n'
   done <<EOF
 $(weave_registry_rows)
 EOF

--- a/internal/proxy/router_feedback.go
+++ b/internal/proxy/router_feedback.go
@@ -66,9 +66,9 @@ const (
 	RouterFeedbackSourceAuto = "auto"
 )
 
-// handleRouterFeedbackCommand persists a /router-feedback submission, emits a
-// router.feedback.command span on the standard OTel pipeline, and returns a
-// synthetic acknowledgment without dispatching to any upstream.
+// handleRouterFeedbackCommand persists a /router-feedback submission and emits
+// a router.feedback.command span. User-issued commands receive a synthetic
+// acknowledgment; agent-issued tool-result commands continue through routing.
 func (s *Service) handleRouterFeedbackCommand(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -77,6 +77,7 @@ func (s *Service) handleRouterFeedbackCommand(
 	installationID uuid.UUID,
 	sessionKey [sessionpin.SessionKeyLen]byte,
 	inputTokens int,
+	synthetic bool,
 ) error {
 	log := observability.FromContext(ctx)
 	role := roleForTier(catalog.TierFor(env.Model()))
@@ -90,7 +91,10 @@ func (s *Service) handleRouterFeedbackCommand(
 		if env.SourceFormat() == translate.FormatOpenAI {
 			msg = "Weave Router: router-feedback needs a verdict or a note, e.g. /rf+ or /rf- too slow."
 		}
-		return writeSyntheticCommandResponse(w, env, msg, inputTokens)
+		if synthetic {
+			return writeSyntheticCommandResponse(w, env, msg, inputTokens)
+		}
+		return nil
 	}
 
 	// The model to attribute: pin's last served (or target), overridden by the resolved telemetry turn when a sequence was specified.
@@ -107,7 +111,10 @@ func (s *Service) handleRouterFeedbackCommand(
 				if env.SourceFormat() == translate.FormatOpenAI {
 					msg = "Weave Router: No turn found at that sequence number. Try `/rf` without a number for the last turn."
 				}
-				return writeSyntheticCommandResponse(w, env, msg, inputTokens)
+				if synthetic {
+					return writeSyntheticCommandResponse(w, env, msg, inputTokens)
+				}
+				return nil
 			}
 			// Infrastructure error: log it, fall through to the pin path so the
 			// rating is persisted with the pin's servedModel rather than dropped.
@@ -236,7 +243,10 @@ func (s *Service) handleRouterFeedbackCommand(
 		"route_id", telemetryRouteID,
 	)
 
-	return writeSyntheticCommandResponse(w, env, routerFeedbackAck(env.SourceFormat(), rating), inputTokens)
+	if synthetic {
+		return writeSyntheticCommandResponse(w, env, routerFeedbackAck(env.SourceFormat(), rating), inputTokens)
+	}
+	return nil
 }
 
 func (s *Service) reportRouterFeedback(

--- a/internal/proxy/router_feedback_proxy_test.go
+++ b/internal/proxy/router_feedback_proxy_test.go
@@ -614,6 +614,31 @@ func TestService_RouterFeedbackCommand_OpenAIIngress(t *testing.T) {
 	assert.Contains(t, content, "Feedback recorded")
 }
 
+func TestService_RouterFeedbackCommand_AgentToolResultContinuesRouting(t *testing.T) {
+	const body = `{
+		"model":"claude-sonnet-4-6",
+		"max_tokens":1024,
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","id":"toolu_skill","name":"exec","input":{}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_skill","content":" /router-feedback too slow"}]}
+		]
+	}`
+	store := newFakePinStore()
+	feedback := &fakeFeedbackStore{}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-6", Reason: "cluster"}}
+	svc := newPinSvc(fr, store).WithRouterFeedbackStore(feedback)
+
+	ctx := authedCtx(uuid.NewString())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(body), rec, httpReq))
+
+	assert.Equal(t, 1, fr.routeCalls, "agent-issued feedback must continue into an agent turn")
+	require.Len(t, feedback.events, 1)
+	assert.Equal(t, "too slow", feedback.events[0].Feedback)
+	assert.NotContains(t, rec.Body.String(), "Feedback recorded", "agent-issued feedback must not terminate with a synthetic ack")
+}
+
 func TestService_RouterFeedbackCommand_EmptyFeedbackAsksForText(t *testing.T) {
 	const body = `{
 		"model":"claude-sonnet-4-6",

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2798,11 +2798,14 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	if !agentShadowMode {
 		if cmd, hasCmd := env.ExtractRouterFeedbackCommand(); hasCmd {
 			log.Info("ProxyMessages router-feedback command")
-			if err := s.handleRouterFeedbackCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens); err != nil {
+			if err := s.handleRouterFeedbackCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens, !cmd.FromToolResult); err != nil {
 				return err
 			}
-			s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
-			return nil
+			if !cmd.FromToolResult {
+				s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
+				return nil
+			}
+			requestBodyChanged = true
 		}
 	}
 
@@ -5401,11 +5404,14 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	}
 	if cmd, hasCmd := env.ExtractRouterFeedbackCommand(); hasCmd {
 		log.Info("ProxyOpenAIChatCompletion router-feedback command")
-		if err := s.handleRouterFeedbackCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens); err != nil {
+		if err := s.handleRouterFeedbackCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens, !cmd.FromToolResult); err != nil {
 			return err
 		}
-		s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
-		return nil
+		if !cmd.FromToolResult {
+			s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
+			return nil
+		}
+		requestBodyChanged = true
 	}
 
 	// Sanitize after command extraction: a skill can encode its command as a
@@ -6310,6 +6316,10 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 	codexNativeRequest := codexResponsesRequest(ctx, r.Header)
 	nativeBody := conversion.OriginalBody
 	if clientAppCodex {
+		nativeBody, err = translate.StripRouterCommandsFromResponsesInput(nativeBody)
+		if err != nil {
+			return fmt.Errorf("strip Responses router command: %w", err)
+		}
 		// Codex records response.output_item.done as conversation history and
 		// sends it back in the next native request. Remove only the badge this
 		// client opted into so router text never reaches the selected model.

--- a/internal/translate/force_model.go
+++ b/internal/translate/force_model.go
@@ -236,7 +236,9 @@ func followsAssistantToolUse(messages []gjson.Result, userIdx int) bool {
 }
 
 // parseForceModelCommand scans text for a /force-model (alias /fm) or
-// /unforce-model (alias /ufm) directive on the first non-empty line.
+// /unforce-model (alias /ufm) directive on the first non-empty line. The
+// dollar-prefixed forms are accepted for clients whose native skill namespace
+// is `$` (notably Codex) when they forward the token verbatim.
 // Restricted to the leading line so pasted content (snippets, transcripts)
 // starting with "/" can't silently rewrite session routing. The short
 // aliases are a fallback for clients without local slash-command expansion
@@ -263,7 +265,7 @@ func parseForceModelCommand(text string) (res ForceModelResult, found bool, stri
 		if trimmed == "" {
 			continue
 		}
-		if after, ok := cutAnyPrefix(trimmed, "/force-model ", "/fm "); ok {
+		if after, ok := cutAnyPrefix(trimmed, "/force-model ", "/fm ", "$force-model ", "$fm "); ok {
 			// Fields+Join collapses runs of whitespace so "/fm  qwen   3.8"
 			// and "/fm qwen 3.8" are the same string to the resolver.
 			if name := strings.Join(strings.Fields(after), " "); name != "" {
@@ -271,7 +273,7 @@ func parseForceModelCommand(text string) (res ForceModelResult, found bool, stri
 				found = true
 				cmdIdx = i
 			}
-		} else if trimmed == "/unforce-model" || trimmed == "/ufm" {
+		} else if trimmed == "/unforce-model" || trimmed == "/ufm" || trimmed == "$unforce-model" || trimmed == "$ufm" {
 			res = ForceModelResult{Clear: true}
 			found = true
 			cmdIdx = i
@@ -279,6 +281,32 @@ func parseForceModelCommand(text string) (res ForceModelResult, found bool, stri
 		break
 	}
 	if !found {
+		// Codex's local exec tool returns a two-part result whose first part is
+		// an execution preamble ("Script completed … Output:") and whose second
+		// part is the skill's leading-space directive. The Responses projection
+		// joins those parts, so inspect only the first non-empty output line;
+		// skill documentation printed by exec can contain command examples.
+		if strings.HasPrefix(strings.TrimSpace(text), "Script completed") {
+			lines := strings.Split(text, "\n")
+			for i, line := range lines {
+				if strings.TrimSpace(line) != "Output:" {
+					continue
+				}
+				for i++; i < len(lines); i++ {
+					if strings.TrimSpace(lines[i]) == "" {
+						continue
+					}
+					candidate, ok, _ := parseForceModelCommand(lines[i])
+					if !ok {
+						break
+					}
+					remaining := append([]string{}, lines[:i]...)
+					remaining = append(remaining, lines[i+1:]...)
+					return candidate, true, strings.TrimSpace(strings.Join(remaining, "\n"))
+				}
+				break
+			}
+		}
 		return ForceModelResult{}, false, text
 	}
 	remaining := make([]string, 0, len(lines))

--- a/internal/translate/force_model.go
+++ b/internal/translate/force_model.go
@@ -281,11 +281,9 @@ func parseForceModelCommand(text string) (res ForceModelResult, found bool, stri
 		break
 	}
 	if !found {
-		// Codex's local exec tool returns a two-part result whose first part is
-		// an execution preamble ("Script completed … Output:") and whose second
-		// part is the skill's leading-space directive. The Responses projection
-		// joins those parts, so inspect only the first non-empty output line;
-		// skill documentation printed by exec can contain command examples.
+		// Codex's exec tool joins a "Script completed … Output:" preamble with
+		// the skill directive; check only the first non-empty output line so
+		// command examples in skill docs don't trigger parsing.
 		if strings.HasPrefix(strings.TrimSpace(text), "Script completed") {
 			lines := strings.Split(text, "\n")
 			for i, line := range lines {

--- a/internal/translate/force_model_test.go
+++ b/internal/translate/force_model_test.go
@@ -168,7 +168,7 @@ func TestParseForceModelCommand_ForceModel(t *testing.T) {
 }
 
 func TestParseForceModelCommand_UnforceModel(t *testing.T) {
-	for _, input := range []string{"/unforce-model", "/ufm"} {
+	for _, input := range []string{"/unforce-model", "/ufm", "$unforce-model", "$ufm"} {
 		t.Run(input, func(t *testing.T) {
 			env, err := translate.ParseAnthropic(buildAnthropicBody(t, input))
 			require.NoError(t, err)
@@ -179,6 +179,52 @@ func TestParseForceModelCommand_UnforceModel(t *testing.T) {
 			assert.Empty(t, res.Model)
 		})
 	}
+}
+
+func TestExtractForceModelCommand_DollarAliases(t *testing.T) {
+	for _, input := range []string{"$force-model gpt-5", "$fm gpt-5"} {
+		t.Run(input, func(t *testing.T) {
+			env, err := translate.ParseAnthropic(buildAnthropicBody(t, input))
+			require.NoError(t, err)
+			res, found := env.ExtractForceModelCommand()
+			require.True(t, found)
+			assert.Equal(t, "gpt-5", res.Model)
+		})
+	}
+}
+
+func TestExtractForceModelCommand_CodexExecPreamble(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "gpt-5.6-sol",
+		"messages": []any{
+			map[string]any{"role": "assistant", "tool_calls": []any{map[string]any{
+				"id": "call_skill", "type": "function", "function": map[string]any{"name": "exec", "arguments": "{}"},
+			}}},
+			map[string]any{"role": "tool", "tool_call_id": "call_skill", "content": "Script completed\nWall time: 0.0 seconds\nOutput:\n /force-model gpt-5"},
+		},
+	})
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	res, found := env.ExtractForceModelCommand()
+	require.True(t, found)
+	assert.True(t, res.FromToolResult)
+	assert.Equal(t, "gpt-5", res.Model)
+}
+
+func TestExtractForceModelCommand_CodexExecDocumentationIsNotCommand(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "gpt-5.6-sol",
+		"messages": []any{
+			map[string]any{"role": "assistant", "tool_calls": []any{map[string]any{
+				"id": "call_skill", "type": "function", "function": map[string]any{"name": "exec", "arguments": "{}"},
+			}}},
+			map[string]any{"role": "tool", "tool_call_id": "call_skill", "content": "Script completed\nOutput:\n---\nname: force-model\n```text\n /force-model gpt-5\n```"},
+		},
+	})
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	_, found := env.ExtractForceModelCommand()
+	assert.False(t, found, "a command example in exec output must not pin the session")
 }
 
 func TestExtractForceModelCommand_OpenAIFormat(t *testing.T) {

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -432,6 +432,72 @@ func StripFeedbackFooterFromResponsesInput(body []byte) ([]byte, error) {
 	return out, nil
 }
 
+// StripRouterCommandsFromResponsesInput removes router directives emitted by a
+// local agent tool from function-call output items. Codex executes its skills
+// through a tool and returns the resulting leading-space command as the tool
+// output; forwarding that text verbatim makes the upstream repeat the command
+// instead of continuing the agent turn.
+func StripRouterCommandsFromResponsesInput(body []byte) ([]byte, error) {
+	input := gjson.GetBytes(body, "input")
+	if !input.IsArray() {
+		return body, nil
+	}
+	out := body
+	changed := false
+	for itemIndex, item := range input.Array() {
+		typ := item.Get("type").Str
+		if typ != "function_call_output" && typ != "custom_tool_call_output" {
+			continue
+		}
+		output := item.Get("output")
+		if output.Type == gjson.String {
+			stripped, found := stripRouterCommandText(output.Str)
+			if !found {
+				continue
+			}
+			var err error
+			out, err = sjson.SetBytes(out, "input."+strconv.Itoa(itemIndex)+".output", stripped)
+			if err != nil {
+				return nil, fmt.Errorf("strip router command from Responses tool output: %w", err)
+			}
+			changed = true
+			continue
+		}
+		if !output.IsArray() {
+			continue
+		}
+		for partIndex, part := range output.Array() {
+			if part.Get("type").Str != "input_text" {
+				continue
+			}
+			stripped, found := stripRouterCommandText(part.Get("text").Str)
+			if !found {
+				continue
+			}
+			var err error
+			out, err = sjson.SetBytes(out, "input."+strconv.Itoa(itemIndex)+".output."+strconv.Itoa(partIndex)+".text", stripped)
+			if err != nil {
+				return nil, fmt.Errorf("strip router command from Responses tool output part: %w", err)
+			}
+			changed = true
+		}
+	}
+	if !changed {
+		return body, nil
+	}
+	return out, nil
+}
+
+func stripRouterCommandText(text string) (string, bool) {
+	if _, found, stripped := parseForceModelCommand(text); found {
+		return stripped, true
+	}
+	if _, found, stripped := parseRouterFeedbackCommand(text); found {
+		return stripped, true
+	}
+	return text, false
+}
+
 // responsesContentHasBody reports whether a content array carries anything
 // beyond the (now stripped) part at skipIndex. Non-text parts always count.
 func responsesContentHasBody(content gjson.Result, skipIndex int) bool {

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -432,10 +432,8 @@ func StripFeedbackFooterFromResponsesInput(body []byte) ([]byte, error) {
 	return out, nil
 }
 
-// StripRouterCommandsFromResponsesInput removes router directives emitted by a
-// local agent tool from function-call output items. Codex executes its skills
-// through a tool and returns the resulting leading-space command as the tool
-// output; forwarding that text verbatim makes the upstream repeat the command
+// StripRouterCommandsFromResponsesInput removes router directives from
+// function-call output items so the upstream doesn't repeat them verbatim
 // instead of continuing the agent turn.
 func StripRouterCommandsFromResponsesInput(body []byte) ([]byte, error) {
 	input := gjson.GetBytes(body, "input")

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -1142,3 +1142,32 @@ func TestStripFeedbackFooterFromResponsesInput(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "answer", gjson.GetBytes(out, "input.0.content.0.text").Str)
 }
+
+// Sanitizing the native Codex body must not disarm command extraction: the
+// strip applies to the passthrough bytes, while pin/feedback extraction runs
+// on the chat projection built from the original body. Ordered exactly as
+// ProxyOpenAIResponses does it, so any aliasing between the two would show up.
+func TestStripRouterCommandsFromResponsesInput_LeavesChatProjectionIntact(t *testing.T) {
+	const body = `{"model":"gpt-5.6-terra","input":[
+{"type":"message","role":"user","content":[{"type":"input_text","text":"invoke fm"}]},
+{"type":"custom_tool_call","call_id":"call_a","name":"exec","input":"x"},
+{"type":"custom_tool_call_output","call_id":"call_a","output":[
+{"type":"input_text","text":"Script completed\nWall time 0.3 seconds\nOutput:\n"},
+{"type":"input_text","text":" /force-model gpt-5.6-terra\n"}]}]}`
+
+	conv, err := translate.ConvertResponsesToChatCompletionsWithOptions(
+		[]byte(body), translate.ResponsesConversionOptions{PortableCodex: true})
+	require.NoError(t, err)
+
+	native, err := translate.StripRouterCommandsFromResponsesInput(conv.OriginalBody)
+	require.NoError(t, err)
+	assert.NotContains(t, string(native), "/force-model gpt-5.6-terra",
+		"the directive must not reach the upstream verbatim")
+
+	env, err := translate.ParseOpenAI(conv.Body)
+	require.NoError(t, err)
+	res, found := env.ExtractForceModelCommand()
+	require.True(t, found, "the chat projection must still carry the directive")
+	assert.Equal(t, "gpt-5.6-terra", res.Model)
+	assert.True(t, res.FromToolResult, "agent-issued, so the turn continues")
+}

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -240,6 +240,21 @@ func TestStripRoutingBadgeFromResponsesInput_PreservesNativeFields(t *testing.T)
 	assert.True(t, root.Get("metadata.keep").Bool())
 }
 
+func TestStripRouterCommandsFromResponsesInput_RemovesAgentToolCommand(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","input":[{"type":"custom_tool_call_output","call_id":"call_skill","output":" /router-feedback too slow"},{"type":"function_call_output","call_id":"call_fm","output":[{"type":"input_text","text":" /force-model gpt-5"}]}]}`)
+	out, err := translate.StripRouterCommandsFromResponsesInput(body)
+	require.NoError(t, err)
+	assert.Equal(t, "", gjson.GetBytes(out, "input.0.output").String())
+	assert.Equal(t, "", gjson.GetBytes(out, "input.1.output.0.text").String())
+}
+
+func TestStripRouterCommandsFromResponsesInput_RemovesCollapsedExecCommand(t *testing.T) {
+	body := []byte(`{"input":[{"type":"function_call_output","call_id":"call_skill","output":"Script completed\nOutput:\n /force-model gpt-5"}]}`)
+	out, err := translate.StripRouterCommandsFromResponsesInput(body)
+	require.NoError(t, err)
+	assert.Equal(t, "Script completed\nOutput:", gjson.GetBytes(out, "input.0.output").String())
+}
+
 // A tool-call-only or reasoning-only turn ships a badge-only assistant message.
 // Stripping it in place would leave a blank assistant shell ahead of the real
 // function_call, which providers reject.

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -1143,10 +1143,7 @@ func TestStripFeedbackFooterFromResponsesInput(t *testing.T) {
 	assert.Equal(t, "answer", gjson.GetBytes(out, "input.0.content.0.text").Str)
 }
 
-// Sanitizing the native Codex body must not disarm command extraction: the
-// strip applies to the passthrough bytes, while pin/feedback extraction runs
-// on the chat projection built from the original body. Ordered exactly as
-// ProxyOpenAIResponses does it, so any aliasing between the two would show up.
+// Strip operates on passthrough bytes; extraction runs on the chat projection (conv.OriginalBody vs conv.Body). Ordered as ProxyOpenAIResponses does, so aliasing surfaces here.
 func TestStripRouterCommandsFromResponsesInput_LeavesChatProjectionIntact(t *testing.T) {
 	const body = `{"model":"gpt-5.6-terra","input":[
 {"type":"message","role":"user","content":[{"type":"input_text","text":"invoke fm"}]},

--- a/internal/translate/router_feedback.go
+++ b/internal/translate/router_feedback.go
@@ -137,10 +137,7 @@ func parseRouterFeedbackCommand(text string) (res RouterFeedbackResult, found bo
 					if strings.TrimSpace(lines[i]) == "" {
 						continue
 					}
-					// Feed the whole remaining block, not just this line: a
-					// /router-feedback note runs to the end of the message, so
-					// parsing one line would record a truncated note and leak
-					// the rest of it upstream as prompt text.
+					// Feed the whole block: /router-feedback consumes everything to EOF; one line truncates the note and leaks the rest upstream.
 					candidate, found, _ := parseRouterFeedbackCommand(strings.Join(lines[i:], "\n"))
 					if !found {
 						break

--- a/internal/translate/router_feedback.go
+++ b/internal/translate/router_feedback.go
@@ -20,9 +20,8 @@ type RouterFeedbackResult struct {
 	// Sequence is an optional leading turn-selector: 0 = last turn (default),
 	// positive = absolute 1-based index, negative = relative offset from last (e.g. -3).
 	Sequence int
-	// FromToolResult is true when an agent emitted the directive through a tool
-	// result. Those commands should continue the agent turn after recording
-	// feedback instead of ending it with a synthetic response.
+	// FromToolResult is true for directives arriving via a tool result; they
+	// continue routing rather than end with a synthetic response.
 	FromToolResult bool
 }
 
@@ -138,14 +137,16 @@ func parseRouterFeedbackCommand(text string) (res RouterFeedbackResult, found bo
 					if strings.TrimSpace(lines[i]) == "" {
 						continue
 					}
-					candidate, found, _ := parseRouterFeedbackCommand(lines[i])
+					// Feed the whole remaining block, not just this line: a
+					// /router-feedback note runs to the end of the message, so
+					// parsing one line would record a truncated note and leak
+					// the rest of it upstream as prompt text.
+					candidate, found, _ := parseRouterFeedbackCommand(strings.Join(lines[i:], "\n"))
 					if !found {
 						break
 					}
-					remaining := append([]string{}, lines[:i]...)
-					remaining = append(remaining, lines[i+1:]...)
 					candidate.FromToolResult = false
-					return candidate, true, strings.TrimSpace(strings.Join(remaining, "\n"))
+					return candidate, true, strings.TrimSpace(strings.Join(lines[:i], "\n"))
 				}
 				break
 			}

--- a/internal/translate/router_feedback.go
+++ b/internal/translate/router_feedback.go
@@ -126,10 +126,8 @@ func parseRouterFeedbackCommand(text string) (res RouterFeedbackResult, found bo
 
 	rating, inline, ok := matchRouterFeedbackCommand(first)
 	if !ok {
-		// Codex's exec tool prefixes a second output part with execution
-		// metadata ("Script completed … Output:"). Responses conversion joins
-		// those parts, so inspect only the first non-empty output line; skill
-		// documentation printed by exec can contain command examples.
+		// Codex's exec tool joins a "Script completed … Output:" preamble with
+		// the skill directive; check only the first non-empty output line.
 		if strings.HasPrefix(strings.TrimSpace(text), "Script completed") {
 			lines := strings.Split(text, "\n")
 			for i, line := range lines {

--- a/internal/translate/router_feedback.go
+++ b/internal/translate/router_feedback.go
@@ -20,6 +20,10 @@ type RouterFeedbackResult struct {
 	// Sequence is an optional leading turn-selector: 0 = last turn (default),
 	// positive = absolute 1-based index, negative = relative offset from last (e.g. -3).
 	Sequence int
+	// FromToolResult is true when an agent emitted the directive through a tool
+	// result. Those commands should continue the agent turn after recording
+	// feedback instead of ending it with a synthetic response.
+	FromToolResult bool
 }
 
 // RouterFeedbackRatingUp and RouterFeedbackRatingDown are the canonical
@@ -39,21 +43,21 @@ var RouterFeedbackLabels = map[string]struct{}{
 	"maximum":  {},
 }
 
-// ExtractRouterFeedbackCommand scans the last user-role message in env for a
-// /router-feedback <text> directive. When found, it strips the command line
-// from env.body and returns the feedback text. A bare /router-feedback with
-// no text still matches (found=true, empty Feedback) so the handler can ack
-// with usage guidance instead of forwarding the command to an upstream model.
-// Returns (zero, false) when no command is present.
+// ExtractRouterFeedbackCommand scans the trailing user/tool-result message in
+// env for a /router-feedback <text> directive. When found, it strips the
+// command from env.body and returns the feedback text. A bare command still
+// matches (found=true, empty Feedback) so user-issued commands can receive
+// usage guidance. Returns (zero, false) when no command is present.
 func (env *RequestEnvelope) ExtractRouterFeedbackCommand() (RouterFeedbackResult, bool) {
 	var res RouterFeedbackResult
-	found := env.extractLeadingCommand(func(text string) (bool, string) {
+	found, fromToolResult := env.extractLeadingCommandWithSource(func(text string) (bool, string) {
 		r, ok, stripped := parseRouterFeedbackCommand(text)
 		if ok {
 			res = r
 		}
 		return ok, stripped
 	})
+	res.FromToolResult = found && fromToolResult
 	return res, found
 }
 
@@ -106,9 +110,11 @@ func (env *RequestEnvelope) StripRouterFeedbackArtifacts() int {
 // directive on the first non-empty line, applying the same leading-line +
 // injected-prefix guards as parseForceModelCommand (see that function for the
 // rationale; the router-side alias serves clients without local slash-command
-// expansion). Unlike /force-model, everything after the command — same line
-// AND following lines — is the feedback payload, so the whole body is
-// consumed and the stripped output keeps only the injected prefix.
+// expansion). Codex exec results get a narrow exception for their known
+// "Script completed" preamble. Unlike /force-model, everything after the
+// command — same line AND following lines — is the feedback payload, so the
+// whole body is consumed and the stripped output keeps only the injected
+// prefix.
 func parseRouterFeedbackCommand(text string) (res RouterFeedbackResult, found bool, stripped string) {
 	prefixEnd := leadingInjectedPrefixEnd(text)
 	prefix := text[:prefixEnd]
@@ -120,6 +126,32 @@ func parseRouterFeedbackCommand(text string) (res RouterFeedbackResult, found bo
 
 	rating, inline, ok := matchRouterFeedbackCommand(first)
 	if !ok {
+		// Codex's exec tool prefixes a second output part with execution
+		// metadata ("Script completed … Output:"). Responses conversion joins
+		// those parts, so inspect only the first non-empty output line; skill
+		// documentation printed by exec can contain command examples.
+		if strings.HasPrefix(strings.TrimSpace(text), "Script completed") {
+			lines := strings.Split(text, "\n")
+			for i, line := range lines {
+				if strings.TrimSpace(line) != "Output:" {
+					continue
+				}
+				for i++; i < len(lines); i++ {
+					if strings.TrimSpace(lines[i]) == "" {
+						continue
+					}
+					candidate, found, _ := parseRouterFeedbackCommand(lines[i])
+					if !found {
+						break
+					}
+					remaining := append([]string{}, lines[:i]...)
+					remaining = append(remaining, lines[i+1:]...)
+					candidate.FromToolResult = false
+					return candidate, true, strings.TrimSpace(strings.Join(remaining, "\n"))
+				}
+				break
+			}
+		}
 		return RouterFeedbackResult{}, false, text
 	}
 

--- a/internal/translate/router_feedback_test.go
+++ b/internal/translate/router_feedback_test.go
@@ -446,3 +446,29 @@ func TestExtractRouterFeedbackCommand_GeminiFormatIgnored(t *testing.T) {
 	_, found := env.ExtractRouterFeedbackCommand()
 	assert.False(t, found, "Gemini format should not be scanned for router-feedback commands")
 }
+
+// emit.sh forwards "$*", so a multi-line note arrives as several output lines
+// under one "Output:" preamble. Parsing only the first would record a
+// truncated note and forward the remainder upstream as prompt text.
+func TestExtractRouterFeedbackCommand_CodexExecMultiLineNote(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "gpt-5.6-terra",
+		"messages": []any{
+			map[string]any{"role": "assistant", "tool_calls": []any{map[string]any{
+				"id": "call_skill", "type": "function",
+				"function": map[string]any{"name": "exec", "arguments": "{}"},
+			}}},
+			map[string]any{
+				"role": "tool", "tool_call_id": "call_skill",
+				"content": "Script completed\nWall time 0.1 seconds\nOutput:\n /router-feedback it broke\nsecond line of the note\n",
+			},
+		},
+	})
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+
+	res, found := env.ExtractRouterFeedbackCommand()
+	require.True(t, found)
+	assert.Equal(t, "it broke\nsecond line of the note", res.Feedback)
+	assert.True(t, res.FromToolResult)
+}

--- a/internal/translate/router_feedback_test.go
+++ b/internal/translate/router_feedback_test.go
@@ -447,9 +447,7 @@ func TestExtractRouterFeedbackCommand_GeminiFormatIgnored(t *testing.T) {
 	assert.False(t, found, "Gemini format should not be scanned for router-feedback commands")
 }
 
-// emit.sh forwards "$*", so a multi-line note arrives as several output lines
-// under one "Output:" preamble. Parsing only the first would record a
-// truncated note and forward the remainder upstream as prompt text.
+// emit.sh forwards "$*", so a multi-line note arrives under one "Output:" preamble; parsing only the first line would truncate the note and leak the rest upstream.
 func TestExtractRouterFeedbackCommand_CodexExecMultiLineNote(t *testing.T) {
 	body := mustMarshalJSON(t, map[string]any{
 		"model": "gpt-5.6-terra",

--- a/internal/translate/router_feedback_test.go
+++ b/internal/translate/router_feedback_test.go
@@ -346,6 +346,60 @@ func TestExtractRouterFeedbackCommand_OpenAIFormat(t *testing.T) {
 	assert.Equal(t, "", lastOpenAIUserMessageText(t, env))
 }
 
+func TestExtractRouterFeedbackCommand_ToolResultContinuesAgentTurn(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "gpt-5.6-sol",
+		"messages": []any{
+			map[string]any{"role": "assistant", "tool_calls": []any{map[string]any{
+				"id": "call_skill", "type": "function", "function": map[string]any{"name": "exec", "arguments": "{}"},
+			}}},
+			map[string]any{"role": "tool", "tool_call_id": "call_skill", "content": " /router-feedback too slow"},
+		},
+	})
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+
+	res, found := env.ExtractRouterFeedbackCommand()
+	require.True(t, found)
+	assert.True(t, res.FromToolResult)
+	assert.Equal(t, "too slow", res.Feedback)
+	assert.Equal(t, "", lastOpenAIUserMessageText(t, env))
+}
+
+func TestExtractRouterFeedbackCommand_CodexExecPreamble(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "gpt-5.6-sol",
+		"messages": []any{
+			map[string]any{"role": "assistant", "tool_calls": []any{map[string]any{
+				"id": "call_skill", "type": "function", "function": map[string]any{"name": "exec", "arguments": "{}"},
+			}}},
+			map[string]any{"role": "tool", "tool_call_id": "call_skill", "content": "Script completed\nWall time: 0.0 seconds\nOutput:\n /router-feedback too slow"},
+		},
+	})
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	res, found := env.ExtractRouterFeedbackCommand()
+	require.True(t, found)
+	assert.True(t, res.FromToolResult)
+	assert.Equal(t, "too slow", res.Feedback)
+}
+
+func TestExtractRouterFeedbackCommand_CodexExecDocumentationIsNotCommand(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "gpt-5.6-sol",
+		"messages": []any{
+			map[string]any{"role": "assistant", "tool_calls": []any{map[string]any{
+				"id": "call_skill", "type": "function", "function": map[string]any{"name": "exec", "arguments": "{}"},
+			}}},
+			map[string]any{"role": "tool", "tool_call_id": "call_skill", "content": "Script completed\nOutput:\n---\nname: router-feedback\n```text\n /router-feedback too slow\n```"},
+		},
+	})
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	_, found := env.ExtractRouterFeedbackCommand()
+	assert.False(t, found, "a command example in exec output must not record feedback")
+}
+
 func TestExtractRouterFeedbackCommand_ArrayContentMultipleTextBlocks(t *testing.T) {
 	// Claude Code splits slash-command turns into an injected-tags block plus
 	// the typed directive; the parser must scan every text block.


### PR DESCRIPTION
Brings Codex to parity with the Claude Code directive surface. **Supersedes #1106**, whose commits are cherry-picked here (authorship preserved) and reconciled with the installer refactor below.

## Problem

Codex had 4 of Claude Code's 8 directives, and two of those four were partly broken:

1. **Aliases were advertised but never installed.** `$force-model`, `$unforce-model`, and `$router-feedback` each told the user they could invoke `$fm`/`$ufm`/`$rf`. Codex discovers skills by *directory name*, and no such directories existed — so those aliases could never resolve.
2. **The skills asked Codex to do something it cannot do.** They instructed it to "send a normal user message whose first character is one literal space." A skill is prompt text; it cannot author a `role: user` message. In session `01a046f1` the model improvised `text(" /router-feedback …")`, which became a `custom_tool_call_output` that was never parsed as a command and ended up returned as the final answer.
3. **`router-off`/`on`/`status`/`models` were gated off** for Codex in the registry — not for lack of a mechanism (`$disable-routing` had shipped as a toggle skill for a while) but because the rows were never enabled. No way to check routing state, re-enable it conversationally, or manage the model list.

## Change

- **Prompt skills exec a `scripts/emit.sh`** that prints the leading-space directive; the router's exec-output parser picks it up. Real capability, verified live against Codex 0.150.1 — including the two-part `custom_tool_call_output` array shape the parser actually receives.
- **Aliases install as their own skill directories**, so `$fm`/`$ufm`/`$rf` resolve.
- **Four new toggle skills** — `$router-status`, `$router-off`, `$router-on`, `$router-models` — each shelling out to the same `weave-router <verb> --codex` the CLI exposes, so there's no second copy of the toggle logic.
- **One skill installer.** `install_codex_prompt_skills` walks `weave_registry_skill_assets`; `install_codex_disable_routing_skill` is deleted (it was that loop hardcoded to one directive).
- **`models --codex`** works, resolving the endpoint via the already-per-client `resolve_installed_endpoint`.

### On the `models` trust check

`models_endpoint_is_trusted` guards a Claude-specific hazard: endpoint in committed `settings.json`, key in gitignored `settings.local.json`, so a hostile repo could redirect a teammate's key. Codex keeps both in one managed block — the same-file case that rule already treats as always-safe. Not weakened; Claude's path is byte-identical.

## Testing

`make test-install` green across all six suites (66 / 82 / 50 / 17 + two pass-only). `go test ./...` green. Verified by hand: all 11 skills install and uninstall cleanly, `models --codex` sends the Codex install's key to that install's `/admin/v1/models`, `--claude` is unchanged, and a client with no install errors cleanly.

New test: **every `$name` a skill advertises must resolve to an installed directory.** That is the regression for bug (1) above. I confirmed it fails on a planted fake alias rather than trusting that it passes.

## Bugs found while merging

- Packaging was **failing silently** — `packaging_test.sh` takes the tarball name from `npm pack | tail -1`, and the new `emit.sh` log lines pushed it off the end. Surfaced as an empty test run with exit 0.
- Alias expansion emits names with no skill asset (`models` is a `router-models` alias for the Claude command surface only). The installer already skipped those; packaging threw on the first one. It now skips alias-only names while still failing loudly if a *canonical* declared skill is missing.
- #1106's packaging threw when `scripts/emit.sh` was absent — correct for prompt skills, wrong for the toggles added here, which legitimately ship none.

Earlier review round (Bugbot/Greptile) also caught: `models` needs `jq` (12 call sites) on a Codex-only box that has no reason to have it; the list footer/usage/rejected-key hints hardcoded `--claude`; and a `$models` alias I advertised without installing. All fixed.