### PR TITLE
Remove Wafer as GLM 5.2 provider

### DIFF
--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -574,12 +574,6 @@ var Models = []Model{
 			Price: Pricing{InputUSDPer1M: 1.400, OutputUSDPer1M: 4.400, CacheReadMultiplier: 0.26 / 1.400}},
 		{Provider: providers.ProviderFireworks, UpstreamID: "accounts/fireworks/models/glm-5p2",
 			Price: Pricing{InputUSDPer1M: 1.400, OutputUSDPer1M: 4.400, CacheReadMultiplier: 0.20}},
-		// Trailing Wafer bindings: resolve only when earlier providers are unwired.
-		// wafer_anthropic trails the OpenAI-compat wafer (same pattern as kimi-k3).
-		{Provider: providers.ProviderWafer, UpstreamID: "GLM-5.2",
-			Price: Pricing{InputUSDPer1M: 1.260, OutputUSDPer1M: 3.960, CacheReadMultiplier: 0.23 / 1.260}},
-		{Provider: providers.ProviderWaferAnthropic, UpstreamID: "GLM-5.2",
-			Price: Pricing{InputUSDPer1M: 1.260, OutputUSDPer1M: 3.960, CacheReadMultiplier: 0.23 / 1.260}},
 	}},
 	// GLM-5.3: text-only (AA inputModalityImage=false); Fireworks is the only
 	// managed binding. ContextWindow is 1,048,576 (Fireworks served max), not

--- a/internal/router/catalog/catalog_test.go
+++ b/internal/router/catalog/catalog_test.go
@@ -388,26 +388,19 @@ func TestResolveBinding_WaferTrailingBindings(t *testing.T) {
 	assert.Equal(t, providers.ProviderFireworks, b.Provider)
 	assert.Equal(t, "accounts/fireworks/models/glm-5p3", b.UpstreamID)
 
-	// glm-5.2: Together leads; Wafer only when nothing ahead of it is available.
+	// glm-5.2: Together leads; Wafer is retired and no longer resolves.
 	b, ok = ResolveBinding("z-ai/glm-5.2", map[string]struct{}{providers.ProviderTogether: {}, providers.ProviderWafer: {}})
 	require.True(t, ok)
 	assert.Equal(t, providers.ProviderTogether, b.Provider)
 
 	b, ok = ResolveBinding("z-ai/glm-5.2", map[string]struct{}{providers.ProviderWafer: {}})
-	require.True(t, ok)
-	assert.Equal(t, providers.ProviderWafer, b.Provider)
-	assert.Equal(t, "GLM-5.2", b.UpstreamID)
+	assert.False(t, ok)
 
-	// wafer_anthropic (Anthropic-spec Messages) trails the OpenAI-compat wafer,
-	// so it resolves only when the OpenAI-compat surface is also absent.
 	b, ok = ResolveBinding("z-ai/glm-5.2", map[string]struct{}{providers.ProviderWaferAnthropic: {}})
-	require.True(t, ok)
-	assert.Equal(t, providers.ProviderWaferAnthropic, b.Provider)
-	assert.Equal(t, "GLM-5.2", b.UpstreamID)
+	assert.False(t, ok)
 
 	b, ok = ResolveBinding("z-ai/glm-5.2", map[string]struct{}{providers.ProviderWafer: {}, providers.ProviderWaferAnthropic: {}})
-	require.True(t, ok)
-	assert.Equal(t, providers.ProviderWafer, b.Provider, "OpenAI-compat wafer must win over wafer_anthropic")
+	assert.False(t, ok)
 
 	// kimi-k3: Fireworks leads, OpenRouter second, Wafer last.
 	b, ok = ResolveBinding("moonshotai/kimi-k3", map[string]struct{}{providers.ProviderOpenRouter: {}, providers.ProviderWafer: {}})
@@ -449,7 +442,6 @@ func TestWaferPricing(t *testing.T) {
 		outputUSD float64
 		cacheRead float64
 	}{
-		{"z-ai/glm-5.2", 1.260, 3.960, 0.23 / 1.260},
 		{"z-ai/glm-5.3-flash", 0.150, 0.500, 0.03 / 0.150},
 		{"moonshotai/kimi-k3", 3.000, 15.000, 0.10},
 		{"deepseek/deepseek-v4-flash", 0.280, 0.560, 0.07 / 0.280},


### PR DESCRIPTION
Summary:
- remove Wafer and wafer_anthropic bindings for z-ai/glm-5.2
- update catalog fallback and pricing coverage

Tests:
- go test ./...