### PR TITLE
fix(translate): widen the text-only-turn nudge's leaked-markup gate

### DIFF
--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -1220,11 +1220,9 @@ const leadingContentCap = 64
 // the arguments as content, so the visible turn opens mid-call on a closing
 // child tag.
 //
-// Matching stays anchored rather than scanning the whole window: a finished
-// answer that quotes completed markup (`</tool_call>`, a balanced
-// `<arg_value>…</arg_value>`) is indistinguishable from a leak by containment
-// alone, and nudging it appends a fabricated tool call to an already-complete
-// turn. The anchored form catches the observed leaks on its own.
+// Matching stays anchored: quoted completed markup (`</tool_call>`,
+// `<arg_value>…</arg_value>`) is indistinguishable from a leak by
+// containment alone — anchored matching catches both observed leaks.
 //
 // Reasoning markup (<think>) is deliberately excluded: models like Mimo-v2.5
 // stream visible chain-of-thought as <think>…</think> then a real answer with

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -1205,21 +1205,37 @@ func (t *AnthropicSSETranslator) emitValidatedToolArgsDelta(blockIdx int) error 
 // dispatchable; the echo surfaces as a tool_result nudging the model to act.
 const routerNudgeCommand = "echo '[router] previous turn produced no tool_use; use Edit/Write/Read/Bash/Grep — do not respond with prose or thinking tags only.'"
 
-// leadingContentCap bounds retained opening text for leadsWithToolishMarkup —
-// enough for any marker plus leading whitespace.
-const leadingContentCap = 64
+// leadingContentCap bounds retained opening text for leadsWithToolishMarkup
+// and containsToolishMarkup. Sized past any single marker because the
+// containment scan needs the *closing* tag in the buffer too: GLM-5.3 emits
+// `</arg_key><arg_value>…</arg_value></tool_call>` where the payload between
+// the tags is a tool name plus arguments, so the closing tags land well past
+// a marker-width window (the production session's leak was 125 bytes).
+const leadingContentCap = 512
 
-// toolishMarkupMarkers are opening tokens of a tool call leaked into the
-// content channel as XML instead of a structured tool_use block; Claude
-// Code's strict parser rejects these and dead-ends the turn, which the nudge
-// rescues. Matched only at the turn's start (see leadsWithToolishMarkup) so a
+// toolishMarkupMarkers are tokens of a tool call leaked into the content
+// channel as XML instead of a structured tool_use block; Claude Code's strict
+// parser rejects these and dead-ends the turn, which the nudge rescues.
+// Matched only at the turn's start (see leadsWithToolishMarkup) so a
 // legitimate answer that discusses these tags mid-prose isn't misflagged.
+//
+// Closing and child tags are included because a leak does not reliably start
+// at the call's opening tag: GLM-5.3 streams the tool name as reasoning and
+// the arguments as content, so the visible turn opens mid-call on `</arg_key>`
+// or `<arg_value>` (session b56057cf — three consecutive dead-ended turns,
+// each 31 output tokens, no tool_use block).
 //
 // Reasoning markup (<think>) is deliberately excluded: models like Mimo-v2.5
 // stream visible chain-of-thought as <think>…</think> then a real answer with
 // finish_reason="stop" — a valid turn, not a parse failure. Nudging on it
 // looped the session (echo -> re-pin -> another <think>+answer -> repeat).
-var toolishMarkupMarkers = []string{"<tool_call", "<function", "<invoke"}
+var toolishMarkupMarkers = []string{
+	"<tool_call", "</tool_call",
+	"<function", "</function",
+	"<invoke", "</invoke",
+	"<arg_key", "</arg_key",
+	"<arg_value", "</arg_value",
+}
 
 // leadsWithToolishMarkup reports whether content opens (ignoring leading
 // whitespace) with tool-call markup — anchored to the start so a substring
@@ -1232,6 +1248,29 @@ func leadsWithToolishMarkup(content string) bool {
 		}
 	}
 	return false
+}
+
+// containsToolishMarkup reports whether content carries leaked tool-call
+// markup anywhere in the retained window, for leaks that begin with prose
+// ("Let me load those schemas.\n<tool_call>…") and so escape the anchored
+// prefix check.
+//
+// Only two shapes count, both chosen because prose that *discusses* tool
+// syntax does not produce them: a closing `</tool_call>`, and a balanced
+// `<arg_value>…</arg_value>` pair. Documentation and explanations name the
+// opening tags (`<tool_call>`, `<function>`) — matching on those here would
+// misfire on the very prose leadsWithToolishMarkup was anchored to protect
+// (see TestAnthropicSSETranslator_TextOnlyTurnNudge_SkippedWhenProseMentionsMarkup).
+// The pair is checked in order so a stray closing tag alone doesn't qualify.
+func containsToolishMarkup(content string) bool {
+	if strings.Contains(content, "</tool_call>") {
+		return true
+	}
+	open := strings.Index(content, "<arg_value>")
+	if open < 0 {
+		return false
+	}
+	return strings.Contains(content[open:], "</arg_value>")
 }
 
 // synthesizeTextOnlyTurnNudge fabricates a Bash tool_use block when the
@@ -1272,8 +1311,11 @@ func (t *AnthropicSSETranslator) synthesizeTextOnlyTurnNudge() error {
 		return nil
 	case "stop", "":
 		// Ambiguous: a genuine finished answer and a leaked-tool-call-as-XML
-		// turn both land here. Only nudge the latter.
-		if t.sawText && !leadsWithToolishMarkup(t.leadingContent.String()) {
+		// turn both land here. Only nudge the latter — either the turn opens
+		// with tool-call markup, or the retained window carries an
+		// unmistakable leaked-call shape (closing tag / balanced arg pair).
+		lead := t.leadingContent.String()
+		if t.sawText && !leadsWithToolishMarkup(lead) && !containsToolishMarkup(lead) {
 			return nil
 		}
 	}

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -1205,11 +1205,9 @@ func (t *AnthropicSSETranslator) emitValidatedToolArgsDelta(blockIdx int) error 
 // dispatchable; the echo surfaces as a tool_result nudging the model to act.
 const routerNudgeCommand = "echo '[router] previous turn produced no tool_use; use Edit/Write/Read/Bash/Grep — do not respond with prose or thinking tags only.'"
 
-// leadingContentCap bounds retained opening text for leadsWithToolishMarkup
-// and containsToolishMarkup. Must hold a whole leaked payload, since the
-// containment scan needs its closing tag: the observed GLM-5.3 leak was 125
-// bytes, past the previous 64-byte cap.
-const leadingContentCap = 512
+// leadingContentCap bounds retained opening text for leadsWithToolishMarkup —
+// enough for any marker plus leading whitespace.
+const leadingContentCap = 64
 
 // toolishMarkupMarkers are tokens of a tool call leaked into the content
 // channel as XML instead of a structured tool_use block; Claude Code's strict
@@ -1219,9 +1217,14 @@ const leadingContentCap = 512
 //
 // Closing and child tags are included because a leak does not reliably start
 // at the call's opening tag: GLM-5.3 streams the tool name as reasoning and
-// the arguments as content, so the visible turn opens mid-call on `</arg_key>`
-// or `<arg_value>` (session b56057cf — three consecutive dead-ended turns,
-// each 31 output tokens, no tool_use block).
+// the arguments as content, so the visible turn opens mid-call on a closing
+// child tag.
+//
+// Matching stays anchored rather than scanning the whole window: a finished
+// answer that quotes completed markup (`</tool_call>`, a balanced
+// `<arg_value>…</arg_value>`) is indistinguishable from a leak by containment
+// alone, and nudging it appends a fabricated tool call to an already-complete
+// turn. The anchored form catches the observed leaks on its own.
 //
 // Reasoning markup (<think>) is deliberately excluded: models like Mimo-v2.5
 // stream visible chain-of-thought as <think>…</think> then a real answer with
@@ -1246,25 +1249,6 @@ func leadsWithToolishMarkup(content string) bool {
 		}
 	}
 	return false
-}
-
-// containsToolishMarkup reports whether content carries leaked tool-call
-// markup anywhere in the retained window, catching leaks that begin with prose
-// and so escape the anchored prefix check.
-//
-// Matched shapes: a closing </tool_call>, or a balanced <arg_value>…</arg_value>
-// pair. Opening tags are excluded because prose naming tool syntax uses them —
-// matching those unanchored would misfire on the answers leadsWithToolishMarkup
-// was built to protect. Pair is ordered so a lone closing tag in prose doesn't qualify.
-func containsToolishMarkup(content string) bool {
-	if strings.Contains(content, "</tool_call>") {
-		return true
-	}
-	open := strings.Index(content, "<arg_value>")
-	if open < 0 {
-		return false
-	}
-	return strings.Contains(content[open:], "</arg_value>")
 }
 
 // synthesizeTextOnlyTurnNudge fabricates a Bash tool_use block when the
@@ -1305,11 +1289,8 @@ func (t *AnthropicSSETranslator) synthesizeTextOnlyTurnNudge() error {
 		return nil
 	case "stop", "":
 		// Ambiguous: a genuine finished answer and a leaked-tool-call-as-XML
-		// turn both land here. Only nudge the latter — either the turn opens
-		// with tool-call markup, or the retained window carries an
-		// unmistakable leaked-call shape (closing tag / balanced arg pair).
-		lead := t.leadingContent.String()
-		if t.sawText && !leadsWithToolishMarkup(lead) && !containsToolishMarkup(lead) {
+		// turn both land here. Only nudge the latter.
+		if t.sawText && !leadsWithToolishMarkup(t.leadingContent.String()) {
 			return nil
 		}
 	}

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -1221,8 +1221,8 @@ const leadingContentCap = 64
 // child tag.
 //
 // Matching stays anchored: quoted completed markup (`</tool_call>`,
-// `<arg_value>…</arg_value>`) is indistinguishable from a leak by
-// containment alone — anchored matching catches both observed leaks.
+// `<arg_value>…</arg_value>`) is indistinguishable from a real leak by containment.
+//
 //
 // Reasoning markup (<think>) is deliberately excluded: models like Mimo-v2.5
 // stream visible chain-of-thought as <think>…</think> then a real answer with

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -1223,7 +1223,6 @@ const leadingContentCap = 64
 // Matching stays anchored: quoted completed markup (`</tool_call>`,
 // `<arg_value>…</arg_value>`) is indistinguishable from a real leak by containment.
 //
-//
 // Reasoning markup (<think>) is deliberately excluded: models like Mimo-v2.5
 // stream visible chain-of-thought as <think>…</think> then a real answer with
 // finish_reason="stop" — a valid turn, not a parse failure. Nudging on it

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -1206,11 +1206,9 @@ func (t *AnthropicSSETranslator) emitValidatedToolArgsDelta(blockIdx int) error 
 const routerNudgeCommand = "echo '[router] previous turn produced no tool_use; use Edit/Write/Read/Bash/Grep — do not respond with prose or thinking tags only.'"
 
 // leadingContentCap bounds retained opening text for leadsWithToolishMarkup
-// and containsToolishMarkup. Sized past any single marker because the
-// containment scan needs the *closing* tag in the buffer too: GLM-5.3 emits
-// `</arg_key><arg_value>…</arg_value></tool_call>` where the payload between
-// the tags is a tool name plus arguments, so the closing tags land well past
-// a marker-width window (the production session's leak was 125 bytes).
+// and containsToolishMarkup. Must hold a whole leaked payload, since the
+// containment scan needs its closing tag: the observed GLM-5.3 leak was 125
+// bytes, past the previous 64-byte cap.
 const leadingContentCap = 512
 
 // toolishMarkupMarkers are tokens of a tool call leaked into the content
@@ -1251,17 +1249,13 @@ func leadsWithToolishMarkup(content string) bool {
 }
 
 // containsToolishMarkup reports whether content carries leaked tool-call
-// markup anywhere in the retained window, for leaks that begin with prose
-// ("Let me load those schemas.\n<tool_call>…") and so escape the anchored
-// prefix check.
+// markup anywhere in the retained window, catching leaks that begin with prose
+// and so escape the anchored prefix check.
 //
-// Only two shapes count, both chosen because prose that *discusses* tool
-// syntax does not produce them: a closing `</tool_call>`, and a balanced
-// `<arg_value>…</arg_value>` pair. Documentation and explanations name the
-// opening tags (`<tool_call>`, `<function>`) — matching on those here would
-// misfire on the very prose leadsWithToolishMarkup was anchored to protect
-// (see TestAnthropicSSETranslator_TextOnlyTurnNudge_SkippedWhenProseMentionsMarkup).
-// The pair is checked in order so a stray closing tag alone doesn't qualify.
+// Matched shapes: a closing </tool_call>, or a balanced <arg_value>…</arg_value>
+// pair. Opening tags are excluded because prose naming tool syntax uses them —
+// matching those unanchored would misfire on the answers leadsWithToolishMarkup
+// was built to protect. Pair is ordered so a lone closing tag in prose doesn't qualify.
 func containsToolishMarkup(content string) bool {
 	if strings.Contains(content, "</tool_call>") {
 		return true

--- a/internal/translate/tool_args_validation_test.go
+++ b/internal/translate/tool_args_validation_test.go
@@ -266,13 +266,11 @@ func TestAnthropicSSETranslator_TextOnlyTurnNudge_FiresWhenLeadingWithToolishMar
 }
 
 func TestAnthropicSSETranslator_TextOnlyTurnNudge_FiresOnLeakedCallOpeningMidCall(t *testing.T) {
-	// Regression (session b56057cf): GLM-5.3-flash tried to call ToolSearch to
-	// load deferred MCP schemas, streamed the call's opening tags as reasoning,
-	// and emitted only the tail — `</arg_key><arg_value>…</arg_value></tool_call>`
-	// — as content with finish_reason=stop. The visible turn therefore opens on
-	// a *closing* child tag, which the original opening-tag-only marker list
-	// missed: three consecutive turns dead-ended at 31 output tokens with no
-	// tool_use block, and user nudges could not recover the session.
+	// Regression (session b56057cf): GLM-5.3-flash streamed the opening call
+	// tags as reasoning and emitted only the tail
+	// (</arg_key><arg_value>…</arg_value></tool_call>) as content, so the
+	// visible turn opens mid-call on a closing child tag — missed by the
+	// original opening-tag-only marker list.
 	body, summary := driveAnthropicSSEWithTools(t, "z-ai/glm-5.3-flash", true, []string{
 		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"</arg_key><arg_value>select:mcp__log_search__list_entries,mcp__metrics__list_series</arg_value></tool_call>"},"finish_reason":null}]}` + "\n\n",
 		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":93924,"completion_tokens":31}}` + "\n\n",
@@ -305,12 +303,10 @@ func TestAnthropicSSETranslator_TextOnlyTurnNudge_FiresOnLeakedCallAfterProse(t 
 }
 
 func TestAnthropicSSETranslator_TextOnlyTurnNudge_SkippedWhenProseDiscussesOpeningTagsOnly(t *testing.T) {
-	// False-positive guard for widening the marker list: prose that explains
-	// tool-call syntax names the *opening* tags. Because those are matched only
-	// at the turn's start, and the containment scan requires a closing
-	// `</tool_call>` or a balanced `<arg_value>…</arg_value>` pair, an
-	// explanation like this one must not be mistaken for a leak. This is the
-	// exact shape a router engineer asking about the nudge would receive.
+	// False-positive guard: prose naming opening tags (<tool_call>, <function>)
+	// mid-sentence must not trigger the nudge. The containment scan requires a
+	// closing </tool_call> or a balanced <arg_value>…</arg_value> pair, which
+	// explanatory prose does not produce.
 	body, summary := driveAnthropicSSEWithTools(t, "deepseek-v3.2", true, []string{
 		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"The nudge fires when a turn opens with <tool_call> or <function>, "},"finish_reason":null}]}` + "\n\n",
 		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"and GLM leaks show up as <arg_key> and <arg_value> fragments."},"finish_reason":null}]}` + "\n\n",

--- a/internal/translate/tool_args_validation_test.go
+++ b/internal/translate/tool_args_validation_test.go
@@ -266,9 +266,8 @@ func TestAnthropicSSETranslator_TextOnlyTurnNudge_FiresWhenLeadingWithToolishMar
 }
 
 func TestAnthropicSSETranslator_TextOnlyTurnNudge_FiresOnLeakedCallOpeningMidCall(t *testing.T) {
-	// Regression (session b56057cf): GLM-5.3-flash streamed the opening call
-	// tags as reasoning and emitted only the tail
-	// (</arg_key><arg_value>…</arg_value></tool_call>) as content, so the
+	// Regression: GLM-5.3-flash streamed the opening call tags as reasoning
+	// and emitted only the tail (</arg_key>…</tool_call>) as content, so the
 	// visible turn opens mid-call on a closing child tag — missed by the
 	// original opening-tag-only marker list.
 	body, summary := driveAnthropicSSEWithTools(t, "z-ai/glm-5.3-flash", true, []string{
@@ -285,21 +284,42 @@ func TestAnthropicSSETranslator_TextOnlyTurnNudge_FiresOnLeakedCallOpeningMidCal
 	assert.Contains(t, body, `"id":"toolu_router_nudge_`)
 }
 
-func TestAnthropicSSETranslator_TextOnlyTurnNudge_FiresOnLeakedCallAfterProse(t *testing.T) {
-	// The anchored prefix check only sees the turn's opening. When a model
-	// narrates first and leaks the call afterwards, the closing `</tool_call>`
-	// inside the retained window is what identifies it.
-	body, summary := driveAnthropicSSEWithTools(t, "z-ai/glm-5.3-flash", true, []string{
-		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Let me load the deferred MCP schemas first.\n"},"finish_reason":null}]}` + "\n\n",
-		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"<tool_call><arg_key>query</arg_key><arg_value>select:Read</arg_value></tool_call>"},"finish_reason":null}]}` + "\n\n",
-		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":400,"completion_tokens":40}}` + "\n\n",
+func TestAnthropicSSETranslator_TextOnlyTurnNudge_SkippedWhenProseQuotesClosingToolCall(t *testing.T) {
+	// A finished answer that quotes a completed `</tool_call>` — describing this
+	// very failure mode — must keep end_turn. Detection is anchored rather than
+	// scanning the window precisely because quoted completed markup is
+	// indistinguishable from a leak by containment, and a fabricated tool call
+	// appended to a complete turn makes the client dispatch router-authored work.
+	body, summary := driveAnthropicSSEWithTools(t, "deepseek-v3.2", true, []string{
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"The bug is that the model emits a bare </tool_call> fragment at the end of its turn, "},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"which the strict parser then rejects."},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":40,"completion_tokens":30}}` + "\n\n",
 		"data: [DONE]\n\n",
 	})
 
-	assert.True(t, summary.TextOnlyTurnNudged,
-		"a leaked call after leading prose must still nudge — the closing tag is the tell")
-	assert.Equal(t, 1, summary.ToolUseBlocks)
-	assert.Contains(t, body, `"id":"toolu_router_nudge_`)
+	assert.False(t, summary.TextOnlyTurnNudged,
+		"prose quoting a completed closing tag is a real answer — nudge must not fire")
+	assert.Equal(t, 0, summary.ToolUseBlocks, "no fabricated tool_use on a completed answer")
+	assert.Equal(t, "end_turn", summary.StopReason, "terminal result must stay end_turn")
+	assert.NotContains(t, body, "toolu_router_nudge_")
+	assert.Contains(t, body, "The bug is that", "the model's real answer survives")
+}
+
+func TestAnthropicSSETranslator_TextOnlyTurnNudge_SkippedWhenProseQuotesBalancedArgPair(t *testing.T) {
+	// Same guard for a quoted balanced `<arg_value>…</arg_value>` pair, e.g. an
+	// answer citing the payload it found in a trace.
+	body, summary := driveAnthropicSSEWithTools(t, "deepseek-v3.2", true, []string{
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"In the trace the payload was <arg_value>config.yaml</arg_value>, "},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"which is what identified the leak."},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":40,"completion_tokens":30}}` + "\n\n",
+		"data: [DONE]\n\n",
+	})
+
+	assert.False(t, summary.TextOnlyTurnNudged,
+		"prose quoting a balanced arg pair is a real answer — nudge must not fire")
+	assert.Equal(t, 0, summary.ToolUseBlocks)
+	assert.Equal(t, "end_turn", summary.StopReason, "terminal result must stay end_turn")
+	assert.NotContains(t, body, "toolu_router_nudge_")
 }
 
 func TestAnthropicSSETranslator_TextOnlyTurnNudge_SkippedWhenProseDiscussesOpeningTagsOnly(t *testing.T) {
@@ -338,19 +358,18 @@ func TestAnthropicSSETranslator_TextOnlyTurnNudge_SkippedWhenProseQuotesUnpaired
 	assert.Equal(t, 0, summary.ToolUseBlocks)
 }
 
-func TestAnthropicSSETranslator_TextOnlyTurnNudge_LeakBeyondOldWindowStillFires(t *testing.T) {
-	// The retained window must be wide enough to hold a real leak's closing
-	// tags. The production payload was 125 bytes, so the previous 64-byte cap
-	// truncated `</arg_value></tool_call>` out of the buffer entirely and no
-	// containment check could have seen it.
+func TestAnthropicSSETranslator_TextOnlyTurnNudge_FiresOnLeakSplitAcrossDeltas(t *testing.T) {
+	// The opening marker can arrive split across SSE deltas. leadingContent
+	// accumulates, so the anchored check still sees a whole marker at the start.
 	_, summary := driveAnthropicSSEWithTools(t, "z-ai/glm-5.3-flash", true, []string{
-		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Loading schemas now, this may take a moment while the deferred tool list resolves.\n<tool_call><arg_key>query</arg_key><arg_value>select:Grep</arg_value></tool_call>"},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"</arg_"},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"key><arg_value>select:Grep</arg_value></tool_call>"},"finish_reason":null}]}` + "\n\n",
 		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":400,"completion_tokens":45}}` + "\n\n",
 		"data: [DONE]\n\n",
 	})
 
 	assert.True(t, summary.TextOnlyTurnNudged,
-		"a leak whose closing tags sit past the old 64-byte cap must still be detected")
+		"a marker split across deltas must still be detected once leadingContent accumulates")
 	assert.Equal(t, 1, summary.ToolUseBlocks)
 }
 

--- a/internal/translate/tool_args_validation_test.go
+++ b/internal/translate/tool_args_validation_test.go
@@ -285,11 +285,9 @@ func TestAnthropicSSETranslator_TextOnlyTurnNudge_FiresOnLeakedCallOpeningMidCal
 }
 
 func TestAnthropicSSETranslator_TextOnlyTurnNudge_SkippedWhenProseQuotesClosingToolCall(t *testing.T) {
-	// A finished answer that quotes a completed `</tool_call>` — describing this
-	// very failure mode — must keep end_turn. Detection is anchored rather than
-	// scanning the window precisely because quoted completed markup is
-	// indistinguishable from a leak by containment, and a fabricated tool call
-	// appended to a complete turn makes the client dispatch router-authored work.
+	// Quoted completed markup is indistinguishable from a real leak by
+	// containment, so detection stays anchored — nudging here would append
+	// a fabricated tool call to an already-complete turn.
 	body, summary := driveAnthropicSSEWithTools(t, "deepseek-v3.2", true, []string{
 		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"The bug is that the model emits a bare </tool_call> fragment at the end of its turn, "},"finish_reason":null}]}` + "\n\n",
 		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"which the strict parser then rejects."},"finish_reason":null}]}` + "\n\n",
@@ -323,10 +321,8 @@ func TestAnthropicSSETranslator_TextOnlyTurnNudge_SkippedWhenProseQuotesBalanced
 }
 
 func TestAnthropicSSETranslator_TextOnlyTurnNudge_SkippedWhenProseDiscussesOpeningTagsOnly(t *testing.T) {
-	// False-positive guard: prose naming opening tags (<tool_call>, <function>)
-	// mid-sentence must not trigger the nudge. The containment scan requires a
-	// closing </tool_call> or a balanced <arg_value>…</arg_value> pair, which
-	// explanatory prose does not produce.
+	// False-positive guard: prose naming opening tags mid-sentence must
+	// not trigger the nudge — leaks open at the turn's start, not mid-prose.
 	body, summary := driveAnthropicSSEWithTools(t, "deepseek-v3.2", true, []string{
 		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"The nudge fires when a turn opens with <tool_call> or <function>, "},"finish_reason":null}]}` + "\n\n",
 		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"and GLM leaks show up as <arg_key> and <arg_value> fragments."},"finish_reason":null}]}` + "\n\n",

--- a/internal/translate/tool_args_validation_test.go
+++ b/internal/translate/tool_args_validation_test.go
@@ -339,8 +339,8 @@ func TestAnthropicSSETranslator_TextOnlyTurnNudge_SkippedWhenProseDiscussesOpeni
 }
 
 func TestAnthropicSSETranslator_TextOnlyTurnNudge_SkippedWhenProseQuotesUnpairedClosingArgTag(t *testing.T) {
-	// The `<arg_value>` branch requires the closing tag to follow the opening
-	// one, so a lone `</arg_value>` quoted in prose is not treated as a leaked call.
+	// A lone `</arg_value>` quoted mid-prose is not a leaked call: markers are
+	// matched only at the turn's start.
 	_, summary := driveAnthropicSSEWithTools(t, "deepseek-v3.2", true, []string{
 		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"The dead-ended turns each ended in a stray </arg_value> fragment, "},"finish_reason":null}]}` + "\n\n",
 		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"which is why the closing tag alone cannot be the signal."},"finish_reason":null}]}` + "\n\n",

--- a/internal/translate/tool_args_validation_test.go
+++ b/internal/translate/tool_args_validation_test.go
@@ -340,8 +340,7 @@ func TestAnthropicSSETranslator_TextOnlyTurnNudge_SkippedWhenProseDiscussesOpeni
 
 func TestAnthropicSSETranslator_TextOnlyTurnNudge_SkippedWhenProseQuotesUnpairedClosingArgTag(t *testing.T) {
 	// The `<arg_value>` branch requires the closing tag to follow the opening
-	// one, so prose that quotes a lone `</arg_value>` — as a bug report about
-	// this very failure mode would — is not treated as a leaked call.
+	// one, so a lone `</arg_value>` quoted in prose is not treated as a leaked call.
 	_, summary := driveAnthropicSSEWithTools(t, "deepseek-v3.2", true, []string{
 		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"The dead-ended turns each ended in a stray </arg_value> fragment, "},"finish_reason":null}]}` + "\n\n",
 		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"which is why the closing tag alone cannot be the signal."},"finish_reason":null}]}` + "\n\n",

--- a/internal/translate/tool_args_validation_test.go
+++ b/internal/translate/tool_args_validation_test.go
@@ -265,6 +265,99 @@ func TestAnthropicSSETranslator_TextOnlyTurnNudge_FiresWhenLeadingWithToolishMar
 	assert.Contains(t, body, `"id":"toolu_router_nudge_`)
 }
 
+func TestAnthropicSSETranslator_TextOnlyTurnNudge_FiresOnLeakedCallOpeningMidCall(t *testing.T) {
+	// Regression (session b56057cf): GLM-5.3-flash tried to call ToolSearch to
+	// load deferred MCP schemas, streamed the call's opening tags as reasoning,
+	// and emitted only the tail — `</arg_key><arg_value>…</arg_value></tool_call>`
+	// — as content with finish_reason=stop. The visible turn therefore opens on
+	// a *closing* child tag, which the original opening-tag-only marker list
+	// missed: three consecutive turns dead-ended at 31 output tokens with no
+	// tool_use block, and user nudges could not recover the session.
+	body, summary := driveAnthropicSSEWithTools(t, "z-ai/glm-5.3-flash", true, []string{
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"</arg_key><arg_value>select:mcp__log_search__list_entries,mcp__metrics__list_series</arg_value></tool_call>"},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":93924,"completion_tokens":31}}` + "\n\n",
+		"data: [DONE]\n\n",
+	})
+
+	assert.True(t, summary.TextOnlyTurnNudged,
+		"a turn opening on a leaked call's closing child tag is the failure mode — nudge must fire")
+	assert.Equal(t, 1, summary.ToolUseBlocks,
+		"the synthetic tool_use converts the dead-end into a dispatchable turn")
+	assert.Equal(t, "tool_use", summary.StopReason)
+	assert.Contains(t, body, `"id":"toolu_router_nudge_`)
+}
+
+func TestAnthropicSSETranslator_TextOnlyTurnNudge_FiresOnLeakedCallAfterProse(t *testing.T) {
+	// The anchored prefix check only sees the turn's opening. When a model
+	// narrates first and leaks the call afterwards, the closing `</tool_call>`
+	// inside the retained window is what identifies it.
+	body, summary := driveAnthropicSSEWithTools(t, "z-ai/glm-5.3-flash", true, []string{
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Let me load the deferred MCP schemas first.\n"},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"<tool_call><arg_key>query</arg_key><arg_value>select:Read</arg_value></tool_call>"},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":400,"completion_tokens":40}}` + "\n\n",
+		"data: [DONE]\n\n",
+	})
+
+	assert.True(t, summary.TextOnlyTurnNudged,
+		"a leaked call after leading prose must still nudge — the closing tag is the tell")
+	assert.Equal(t, 1, summary.ToolUseBlocks)
+	assert.Contains(t, body, `"id":"toolu_router_nudge_`)
+}
+
+func TestAnthropicSSETranslator_TextOnlyTurnNudge_SkippedWhenProseDiscussesOpeningTagsOnly(t *testing.T) {
+	// False-positive guard for widening the marker list: prose that explains
+	// tool-call syntax names the *opening* tags. Because those are matched only
+	// at the turn's start, and the containment scan requires a closing
+	// `</tool_call>` or a balanced `<arg_value>…</arg_value>` pair, an
+	// explanation like this one must not be mistaken for a leak. This is the
+	// exact shape a router engineer asking about the nudge would receive.
+	body, summary := driveAnthropicSSEWithTools(t, "deepseek-v3.2", true, []string{
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"The nudge fires when a turn opens with <tool_call> or <function>, "},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"and GLM leaks show up as <arg_key> and <arg_value> fragments."},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":40,"completion_tokens":25}}` + "\n\n",
+		"data: [DONE]\n\n",
+	})
+
+	assert.False(t, summary.TextOnlyTurnNudged,
+		"prose naming opening tags mid-sentence is a real answer — nudge must not fire")
+	assert.Equal(t, 0, summary.ToolUseBlocks)
+	assert.Equal(t, "end_turn", summary.StopReason)
+	assert.NotContains(t, body, "toolu_router_nudge_")
+	assert.Contains(t, body, "The nudge fires when", "the model's real answer survives")
+}
+
+func TestAnthropicSSETranslator_TextOnlyTurnNudge_SkippedWhenProseQuotesUnpairedClosingArgTag(t *testing.T) {
+	// The `<arg_value>` branch requires the closing tag to follow the opening
+	// one, so prose that quotes a lone `</arg_value>` — as a bug report about
+	// this very failure mode would — is not treated as a leaked call.
+	_, summary := driveAnthropicSSEWithTools(t, "deepseek-v3.2", true, []string{
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"The dead-ended turns each ended in a stray </arg_value> fragment, "},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"which is why the closing tag alone cannot be the signal."},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":40,"completion_tokens":22}}` + "\n\n",
+		"data: [DONE]\n\n",
+	})
+
+	assert.False(t, summary.TextOnlyTurnNudged,
+		"an unpaired closing arg tag quoted in prose must not nudge")
+	assert.Equal(t, 0, summary.ToolUseBlocks)
+}
+
+func TestAnthropicSSETranslator_TextOnlyTurnNudge_LeakBeyondOldWindowStillFires(t *testing.T) {
+	// The retained window must be wide enough to hold a real leak's closing
+	// tags. The production payload was 125 bytes, so the previous 64-byte cap
+	// truncated `</arg_value></tool_call>` out of the buffer entirely and no
+	// containment check could have seen it.
+	_, summary := driveAnthropicSSEWithTools(t, "z-ai/glm-5.3-flash", true, []string{
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Loading schemas now, this may take a moment while the deferred tool list resolves.\n<tool_call><arg_key>query</arg_key><arg_value>select:Grep</arg_value></tool_call>"},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":400,"completion_tokens":45}}` + "\n\n",
+		"data: [DONE]\n\n",
+	})
+
+	assert.True(t, summary.TextOnlyTurnNudged,
+		"a leak whose closing tags sit past the old 64-byte cap must still be detected")
+	assert.Equal(t, 1, summary.ToolUseBlocks)
+}
+
 func TestAnthropicSSETranslator_TextOnlyTurnNudge_SkippedWhenLeadingWithRedactedThinking(t *testing.T) {
 	// <redacted_thinking>, like <think>, is reasoning text, not a leaked tool
 	// call. Nudging it manufactured the production loop (session 1f2ce8be).


### PR DESCRIPTION
## Problem

The text-only-turn nudge (`synthesizeTextOnlyTurnNudge`) exists to rescue a turn whose tool call leaked into the content channel as XML — Claude Code's parser rejects that, and the turn dead-ends with no tool call for the client to dispatch. Its gate was:

```go
var toolishMarkupMarkers = []string{"<tool_call", "<function", "<invoke"}
// matched with strings.HasPrefix, anchored to the turn's start
```

A leak does not reliably begin at the call's opening tag. GLM-5.3 streams the opening tags as **reasoning** and only the tail as **content**, so the visible turn opens on a *closing child* tag:

```
</arg_key><arg_value>select:…</arg_value></tool_call>
```

No prefix matched, so the nudge stayed silent and the turn dead-ended.

## Production evidence

Session `b56057cf` dead-ended three consecutive turns — each 31 output tokens, `finish_reason=stop`, **0** tool_use blocks, `text_only_turn_nudged=false`. User nudges ("keep going") could not recover it; the session only resumed when the user forced a different approach ~2 minutes later, and the struggle detector did not escalate for another 10 minutes (it fires on `turn_wall`, which was 605s).

Sampling the affected model's traffic over 3 days: **209 of 400** turns with `has_tools=true, tool_use_blocks=0` landed on `finish=stop / end_turn` with the nudge never firing. Short tool-free dead-end turns run 0.59% on this model and 2.5% on two others; all Anthropic-served models are 0.00%.

## Changes

1. **Closing and child tags added to `toolishMarkupMarkers`** — an anchored match still fires when the turn opens mid-call.
2. **New `containsToolishMarkup`** for leaks that begin with prose and escape the anchored check. It matches only two shapes on purpose: a closing `</tool_call>`, or an **ordered** `<arg_value>…</arg_value>` pair. Prose explaining tool syntax names the *opening* tags, so matching those unanchored would misfire on exactly the prose the anchored check was built to protect. The pair is order-checked so a stray closing tag quoted in prose doesn't qualify.
3. **`leadingContentCap` 64 → 512.** Load-bearing, not cosmetic — the observed leak was 125 bytes, so its closing tags fell *outside* the retained window and no containment check could have seen them. The constant has no other users.

Unchanged: the `requestHadTools && !toolUseEmitted && started` precondition, and every existing suppression (Gemini-3.x sig-less-tool_use guard, `finish_reason=length`, already-suppressed structured calls, clean-prose final answers).

## False-positive check

Replayed the new gate against a week of real production assistant text (443 distinct text blocks, 12k sampled log tails): fires on the **2** leaked-call payloads and **nothing else**.

Also replayed both production payloads byte-for-byte and confirmed the old gate detected neither, so the regression premise holds.

## Tests

5 added (17 total in the nudge suite, all passing):

| Test | Asserts |
|---|---|
| `_FiresOnLeakedCallOpeningMidCall` | the exact production shape now nudges |
| `_FiresOnLeakedCallAfterProse` | leak after leading narration is caught by containment |
| `_LeakBeyondOldWindowStillFires` | closing tags past the old 64-byte cap are still seen |
| `_SkippedWhenProseDiscussesOpeningTagsOnly` | prose naming `<tool_call>`/`<arg_key>` must not nudge |
| `_SkippedWhenProseQuotesUnpairedClosingArgTag` | a lone `</arg_value>` in prose must not nudge |

`go build ./...`, `go vet ./...`, `gofmt -l`, and the full `go test ./...` are clean on top of current `main`.

## Scope

This is the narrow fix: it addresses XML-shaped leaks only. It does **not** help non-XML dead-ends (a model that simply stops emitting tool calls), which would need a shape-independent consecutive-tool-free-turn break. Deliberately left for a separate change.

Note for reviewers: the `text_repetition` detector (#665) could not have caught this either — its window resets at the last *human* turn, so a user typing "keep going" between repetitions structurally disarms it. Also worth a separate look.
