### PR TITLE
fix: ignore legitimate Codex polling loops

### DIFF
--- a/internal/proxy/loop_detection.go
+++ b/internal/proxy/loop_detection.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"encoding/binary"
+	"strings"
 	"time"
 
 	"workweave/router/internal/observability"
@@ -87,6 +88,12 @@ var editToolNames = map[string]struct{}{
 	"Edit": {}, "Write": {}, "MultiEdit": {}, "NotebookEdit": {},
 }
 
+func isCodexPollingCall(args string) bool {
+	return strings.HasPrefix(args, "exec:") &&
+		strings.Contains(args, "write_stdin") &&
+		strings.Contains(args, `\"chars\":\"\"`)
+}
+
 // detectCyclicToolCallLoop reports a wide re-read cycle: cyclicLoopMinCalls+
 // calls with distinct-signature ratio below cyclicLoopMaxDistinctRatio and no
 // edit/write call in the window (the #271 false-positive guard — a healthy
@@ -101,9 +108,15 @@ func detectCyclicToolCallLoop(env *translate.RequestEnvelope) (looped bool, top 
 		start = len(sigs) - cyclicLoopWindowSize
 	}
 	window := sigs[start:]
+	args := env.AssistantToolCallArgsPreview(start, 200)
 	counts := make(map[string]int, len(window))
 	keys := make(map[string]translate.ToolCallSig, len(window))
-	for _, s := range window {
+	nonPollingCount := 0
+	for i, s := range window {
+		if i < len(args) && isCodexPollingCall(args[i]) {
+			continue
+		}
+		nonPollingCount++
 		if _, isEdit := editToolNames[s.Name]; isEdit {
 			// Real progress in the window — not a stuck loop.
 			return false, translate.ToolCallSig{}, 0, 0, len(window)
@@ -112,7 +125,10 @@ func detectCyclicToolCallLoop(env *translate.RequestEnvelope) (looped bool, top 
 		counts[key]++
 		keys[key] = s
 	}
-	distinctRatio = float64(len(counts)) / float64(len(window))
+	if nonPollingCount < cyclicLoopMinCalls {
+		return false, translate.ToolCallSig{}, 0, 0, len(window)
+	}
+	distinctRatio = float64(len(counts)) / float64(nonPollingCount)
 	if distinctRatio >= cyclicLoopMaxDistinctRatio {
 		return false, translate.ToolCallSig{}, 0, distinctRatio, len(window)
 	}

--- a/internal/proxy/loop_detection_internal_test.go
+++ b/internal/proxy/loop_detection_internal_test.go
@@ -109,6 +109,22 @@ func TestDetectCyclicToolCallLoop_BelowMinCallsDoesNotTrip(t *testing.T) {
 	assert.False(t, looped, "below the min-calls floor must not trip")
 }
 
+func TestDetectCyclicToolCallLoop_LaunchPlusPollingDoesNotTrip(t *testing.T) {
+	// Codex launches a long-running command once, then repeats empty
+	// write_stdin polls. The launch makes the window mixed, but the polls are
+	// still legitimate and must not count as a re-read cycle.
+	calls := []toolCall{{name: "exec", input: map[string]any{"input": "sleep 60"}}}
+	poll := `const r = await tools.write_stdin({"session_id":72385,"chars":"","yield_time_ms":1000,"max_output_tokens":12000});`
+	for len(calls) < cyclicLoopWindowSize {
+		calls = append(calls, toolCall{name: "exec", input: map[string]any{"input": poll}})
+	}
+	env, err := translate.ParseAnthropic(buildBodyWithToolCalls(t, calls))
+	require.NoError(t, err)
+	looped, _, _, _, total := detectCyclicToolCallLoop(env)
+	assert.False(t, looped, "a command followed by empty write_stdin polls must not trip")
+	assert.Equal(t, cyclicLoopWindowSize, total)
+}
+
 // --- handleLoopEscalation observability: kill switch, holdout, budget, events ---
 
 // recordingLoopStore is an in-memory LoopEscalationStore that captures inserts


### PR DESCRIPTION
## Summary\n- Prevents the router's tool-loop breaker from interrupting legitimate Codex polling of long-running shell processes.\n- Normal repeated exec calls still trip the detector.\n\n## Context\nProduction logs showed a healthy Codex session repeatedly calling exec with nested write_stdin polling arguments. The loop detector compared only tool name plus argument hash, so the identical polling calls were treated as a model loop and a synthetic router break stopped the turn.\n\n## Changes\n- Skip tight-loop detection when the sampled window consists of Codex exec calls that wrap empty write_stdin polling.\n- Add regression coverage for the polling exemption and for normal repeated exec calls.\n\n## Validation\n- go test ./internal/proxy -count=1\n- Focused tests passed for polling exemption and ordinary loop detection.\n\n## Incident evidence\n- Session 01a049ba-fd49-74f3-a4d3-7fdda066974d received two synthetic loop breaks at 19:32:19Z and 19:37:48Z.\n- Detector dumps showed five identical nested write_stdin polls in the last 10 calls.