### PR TITLE
feat: add subscription-state conditional model allowlists

### DIFF
--- a/db/migrations/0071_installation-subscription-state-models.down.sql
+++ b/db/migrations/0071_installation-subscription-state-models.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE router.model_router_installations
+  DROP COLUMN models_when_subscription_active,
+  DROP COLUMN models_when_subscription_inactive;
+
+COMMIT;

--- a/db/migrations/0071_installation-subscription-state-models.up.sql
+++ b/db/migrations/0071_installation-subscription-state-models.up.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+-- Optional per-installation model allowlists selected from the caller's
+-- subscription state. Empty arrays preserve the existing no-restriction
+-- behavior. The router chooses one at request time from the usage observer:
+-- models_when_subscription_active while the subscription has headroom, and
+-- models_when_subscription_inactive after usage.Observer reports exhaustion.
+ALTER TABLE router.model_router_installations
+  ADD COLUMN models_when_subscription_active TEXT[] NOT NULL DEFAULT '{}',
+  ADD COLUMN models_when_subscription_inactive TEXT[] NOT NULL DEFAULT '{}';
+
+COMMENT ON COLUMN router.model_router_installations.models_when_subscription_active IS
+  'Optional model allowlist while the caller subscription is active; empty means no conditional restriction.';
+COMMENT ON COLUMN router.model_router_installations.models_when_subscription_inactive IS
+  'Optional model allowlist while the caller subscription is exhausted; empty means no conditional restriction.';
+
+COMMIT;

--- a/internal/auth/installation.go
+++ b/internal/auth/installation.go
@@ -25,6 +25,12 @@ type Installation struct {
 	// routing is confined to these models minus ExcludedModels.
 	// Empty = no restriction; fail-closed when no eligible overlap remains.
 	AllowedModels []string
+	// ModelsWhenSubscriptionActive optionally confines routing while the caller's
+	// subscription has headroom. Empty means no conditional restriction.
+	ModelsWhenSubscriptionActive []string
+	// ModelsWhenSubscriptionInactive optionally confines routing after the
+	// caller's subscription is exhausted. Empty means no conditional restriction.
+	ModelsWhenSubscriptionInactive []string
 	// ExcludedProviders is the per-installation provider exclusion list.
 	// Empty means no exclusion.
 	ExcludedProviders []string

--- a/internal/postgres/converters.go
+++ b/internal/postgres/converters.go
@@ -30,6 +30,14 @@ func toAuthInstallation(row sqlc.RouterModelRouterInstallation) *auth.Installati
 	if allowed == nil {
 		allowed = []string{}
 	}
+	modelsWhenSubscriptionActive := row.ModelsWhenSubscriptionActive
+	if modelsWhenSubscriptionActive == nil {
+		modelsWhenSubscriptionActive = []string{}
+	}
+	modelsWhenSubscriptionInactive := row.ModelsWhenSubscriptionInactive
+	if modelsWhenSubscriptionInactive == nil {
+		modelsWhenSubscriptionInactive = []string{}
+	}
 	// Parsed once per API-key cache fill, not per request. A malformed or
 	// retired-key payload degrades to "no overrides" rather than failing the
 	// request — a stored row must not be able to take an org's traffic down.
@@ -44,33 +52,35 @@ func toAuthInstallation(row sqlc.RouterModelRouterInstallation) *auth.Installati
 		overrides = flags.Overrides{}
 	}
 	return &auth.Installation{
-		ID:                           row.ID.String(),
-		ExternalID:                   row.ExternalID,
-		Name:                         row.Name,
-		CreatedAt:                    timestampOrZero(row.CreatedAt),
-		UpdatedAt:                    timestampOrZero(row.UpdatedAt),
-		DeletedAt:                    timestampPtr(row.DeletedAt),
-		CreatedBy:                    row.CreatedBy,
-		ExcludedModels:               excluded,
-		AllowedModels:                allowed,
-		ExcludedProviders:            excludedProviders,
-		PreferredModels:              preferred,
-		RoutingQualityWeight:         row.RoutingQualityWeight,
-		UsageBypassEnabled:           row.UsageBypassEnabled,
-		UsageBypassThreshold:         row.UsageBypassThreshold,
-		SubscriptionRoutingDisabled:  row.SubscriptionRoutingDisabled,
-		RoutingStrategy:              router.Strategy(derefString(row.RoutingStrategy)),
-		RoutingRolloutID:             derefString(row.RoutingRolloutID),
-		PolicyShadowStrategy:         router.Strategy(derefString(row.PolicyShadowStrategy)),
-		PolicyDebugEnabled:           row.PolicyDebugEnabled,
-		PolicyHeaderOverridesEnabled: row.PolicyHeaderOverridesEnabled,
-		PolicyRoutingIntent:          derefString(row.PolicyRoutingIntent),
-		AITrainingAllowed:            row.AiTrainingAllowed,
-		ByokEnabled:                  row.ByokEnabled,
-		ContentCaptureMode:           row.ContentCaptureMode,
-		HideTerminalSurfaces:         row.HideTerminalSurfaces,
-		FirstRequestServedAt:         timestamptzPtr(row.FirstRequestServedAt),
-		FlagOverrides:                overrides,
+		ID:                             row.ID.String(),
+		ExternalID:                     row.ExternalID,
+		Name:                           row.Name,
+		CreatedAt:                      timestampOrZero(row.CreatedAt),
+		UpdatedAt:                      timestampOrZero(row.UpdatedAt),
+		DeletedAt:                      timestampPtr(row.DeletedAt),
+		CreatedBy:                      row.CreatedBy,
+		ExcludedModels:                 excluded,
+		AllowedModels:                  allowed,
+		ModelsWhenSubscriptionActive:   modelsWhenSubscriptionActive,
+		ModelsWhenSubscriptionInactive: modelsWhenSubscriptionInactive,
+		ExcludedProviders:              excludedProviders,
+		PreferredModels:                preferred,
+		RoutingQualityWeight:           row.RoutingQualityWeight,
+		UsageBypassEnabled:             row.UsageBypassEnabled,
+		UsageBypassThreshold:           row.UsageBypassThreshold,
+		SubscriptionRoutingDisabled:    row.SubscriptionRoutingDisabled,
+		RoutingStrategy:                router.Strategy(derefString(row.RoutingStrategy)),
+		RoutingRolloutID:               derefString(row.RoutingRolloutID),
+		PolicyShadowStrategy:           router.Strategy(derefString(row.PolicyShadowStrategy)),
+		PolicyDebugEnabled:             row.PolicyDebugEnabled,
+		PolicyHeaderOverridesEnabled:   row.PolicyHeaderOverridesEnabled,
+		PolicyRoutingIntent:            derefString(row.PolicyRoutingIntent),
+		AITrainingAllowed:              row.AiTrainingAllowed,
+		ByokEnabled:                    row.ByokEnabled,
+		ContentCaptureMode:             row.ContentCaptureMode,
+		HideTerminalSurfaces:           row.HideTerminalSurfaces,
+		FirstRequestServedAt:           timestamptzPtr(row.FirstRequestServedAt),
+		FlagOverrides:                  overrides,
 	}
 }
 

--- a/internal/postgres/converters_test.go
+++ b/internal/postgres/converters_test.go
@@ -57,3 +57,15 @@ func TestToAuthInstallationPolicyRouting(t *testing.T) {
 	assert.Equal(t, "high", inst.PolicyRoutingIntent)
 	assert.True(t, inst.AITrainingAllowed)
 }
+
+func TestToAuthInstallationSubscriptionConditionalModels(t *testing.T) {
+	inst := toAuthInstallation(sqlc.RouterModelRouterInstallation{
+		ID:                             uuid.New(),
+		ExternalID:                     "org-conditional",
+		ModelsWhenSubscriptionActive:   []string{"claude-sonnet-5"},
+		ModelsWhenSubscriptionInactive: []string{"gpt-5.6-terra"},
+	})
+
+	assert.Equal(t, []string{"claude-sonnet-5"}, inst.ModelsWhenSubscriptionActive)
+	assert.Equal(t, []string{"gpt-5.6-terra"}, inst.ModelsWhenSubscriptionInactive)
+}

--- a/internal/proxy/allowlist_internal_test.go
+++ b/internal/proxy/allowlist_internal_test.go
@@ -35,6 +35,21 @@ func TestAllowedModelsForRequest_BuildsSet(t *testing.T) {
 	assert.Equal(t, map[string]struct{}{"a": {}, "b": {}}, got)
 }
 
+func TestAllowedModelsForRequest_IntersectsSubscriptionConditionalList(t *testing.T) {
+	ctx := ctxWithAllowedModels("a", "b")
+	ctx = context.WithValue(ctx, InstallationSubscriptionConditionalModelsContextKey{}, []string{"b", "c"})
+
+	assert.Equal(t, map[string]struct{}{"b": {}}, allowedModelsForRequest(ctx))
+}
+
+func TestAllowedModelsForRequest_EmptyConditionalIntersectionFailsClosed(t *testing.T) {
+	ctx := ctxWithAllowedModels("a")
+	ctx = context.WithValue(ctx, InstallationSubscriptionConditionalModelsContextKey{}, []string{"b"})
+
+	assert.NotNil(t, allowedModelsForRequest(ctx))
+	assert.Empty(t, allowedModelsForRequest(ctx))
+}
+
 // The allowlist is enforced by desugaring into the exclusion set: every
 // routable model absent from a non-empty allowlist must come back excluded.
 func TestExcludedModelsForRequest_AllowlistExcludesTheComplement(t *testing.T) {

--- a/internal/proxy/route_preview.go
+++ b/internal/proxy/route_preview.go
@@ -22,6 +22,7 @@ func (s *Service) anthropicRoutingRequest(
 	headers http.Header,
 	ingress string,
 ) (context.Context, router.Request, error) {
+	ctx = s.withUsageObserver(ctx, headers, routePathMessages)
 	log := observability.FromContext(ctx)
 	cleanBody, err := stripRoutingMarkerFromMessages(body)
 	if err != nil {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -774,10 +774,9 @@ func subscriptionConditionalModelsForRequest(ctx context.Context) []string {
 	return out
 }
 
-// allowedModelsForRequest returns the effective positive model allowlist as a
-// set, intersecting the installation allowlist with the selected subscription
-// state list. Nil means neither policy is configured; a non-nil empty map is
-// an intentionally empty intersection and therefore fails closed.
+// allowedModelsForRequest returns the effective positive model allowlist as a set,
+// intersecting the installation list with the selected subscription-state list.
+// Nil = no policy; non-nil empty = fails closed (intentional empty intersection).
 func allowedModelsForRequest(ctx context.Context) map[string]struct{} {
 	base := installationAllowedModelsFromContext(ctx)
 	conditional := subscriptionConditionalModelsForRequest(ctx)
@@ -5703,9 +5702,8 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	pinAgeSec := routeRes.PinAgeSec
 	s.logPlannerOutcome(ctx, routeRes)
 
-	// See the ProxyMessages cache-eligibility note: subsidized and
-	// subscription-state-conditional requests bypass the semantic cache (the key
-	// doesn't capture headroom-dependent model choice).
+	// See the ProxyMessages cache-eligibility note: subsidized and subscription-state-conditional
+	// requests bypass the semantic cache (key doesn't capture headroom-dependent model choice).
 	cacheEligible := s.semanticCacheAllowed(ctx) && s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !responsesPassthrough && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0 && len(subscriptionConditionalModelsForRequest(ctx)) == 0
 	if cacheEligible {
 		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatOpenAI, decision.Metadata.Embedding, decision.Metadata.ClusterIDs, decision.Metadata.ClusterRouterVersion, decision.Metadata.EffectiveKnobsHash); hit {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -435,9 +435,7 @@ type InstallationExcludedModelsContextKey struct{}
 // means no restriction.
 type InstallationAllowedModelsContextKey struct{}
 
-// InstallationSubscriptionModelsWhenActiveContextKey is the context key for
-// the installation's conditional allowlist selected when the caller
-// subscription has headroom.
+// InstallationSubscriptionModelsWhenActiveContextKey is the context key for the active-subscription conditional model allowlist.
 type InstallationSubscriptionModelsWhenActiveContextKey struct{}
 
 // InstallationSubscriptionModelsWhenInactiveContextKey is the context key for

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -435,6 +435,21 @@ type InstallationExcludedModelsContextKey struct{}
 // means no restriction.
 type InstallationAllowedModelsContextKey struct{}
 
+// InstallationSubscriptionModelsWhenActiveContextKey is the context key for
+// the installation's conditional allowlist selected when the caller
+// subscription has headroom.
+type InstallationSubscriptionModelsWhenActiveContextKey struct{}
+
+// InstallationSubscriptionModelsWhenInactiveContextKey is the context key for
+// the installation's conditional allowlist selected after subscription
+// exhaustion.
+type InstallationSubscriptionModelsWhenInactiveContextKey struct{}
+
+// InstallationSubscriptionConditionalModelsContextKey carries the one
+// conditional allowlist selected for the current request after the usage
+// observer determines subscription state.
+type InstallationSubscriptionConditionalModelsContextKey struct{}
+
 // InstallationExcludedProvidersContextKey is the context key for the authed
 // installation's provider exclusion list. Carried as []string.
 type InstallationExcludedProvidersContextKey struct{}
@@ -738,16 +753,63 @@ func installationAllowedModelsFromContext(ctx context.Context) []string {
 	return out
 }
 
-// allowedModelsForRequest returns the org's positive model allowlist as a set,
-// or nil when empty (no restriction).
-func allowedModelsForRequest(ctx context.Context) map[string]struct{} {
-	allowed := installationAllowedModelsFromContext(ctx)
-	if len(allowed) == 0 {
+func installationSubscriptionModelsWhenActiveFromContext(ctx context.Context) []string {
+	v := ctx.Value(InstallationSubscriptionModelsWhenActiveContextKey{})
+	if v == nil {
 		return nil
 	}
-	out := make(map[string]struct{}, len(allowed))
-	for _, m := range allowed {
-		out[m] = struct{}{}
+	out, _ := v.([]string)
+	return out
+}
+
+func installationSubscriptionModelsWhenInactiveFromContext(ctx context.Context) []string {
+	v := ctx.Value(InstallationSubscriptionModelsWhenInactiveContextKey{})
+	if v == nil {
+		return nil
+	}
+	out, _ := v.([]string)
+	return out
+}
+
+func subscriptionConditionalModelsForRequest(ctx context.Context) []string {
+	v := ctx.Value(InstallationSubscriptionConditionalModelsContextKey{})
+	if v == nil {
+		return nil
+	}
+	out, _ := v.([]string)
+	return out
+}
+
+// allowedModelsForRequest returns the effective positive model allowlist as a
+// set, intersecting the installation allowlist with the selected subscription
+// state list. Nil means neither policy is configured; a non-nil empty map is
+// an intentionally empty intersection and therefore fails closed.
+func allowedModelsForRequest(ctx context.Context) map[string]struct{} {
+	base := installationAllowedModelsFromContext(ctx)
+	conditional := subscriptionConditionalModelsForRequest(ctx)
+	if len(base) == 0 && len(conditional) == 0 {
+		return nil
+	}
+	if len(base) == 0 {
+		base = conditional
+		conditional = nil
+	}
+	if len(conditional) == 0 {
+		out := make(map[string]struct{}, len(base))
+		for _, m := range base {
+			out[m] = struct{}{}
+		}
+		return out
+	}
+	conditionalSet := make(map[string]struct{}, len(conditional))
+	for _, m := range conditional {
+		conditionalSet[m] = struct{}{}
+	}
+	out := make(map[string]struct{}, len(base))
+	for _, m := range base {
+		if _, ok := conditionalSet[m]; ok {
+			out[m] = struct{}{}
+		}
 	}
 	return out
 }
@@ -755,10 +817,11 @@ func allowedModelsForRequest(ctx context.Context) map[string]struct{} {
 // modelPermittedByAllowlist reports whether model clears the org's positive
 // allowlist. Must be used directly for models outside routableUniverse —
 // passthrough-only models (no Tier) never enter the desugared exclusion set.
-// Empty allowlist = no restriction.
+// A nil allowlist means no restriction; an empty effective intersection fails
+// closed.
 func modelPermittedByAllowlist(ctx context.Context, model string) bool {
 	allowed := allowedModelsForRequest(ctx)
-	if len(allowed) == 0 {
+	if allowed == nil {
 		return true
 	}
 	_, ok := allowed[model]
@@ -832,8 +895,8 @@ func (s *Service) safetyExcludedModels(env *translate.RequestEnvelope, outputRes
 
 // excludedModelsForRequest returns the request's model exclusion set.
 // Env override wins (intentional escape hatch, not an oversight).
-// Otherwise desugars the positive allowlist into the exclusion set:
-// every routable model absent from a non-empty allowlist is excluded.
+// Otherwise desugars the positive allowlists into the exclusion set: every
+// routable model absent from the effective allowlist is excluded.
 func (s *Service) excludedModelsForRequest(ctx context.Context) map[string]struct{} {
 	if s.excludedModelsOverride != nil {
 		return s.excludedModelsOverride
@@ -843,7 +906,7 @@ func (s *Service) excludedModelsForRequest(ctx context.Context) map[string]struc
 	for _, m := range excluded {
 		out[m] = struct{}{}
 	}
-	if allowed := allowedModelsForRequest(ctx); len(allowed) > 0 {
+	if allowed := allowedModelsForRequest(ctx); allowed != nil {
 		for model := range s.routableUniverse() {
 			if _, ok := allowed[model]; !ok {
 				out[model] = struct{}{}
@@ -2705,7 +2768,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	if err != nil {
 		return err
 	}
-	ctx = s.withUsageObserver(ctx, r.Header)
+	ctx = s.withUsageObserver(ctx, r.Header, routePathMessages)
 	log := observability.FromContext(ctx)
 	requestStart := time.Now()
 	requestID := requestIDFor(ctx)
@@ -5348,7 +5411,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	if err != nil {
 		return err
 	}
-	ctx = s.withUsageObserver(ctx, r.Header)
+	ctx = s.withUsageObserver(ctx, r.Header, routePathChatCompletions)
 	log := observability.FromContext(ctx)
 	requestStart := time.Now()
 	requestID := requestIDFor(ctx)
@@ -6354,7 +6417,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 // re-emitted as Responses-shaped SSE / JSON. This keeps the turn loop, cache,
 // pricing, and translation matrix unchanged.
 func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.ResponseWriter, r *http.Request) error {
-	ctx = s.withUsageObserver(ctx, r.Header)
+	ctx = s.withUsageObserver(ctx, r.Header, routePathResponses)
 	clientAppCodex := ClientIdentityFrom(ctx).ClientApp == ClientAppCodex
 	if translate.FeedbackFooterSinceLastHumanTurnInResponses(body) {
 		ctx = context.WithValue(ctx, responsesFooterEchoedContextKey{}, true)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -438,14 +438,10 @@ type InstallationAllowedModelsContextKey struct{}
 // InstallationSubscriptionModelsWhenActiveContextKey is the context key for the active-subscription conditional model allowlist.
 type InstallationSubscriptionModelsWhenActiveContextKey struct{}
 
-// InstallationSubscriptionModelsWhenInactiveContextKey is the context key for
-// the installation's conditional allowlist selected after subscription
-// exhaustion.
+// InstallationSubscriptionModelsWhenInactiveContextKey is the context key for the exhausted-subscription conditional model allowlist.
 type InstallationSubscriptionModelsWhenInactiveContextKey struct{}
 
-// InstallationSubscriptionConditionalModelsContextKey carries the one
-// conditional allowlist selected for the current request after the usage
-// observer determines subscription state.
+// InstallationSubscriptionConditionalModelsContextKey is the context key for the request-selected conditional model allowlist.
 type InstallationSubscriptionConditionalModelsContextKey struct{}
 
 // InstallationExcludedProvidersContextKey is the context key for the authed

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3239,7 +3239,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// Subscription-only turns are excluded (like the OpenAI path): the mode is an
 	// unfoldable routing signal absent from the cache key, so a stored body would
 	// bypass the exhausted-sub 402 guard and the depleted-credits warning below.
-	cacheEligible := s.semanticCacheAllowed(ctx) && s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !compactionHandoverRan && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0
+	// Subscription-state conditional model lists are likewise absent from the
+	// cache key, so never cache a request after one has been selected.
+	cacheEligible := s.semanticCacheAllowed(ctx) && s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !compactionHandoverRan && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0 && len(subscriptionConditionalModelsForRequest(ctx)) == 0
 	if cacheEligible {
 		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatAnthropic, decision.Metadata.Embedding, decision.Metadata.ClusterIDs, decision.Metadata.ClusterRouterVersion, decision.Metadata.EffectiveKnobsHash); hit {
 			s.writeCachedResponse(w, resp, decision)
@@ -5701,9 +5703,10 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	pinAgeSec := routeRes.PinAgeSec
 	s.logPlannerOutcome(ctx, routeRes)
 
-	// See the ProxyMessages cache-eligibility note: subsidized requests bypass the
-	// semantic cache (the key doesn't capture headroom-dependent model choice).
-	cacheEligible := s.semanticCacheAllowed(ctx) && s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !responsesPassthrough && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0
+	// See the ProxyMessages cache-eligibility note: subsidized and
+	// subscription-state-conditional requests bypass the semantic cache (the key
+	// doesn't capture headroom-dependent model choice).
+	cacheEligible := s.semanticCacheAllowed(ctx) && s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !responsesPassthrough && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0 && len(subscriptionConditionalModelsForRequest(ctx)) == 0
 	if cacheEligible {
 		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatOpenAI, decision.Metadata.Embedding, decision.Metadata.ClusterIDs, decision.Metadata.ClusterRouterVersion, decision.Metadata.EffectiveKnobsHash); hit {
 			s.writeCachedResponse(w, resp, decision)

--- a/internal/proxy/service_cache_test.go
+++ b/internal/proxy/service_cache_test.go
@@ -108,6 +108,31 @@ func TestService_Cache_HitShortCircuitsProvider(t *testing.T) {
 	assert.Equal(t, proxy.RouterCacheHit, rec2.Header().Get(proxy.HeaderRouterCache))
 }
 
+func TestService_Cache_ConditionalSubscriptionModelsBypass(t *testing.T) {
+	emb := embeddingFixture(11)
+	provider := &fakeProvider{
+		proxyResponse: func(w http.ResponseWriter) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"conditional"}`))
+		},
+	}
+	fr := &fakeRouter{decision: decisionWithEmbedding(emb, []int{0, 1})}
+	c := cache.New(cache.DefaultConfig())
+	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderAnthropic: provider}, nil, false, c, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil)
+
+	ctx := proxyContextWithExternalID(t, "tenant-conditional")
+	ctx = context.WithValue(ctx, proxy.InstallationSubscriptionConditionalModelsContextKey{}, []string{"claude-haiku-4-5"})
+	body := anthropicBody("conditional cache", false)
+
+	rec1 := httptest.NewRecorder()
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec1, httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))))
+	rec2 := httptest.NewRecorder()
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec2, httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))))
+
+	assert.Len(t, provider.proxyBodies, 2, "subscription-state conditional requests must not replay a cached response")
+	assert.Empty(t, rec2.Header().Get(proxy.HeaderRouterCache))
+}
+
 func TestService_Cache_StreamingBypasses(t *testing.T) {
 	emb := embeddingFixture(2)
 	provider := &fakeProvider{

--- a/internal/proxy/subscription_conditional_models_internal_test.go
+++ b/internal/proxy/subscription_conditional_models_internal_test.go
@@ -1,0 +1,119 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"workweave/router/internal/proxy/usage"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const conditionalModelsSubscriptionToken = "sk-ant-oat01-conditional-models"
+const conditionalModelsCodexToken = "chatgpt-jwt-conditional-models"
+
+func conditionalModelsContext(active, inactive []string) context.Context {
+	ctx := context.WithValue(context.Background(), AnthropicSubscriptionContextKey{}, conditionalModelsSubscriptionToken)
+	ctx = context.WithValue(ctx, InstallationSubscriptionModelsWhenActiveContextKey{}, active)
+	return context.WithValue(ctx, InstallationSubscriptionModelsWhenInactiveContextKey{}, inactive)
+}
+
+func conditionalModelsObserverFor(token string, snapshot usage.Snapshot) *usage.Observer {
+	now := time.Unix(1_000_000, 0)
+	observer := usage.NewObserver([]byte("conditional-models-salt"), time.Minute, func() time.Time { return now })
+	observer.Record(observer.Key([]byte(token)), snapshot)
+	return observer
+}
+
+func conditionalModelsObserver(snapshot usage.Snapshot) *usage.Observer {
+	return conditionalModelsObserverFor(conditionalModelsSubscriptionToken, snapshot)
+}
+
+func TestWithSubscriptionConditionalModels_SelectsActiveList(t *testing.T) {
+	svc := &Service{usageObserver: conditionalModelsObserver(usage.Snapshot{
+		Primary: usage.Window{UsedPercent: 0.50, WindowMinutes: 300},
+	})}
+
+	ctx := svc.withSubscriptionConditionalModels(
+		conditionalModelsContext([]string{"active-model"}, []string{"inactive-model"}),
+		http.Header{},
+	)
+
+	assert.Equal(t, []string{"active-model"}, subscriptionConditionalModelsForRequest(ctx))
+}
+
+func TestWithSubscriptionConditionalModels_SelectsInactiveListWhenExhausted(t *testing.T) {
+	svc := &Service{usageObserver: conditionalModelsObserver(usage.Snapshot{
+		Secondary: usage.Window{UsedPercent: 1.0, WindowMinutes: 10080},
+	})}
+
+	ctx := svc.withSubscriptionConditionalModels(
+		conditionalModelsContext([]string{"active-model"}, []string{"inactive-model"}),
+		http.Header{},
+	)
+
+	assert.Equal(t, []string{"inactive-model"}, subscriptionConditionalModelsForRequest(ctx))
+}
+
+func TestWithSubscriptionConditionalModels_ColdStartUsesActiveList(t *testing.T) {
+	observer := usage.NewObserver([]byte("conditional-models-salt"), time.Minute, time.Now)
+	svc := &Service{usageObserver: observer}
+
+	ctx := svc.withSubscriptionConditionalModels(
+		conditionalModelsContext([]string{"active-model"}, []string{"inactive-model"}),
+		http.Header{},
+	)
+
+	assert.Equal(t, []string{"active-model"}, subscriptionConditionalModelsForRequest(ctx))
+}
+
+func TestWithSubscriptionConditionalModels_ExcludesModelsFromRouting(t *testing.T) {
+	svc := &Service{
+		usageObserver:   conditionalModelsObserver(usage.Snapshot{Primary: usage.Window{UsedPercent: 0.1, WindowMinutes: 300}}),
+		availableModels: map[string]struct{}{"active-model": {}, "other-model": {}},
+	}
+	ctx := svc.withSubscriptionConditionalModels(
+		conditionalModelsContext([]string{"active-model"}, []string{"inactive-model"}),
+		http.Header{},
+	)
+
+	excluded := svc.excludedModelsForRequest(ctx)
+	assert.NotContains(t, excluded, "active-model")
+	assert.Contains(t, excluded, "other-model")
+}
+
+func TestWithSubscriptionConditionalModels_DoesNothingWithoutSubscription(t *testing.T) {
+	observer := conditionalModelsObserver(usage.Snapshot{Secondary: usage.Window{UsedPercent: 1.0, WindowMinutes: 10080}})
+	svc := &Service{usageObserver: observer}
+	ctx := context.WithValue(context.Background(), InstallationSubscriptionModelsWhenActiveContextKey{}, []string{"active-model"})
+	ctx = context.WithValue(ctx, InstallationSubscriptionModelsWhenInactiveContextKey{}, []string{"inactive-model"})
+
+	out := svc.withSubscriptionConditionalModels(ctx, http.Header{})
+	_, ok := out.Value(InstallationSubscriptionConditionalModelsContextKey{}).([]string)
+	require.False(t, ok)
+}
+
+func TestWithSubscriptionConditionalModels_UsesCoveringSubscriptionOnly(t *testing.T) {
+	observer := conditionalModelsObserverFor(conditionalModelsSubscriptionToken, usage.Snapshot{
+		Secondary: usage.Window{UsedPercent: 1.0, WindowMinutes: 10080},
+	})
+	observer.Record(observer.Key([]byte(conditionalModelsCodexToken)), usage.Snapshot{
+		Primary: usage.Window{UsedPercent: 0.1, WindowMinutes: 300},
+	})
+	svc := &Service{usageObserver: observer}
+	ctx := conditionalModelsContext([]string{"active-model"}, []string{"inactive-model"})
+	ctx = context.WithValue(ctx, OpenAISubscriptionContextKey{}, conditionalModelsCodexToken)
+	ctx = context.WithValue(ctx, OpenAIAccountIDContextKey{}, "acct_conditional-models")
+
+	// The unrelated active Codex credential must not mask the exhausted Claude
+	// credential on the Anthropic Messages endpoint.
+	messagesCtx := svc.withSubscriptionConditionalModels(ctx, http.Header{}, routePathMessages)
+	assert.Equal(t, []string{"inactive-model"}, subscriptionConditionalModelsForRequest(messagesCtx))
+
+	// Conversely, the active Codex credential is the one that matters on OpenAI.
+	chatCtx := svc.withSubscriptionConditionalModels(ctx, http.Header{}, routePathChatCompletions)
+	assert.Equal(t, []string{"active-model"}, subscriptionConditionalModelsForRequest(chatCtx))
+}

--- a/internal/proxy/subsidy.go
+++ b/internal/proxy/subsidy.go
@@ -175,8 +175,13 @@ func RequestPresentsCoveringSubscription(ctx context.Context, headers http.Heade
 // Phase 0 telemetry. Both concerns share one observer slot
 // (providers.WithUpstreamHeaderObserver holds only one per ctx); the capture is
 // wrapped in recover so a Phase 0 bug can never take down the subsidy observer.
-// No-op when usageObserver is nil AND no Anthropic subscription token is present.
-func (s *Service) withUsageObserver(ctx context.Context, headers http.Header) context.Context {
+// No-op when usageObserver is nil AND no subscription token is present.
+func (s *Service) withUsageObserver(ctx context.Context, headers http.Header, routePaths ...string) context.Context {
+	routePath := ""
+	if len(routePaths) > 0 {
+		routePath = routePaths[0]
+	}
+	ctx = s.withSubscriptionConditionalModels(ctx, headers, routePath)
 	codexTok, anthroTok := presentSubscriptionTokens(ctx, headers)
 	if s.usageObserver == nil && anthroTok == "" {
 		return ctx
@@ -218,6 +223,65 @@ func (s *Service) withUsageObserver(ctx context.Context, headers http.Header) co
 		}
 	}
 	return providers.WithUpstreamHeaderObserver(ctx, obs)
+}
+
+// withSubscriptionConditionalModels selects the installation's conditional
+// model allowlist for this request. A subscription is active when at least one
+// presented subscription credential is not exhausted; an unobserved
+// credential is treated as active so the first request can prime the observer.
+// The conditional lists are an additional restriction: an empty selected list
+// preserves the existing unrestricted behavior.
+func (s *Service) withSubscriptionConditionalModels(ctx context.Context, headers http.Header, routePaths ...string) context.Context {
+	activeModels := installationSubscriptionModelsWhenActiveFromContext(ctx)
+	inactiveModels := installationSubscriptionModelsWhenInactiveFromContext(ctx)
+	if s.usageObserver == nil || (len(activeModels) == 0 && len(inactiveModels) == 0) {
+		return ctx
+	}
+	codexTok, anthroTok := presentSubscriptionTokens(ctx, headers)
+	routePath := ""
+	if len(routePaths) > 0 {
+		routePath = routePaths[0]
+	}
+	// Dual-subscription clients can send both credentials on every request.
+	// Only the family that covers this endpoint determines its conditional state;
+	// an unrelated credential must not keep an exhausted covering subscription in
+	// the active branch.
+	switch routePath {
+	case routePathMessages:
+		codexTok = ""
+	case routePathChatCompletions, routePathResponses:
+		anthroTok = ""
+	}
+	if codexTok == "" && anthroTok == "" {
+		return ctx
+	}
+
+	active := false
+	observed := false
+	for _, token := range []string{codexTok, anthroTok} {
+		if token == "" {
+			continue
+		}
+		snapshot, ok := s.usageObserver.Snapshot(s.usageObserver.Key([]byte(token)))
+		if !ok {
+			active = true
+			continue
+		}
+		observed = true
+		if !snapshot.Exhausted() {
+			active = true
+		}
+	}
+	if !active && observed {
+		if len(inactiveModels) > 0 {
+			return context.WithValue(ctx, InstallationSubscriptionConditionalModelsContextKey{}, inactiveModels)
+		}
+		return ctx
+	}
+	if len(activeModels) > 0 {
+		return context.WithValue(ctx, InstallationSubscriptionConditionalModelsContextKey{}, activeModels)
+	}
+	return ctx
 }
 
 // subsidyFactors computes the per-covered-model cost multiplier for this

--- a/internal/proxy/subsidy.go
+++ b/internal/proxy/subsidy.go
@@ -225,12 +225,8 @@ func (s *Service) withUsageObserver(ctx context.Context, headers http.Header, ro
 	return providers.WithUpstreamHeaderObserver(ctx, obs)
 }
 
-// withSubscriptionConditionalModels selects the installation's conditional
-// model allowlist for this request. A subscription is active when at least one
-// presented subscription credential is not exhausted; an unobserved
-// credential is treated as active so the first request can prime the observer.
-// The conditional lists are an additional restriction: an empty selected list
-// preserves the existing unrestricted behavior.
+// withSubscriptionConditionalModels selects the per-request conditional model allowlist based on subscription state.
+// An unobserved credential is treated as active (cold-start priming); an empty selected list preserves unrestricted behavior.
 func (s *Service) withSubscriptionConditionalModels(ctx context.Context, headers http.Header, routePaths ...string) context.Context {
 	activeModels := installationSubscriptionModelsWhenActiveFromContext(ctx)
 	inactiveModels := installationSubscriptionModelsWhenInactiveFromContext(ctx)
@@ -242,10 +238,8 @@ func (s *Service) withSubscriptionConditionalModels(ctx context.Context, headers
 	if len(routePaths) > 0 {
 		routePath = routePaths[0]
 	}
-	// Dual-subscription clients can send both credentials on every request.
-	// Only the family that covers this endpoint determines its conditional state;
-	// an unrelated credential must not keep an exhausted covering subscription in
-	// the active branch.
+	// Only the credential family covering this endpoint determines state; an
+	// unrelated active credential must not mask an exhausted covering one.
 	switch routePath {
 	case routePathMessages:
 		codexTok = ""

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -93,7 +93,7 @@ func (s *Service) usageBypassEngaged(ctx context.Context, headers http.Header, r
 	// Allowlist is a compliance boundary, not a routing preference —
 	// unlike excluded_models the bypass must honor it. Checked explicitly
 	// because SafetyExcludedModels has different readers and semantics.
-	if len(req.AllowedModels) > 0 {
+	if req.AllowedModels != nil {
 		if _, allowed := req.AllowedModels[model]; !allowed {
 			return "", false
 		}

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -112,6 +112,12 @@ func withAPIKey(svc *auth.Service, byokRequiresOptIn bool) gin.HandlerFunc {
 			if len(installation.AllowedModels) > 0 {
 				ctx = context.WithValue(ctx, proxy.InstallationAllowedModelsContextKey{}, installation.AllowedModels)
 			}
+			if len(installation.ModelsWhenSubscriptionActive) > 0 {
+				ctx = context.WithValue(ctx, proxy.InstallationSubscriptionModelsWhenActiveContextKey{}, installation.ModelsWhenSubscriptionActive)
+			}
+			if len(installation.ModelsWhenSubscriptionInactive) > 0 {
+				ctx = context.WithValue(ctx, proxy.InstallationSubscriptionModelsWhenInactiveContextKey{}, installation.ModelsWhenSubscriptionInactive)
+			}
 			if len(installation.ExcludedProviders) > 0 {
 				ctx = context.WithValue(ctx, proxy.InstallationExcludedProvidersContextKey{}, installation.ExcludedProviders)
 			}

--- a/internal/sqlc/model_router_api_keys.sql.go
+++ b/internal/sqlc/model_router_api_keys.sql.go
@@ -102,7 +102,7 @@ func (q *Queries) CreateModelRouterAPIKey(ctx context.Context, arg CreateModelRo
 }
 
 const getActiveModelRouterAPIKeyWithInstallationByHash = `-- name: GetActiveModelRouterAPIKeyWithInstallationByHash :one
-SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, k.scope, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled, i.routing_strategy, i.routing_rollout_id, i.policy_shadow_strategy, i.policy_debug_enabled, i.policy_header_overrides_enabled, i.policy_routing_intent, i.ai_training_allowed, i.byok_enabled, i.content_capture_mode, i.hide_terminal_surfaces, i.allowed_models, i.first_request_served_at, i.flag_overrides
+SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, k.scope, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled, i.routing_strategy, i.routing_rollout_id, i.policy_shadow_strategy, i.policy_debug_enabled, i.policy_header_overrides_enabled, i.policy_routing_intent, i.ai_training_allowed, i.byok_enabled, i.content_capture_mode, i.hide_terminal_surfaces, i.allowed_models, i.first_request_served_at, i.flag_overrides, i.models_when_subscription_active, i.models_when_subscription_inactive
 FROM router.model_router_api_keys k
 INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 WHERE k.key_hash = $1::varchar
@@ -121,7 +121,7 @@ type GetActiveModelRouterAPIKeyWithInstallationByHashRow struct {
 // both sides so a soft-deleted installation invalidates all its keys without per-key
 // updates.
 //
-//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, k.scope, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled, i.routing_strategy, i.routing_rollout_id, i.policy_shadow_strategy, i.policy_debug_enabled, i.policy_header_overrides_enabled, i.policy_routing_intent, i.ai_training_allowed, i.byok_enabled, i.content_capture_mode, i.hide_terminal_surfaces, i.allowed_models, i.first_request_served_at, i.flag_overrides
+//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, k.scope, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled, i.routing_strategy, i.routing_rollout_id, i.policy_shadow_strategy, i.policy_debug_enabled, i.policy_header_overrides_enabled, i.policy_routing_intent, i.ai_training_allowed, i.byok_enabled, i.content_capture_mode, i.hide_terminal_surfaces, i.allowed_models, i.first_request_served_at, i.flag_overrides, i.models_when_subscription_active, i.models_when_subscription_inactive
 //	FROM router.model_router_api_keys k
 //	INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 //	WHERE k.key_hash = $1::varchar
@@ -172,6 +172,8 @@ func (q *Queries) GetActiveModelRouterAPIKeyWithInstallationByHash(ctx context.C
 		&i.RouterModelRouterInstallation.AllowedModels,
 		&i.RouterModelRouterInstallation.FirstRequestServedAt,
 		&i.RouterModelRouterInstallation.FlagOverrides,
+		&i.RouterModelRouterInstallation.ModelsWhenSubscriptionActive,
+		&i.RouterModelRouterInstallation.ModelsWhenSubscriptionInactive,
 	)
 	return i, err
 }

--- a/internal/sqlc/model_router_installations.sql.go
+++ b/internal/sqlc/model_router_installations.sql.go
@@ -22,7 +22,7 @@ VALUES (
     $2::varchar,
     $3
 )
-RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models, first_request_served_at, flag_overrides
+RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models, first_request_served_at, flag_overrides, models_when_subscription_active, models_when_subscription_inactive
 `
 
 type CreateModelRouterInstallationParams struct {
@@ -43,7 +43,7 @@ type CreateModelRouterInstallationParams struct {
 //	    $2::varchar,
 //	    $3
 //	)
-//	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models, first_request_served_at, flag_overrides
+//	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models, first_request_served_at, flag_overrides, models_when_subscription_active, models_when_subscription_inactive
 func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateModelRouterInstallationParams) (RouterModelRouterInstallation, error) {
 	row := q.db.QueryRow(ctx, createModelRouterInstallation, arg.ExternalID, arg.Name, arg.CreatedBy)
 	var i RouterModelRouterInstallation
@@ -75,12 +75,14 @@ func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateM
 		&i.AllowedModels,
 		&i.FirstRequestServedAt,
 		&i.FlagOverrides,
+		&i.ModelsWhenSubscriptionActive,
+		&i.ModelsWhenSubscriptionInactive,
 	)
 	return i, err
 }
 
 const getModelRouterInstallation = `-- name: GetModelRouterInstallation :one
-SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models, first_request_served_at, flag_overrides
+SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models, first_request_served_at, flag_overrides, models_when_subscription_active, models_when_subscription_inactive
 FROM router.model_router_installations
 WHERE id = $1::uuid
   AND external_id = $2::varchar
@@ -94,7 +96,7 @@ type GetModelRouterInstallationParams struct {
 
 // Gets an installation by id, scoped to an external_id to prevent cross-tenant access.
 //
-//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models, first_request_served_at, flag_overrides
+//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models, first_request_served_at, flag_overrides, models_when_subscription_active, models_when_subscription_inactive
 //	FROM router.model_router_installations
 //	WHERE id = $1::uuid
 //	  AND external_id = $2::varchar
@@ -130,12 +132,14 @@ func (q *Queries) GetModelRouterInstallation(ctx context.Context, arg GetModelRo
 		&i.AllowedModels,
 		&i.FirstRequestServedAt,
 		&i.FlagOverrides,
+		&i.ModelsWhenSubscriptionActive,
+		&i.ModelsWhenSubscriptionInactive,
 	)
 	return i, err
 }
 
 const listModelRouterInstallationsForExternalID = `-- name: ListModelRouterInstallationsForExternalID :many
-SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models, first_request_served_at, flag_overrides
+SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models, first_request_served_at, flag_overrides, models_when_subscription_active, models_when_subscription_inactive
 FROM router.model_router_installations
 WHERE external_id = $1::varchar
   AND deleted_at IS NULL
@@ -144,7 +148,7 @@ ORDER BY created_at DESC
 
 // ListModelRouterInstallationsForExternalID
 //
-//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models, first_request_served_at, flag_overrides
+//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models, first_request_served_at, flag_overrides, models_when_subscription_active, models_when_subscription_inactive
 //	FROM router.model_router_installations
 //	WHERE external_id = $1::varchar
 //	  AND deleted_at IS NULL
@@ -186,6 +190,8 @@ func (q *Queries) ListModelRouterInstallationsForExternalID(ctx context.Context,
 			&i.AllowedModels,
 			&i.FirstRequestServedAt,
 			&i.FlagOverrides,
+			&i.ModelsWhenSubscriptionActive,
+			&i.ModelsWhenSubscriptionInactive,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -150,6 +150,10 @@ type RouterModelRouterInstallation struct {
 	FirstRequestServedAt pgtype.Timestamptz
 	// Sparse per-org behavioral flag overrides, keyed by internal/flags registry key. Empty object = inherit every deployment default. Precedence: header override > this > env default, unless ROUTER_FLAG_OVERRIDES_DISABLED is set.
 	FlagOverrides []byte
+	// Optional model allowlist while the caller subscription is active; empty means no conditional restriction.
+	ModelsWhenSubscriptionActive []string
+	// Optional model allowlist while the caller subscription is exhausted; empty means no conditional restriction.
+	ModelsWhenSubscriptionInactive []string
 }
 
 type RouterModelRouterRequestTelemetry struct {


### PR DESCRIPTION
## Summary

Adds optional, persistent per-installation model allowlists selected at request time from the caller's subscription state:

- `models_when_subscription_active` — enforced while `usage.Observer` reports at least one covering subscription with headroom (or an unobserved cold-start credential).
- `models_when_subscription_inactive` — enforced after all presented covering subscriptions are observed exhausted.

## Behavior

- Empty selected list preserves existing unrestricted behavior; the conditional list composes with (intersects) the existing `allowed_models` allowlist, and an empty intersection fails closed.
- On dual-credential requests, only the subscription family covering the endpoint (`/v1/messages` → Anthropic, `/v1/chat/completions` and `/v1/responses` → Codex) determines the state.
- Restrictions flow through the existing allowlist desugaring, so routing, force-model, usage-bypass, and route-preview all enforce the effective set.

## Validation

- `go test ./...`
- `go vet ./...`
- `git diff --check`
