### PR TITLE
fix: fail closed for empty subscription model lists

### DIFF
--- a/internal/proxy/allowlist_internal_test.go
+++ b/internal/proxy/allowlist_internal_test.go
@@ -50,6 +50,14 @@ func TestAllowedModelsForRequest_EmptyConditionalIntersectionFailsClosed(t *test
 	assert.Empty(t, allowedModelsForRequest(ctx))
 }
 
+func TestAllowedModelsForRequest_EmptyConfiguredConditionalListFailsClosed(t *testing.T) {
+	ctx := context.WithValue(context.Background(), InstallationSubscriptionConditionalModelsContextKey{}, []string{})
+
+	assert.True(t, subscriptionConditionalModelsConfigured(ctx))
+	assert.NotNil(t, allowedModelsForRequest(ctx))
+	assert.Empty(t, allowedModelsForRequest(ctx))
+}
+
 // The allowlist is enforced by desugaring into the exclusion set: every
 // routable model absent from a non-empty allowlist must come back excluded.
 func TestExcludedModelsForRequest_AllowlistExcludesTheComplement(t *testing.T) {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -774,22 +774,30 @@ func subscriptionConditionalModelsForRequest(ctx context.Context) []string {
 	return out
 }
 
+func subscriptionConditionalModelsConfigured(ctx context.Context) bool {
+	return ctx.Value(InstallationSubscriptionConditionalModelsContextKey{}) != nil
+}
+
 // allowedModelsForRequest returns the effective positive model allowlist as a set,
 // intersecting the installation list with the selected subscription-state list.
 // Nil = no policy; non-nil empty = fails closed (intentional empty intersection).
 func allowedModelsForRequest(ctx context.Context) map[string]struct{} {
 	base := installationAllowedModelsFromContext(ctx)
 	conditional := subscriptionConditionalModelsForRequest(ctx)
-	if len(base) == 0 && len(conditional) == 0 {
+	conditionalConfigured := subscriptionConditionalModelsConfigured(ctx)
+	if len(base) == 0 && !conditionalConfigured {
 		return nil
 	}
-	if len(base) == 0 {
-		base = conditional
-		conditional = nil
-	}
-	if len(conditional) == 0 {
+	if !conditionalConfigured {
 		out := make(map[string]struct{}, len(base))
 		for _, m := range base {
+			out[m] = struct{}{}
+		}
+		return out
+	}
+	if len(base) == 0 {
+		out := make(map[string]struct{}, len(conditional))
+		for _, m := range conditional {
 			out[m] = struct{}{}
 		}
 		return out
@@ -3240,7 +3248,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// bypass the exhausted-sub 402 guard and the depleted-credits warning below.
 	// Subscription-state conditional model lists are likewise absent from the
 	// cache key, so never cache a request after one has been selected.
-	cacheEligible := s.semanticCacheAllowed(ctx) && s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !compactionHandoverRan && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0 && len(subscriptionConditionalModelsForRequest(ctx)) == 0
+	cacheEligible := s.semanticCacheAllowed(ctx) && s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !compactionHandoverRan && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0 && !subscriptionConditionalModelsConfigured(ctx)
 	if cacheEligible {
 		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatAnthropic, decision.Metadata.Embedding, decision.Metadata.ClusterIDs, decision.Metadata.ClusterRouterVersion, decision.Metadata.EffectiveKnobsHash); hit {
 			s.writeCachedResponse(w, resp, decision)
@@ -5704,7 +5712,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	// See the ProxyMessages cache-eligibility note: subsidized and subscription-state-conditional
 	// requests bypass the semantic cache (key doesn't capture headroom-dependent model choice).
-	cacheEligible := s.semanticCacheAllowed(ctx) && s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !responsesPassthrough && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0 && len(subscriptionConditionalModelsForRequest(ctx)) == 0
+	cacheEligible := s.semanticCacheAllowed(ctx) && s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !responsesPassthrough && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0 && !subscriptionConditionalModelsConfigured(ctx)
 	if cacheEligible {
 		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatOpenAI, decision.Metadata.Embedding, decision.Metadata.ClusterIDs, decision.Metadata.ClusterRouterVersion, decision.Metadata.EffectiveKnobsHash); hit {
 			s.writeCachedResponse(w, resp, decision)

--- a/internal/proxy/service_cache_test.go
+++ b/internal/proxy/service_cache_test.go
@@ -133,6 +133,31 @@ func TestService_Cache_ConditionalSubscriptionModelsBypass(t *testing.T) {
 	assert.Empty(t, rec2.Header().Get(proxy.HeaderRouterCache))
 }
 
+func TestService_Cache_EmptyConfiguredSubscriptionModelsBypass(t *testing.T) {
+	emb := embeddingFixture(12)
+	provider := &fakeProvider{
+		proxyResponse: func(w http.ResponseWriter) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"conditional-empty"}`))
+		},
+	}
+	fr := &fakeRouter{decision: decisionWithEmbedding(emb, []int{0, 1})}
+	c := cache.New(cache.DefaultConfig())
+	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderAnthropic: provider}, nil, false, c, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil)
+
+	ctx := proxyContextWithExternalID(t, "tenant-conditional-empty")
+	ctx = context.WithValue(ctx, proxy.InstallationSubscriptionConditionalModelsContextKey{}, []string{})
+	body := anthropicBody("conditional empty cache", false)
+
+	rec1 := httptest.NewRecorder()
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec1, httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))))
+	rec2 := httptest.NewRecorder()
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec2, httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))))
+
+	assert.Len(t, provider.proxyBodies, 2, "empty configured subscription-state requests must not replay a cached response")
+	assert.Empty(t, rec2.Header().Get(proxy.HeaderRouterCache))
+}
+
 func TestService_Cache_StreamingBypasses(t *testing.T) {
 	emb := embeddingFixture(2)
 	provider := &fakeProvider{

--- a/internal/proxy/subscription_conditional_models_internal_test.go
+++ b/internal/proxy/subscription_conditional_models_internal_test.go
@@ -58,6 +58,35 @@ func TestWithSubscriptionConditionalModels_SelectsInactiveListWhenExhausted(t *t
 	assert.Equal(t, []string{"inactive-model"}, subscriptionConditionalModelsForRequest(ctx))
 }
 
+func TestWithSubscriptionConditionalModels_SelectsEmptyInactiveListWhenExhausted(t *testing.T) {
+	svc := &Service{usageObserver: conditionalModelsObserver(usage.Snapshot{
+		Secondary: usage.Window{UsedPercent: 1.0, WindowMinutes: 10080},
+	})}
+
+	ctx := svc.withSubscriptionConditionalModels(
+		conditionalModelsContext([]string{"active-model"}, []string{}),
+		http.Header{},
+	)
+
+	assert.Empty(t, subscriptionConditionalModelsForRequest(ctx))
+	assert.True(t, subscriptionConditionalModelsConfigured(ctx))
+	excluded := (&Service{availableModels: map[string]struct{}{"active-model": {}}}).excludedModelsForRequest(ctx)
+	assert.Contains(t, excluded, "active-model")
+}
+
+func TestWithSubscriptionConditionalModels_BothEmptyLeavesFeatureOff(t *testing.T) {
+	svc := &Service{usageObserver: conditionalModelsObserver(usage.Snapshot{
+		Secondary: usage.Window{UsedPercent: 1.0, WindowMinutes: 10080},
+	})}
+
+	ctx := svc.withSubscriptionConditionalModels(
+		conditionalModelsContext([]string{}, []string{}),
+		http.Header{},
+	)
+
+	assert.False(t, subscriptionConditionalModelsConfigured(ctx))
+}
+
 func TestWithSubscriptionConditionalModels_ColdStartUsesActiveList(t *testing.T) {
 	observer := usage.NewObserver([]byte("conditional-models-salt"), time.Minute, time.Now)
 	svc := &Service{usageObserver: observer}

--- a/internal/proxy/subsidy.go
+++ b/internal/proxy/subsidy.go
@@ -226,7 +226,8 @@ func (s *Service) withUsageObserver(ctx context.Context, headers http.Header, ro
 }
 
 // withSubscriptionConditionalModels selects the per-request conditional model allowlist based on subscription state.
-// An unobserved credential is treated as active (cold-start priming); an empty selected list preserves unrestricted behavior.
+// An unobserved credential is treated as active (cold-start priming); an empty
+// selected list is kept in context so configured empty state lists fail closed.
 func (s *Service) withSubscriptionConditionalModels(ctx context.Context, headers http.Header, routePaths ...string) context.Context {
 	activeModels := installationSubscriptionModelsWhenActiveFromContext(ctx)
 	inactiveModels := installationSubscriptionModelsWhenInactiveFromContext(ctx)
@@ -267,15 +268,9 @@ func (s *Service) withSubscriptionConditionalModels(ctx context.Context, headers
 		}
 	}
 	if !active && observed {
-		if len(inactiveModels) > 0 {
-			return context.WithValue(ctx, InstallationSubscriptionConditionalModelsContextKey{}, inactiveModels)
-		}
-		return ctx
+		return context.WithValue(ctx, InstallationSubscriptionConditionalModelsContextKey{}, inactiveModels)
 	}
-	if len(activeModels) > 0 {
-		return context.WithValue(ctx, InstallationSubscriptionConditionalModelsContextKey{}, activeModels)
-	}
-	return ctx
+	return context.WithValue(ctx, InstallationSubscriptionConditionalModelsContextKey{}, activeModels)
 }
 
 // subsidyFactors computes the per-covered-model cost multiplier for this


### PR DESCRIPTION
Makes subscription-state model lists true allowlists once the feature is configured.

- Empty active/exhausted state lists now route to no models instead of silently becoming unrestricted.
- Both lists empty still preserves the feature-off behavior.
- Empty-but-configured state lists continue to bypass semantic caching.
- Adds coverage for empty-state selection, fail-closed exclusion, legacy both-empty behavior, and cache bypass.

Validation: `go test ./...`, `go vet ./...`, and `git diff --check`.