### PR TITLE
fix(codex): keep router status out of the transcript

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -120,7 +120,7 @@ logged-in user's Team/Pro/Max/individual plan.
 | Path                       | Purpose                                                       |
 | -------------------------- | ------------------------------------------------------------- |
 | `~/.codex/config.toml`     | Adds a managed `[model_providers.weave]` block + sets top-level `model_provider = "weave"`, both between `# >>> weave-router managed` markers. The provider preserves the existing ChatGPT OAuth login and keeps the target router's default routing strategy. Anything outside the markers is preserved. |
-| `~/.weave/codex-status.sh` | Codex `SessionStart`/`Stop` hook helper. Keeps the latest routed model in the terminal title and emits a compact `Weave Router · …` status message when the router reports a new routed model. |
+| `~/.weave/codex-status.sh` | Codex `SessionStart`/`Stop` hook helper. Keeps the latest routed model in the terminal title without adding status messages to the conversation. |
 
 The status helper is installed with mode `0700`, stores only the session's requested and routed model IDs under `${XDG_CACHE_HOME:-~/.cache}/weave-router/codex/`, and never stores prompts, credentials, or response bodies. Existing Codex hooks are preserved and the managed hooks are safe to reinstall or remove.
 
@@ -279,7 +279,7 @@ nothing lands in a repo working tree.
 | `WEAVE_STATUSLINE_URL`                      | GitHub raw | Source for the statusline (self-hosters who fork).          |
 | `WEAVE_COMMANDS_URL_BASE`                   | GitHub raw | Source directory for the slash-command wrappers.            |
 
-**Codex status integration.** Codex 0.150+ supports lifecycle hooks. The installer enables hooks and adds managed `SessionStart` and `Stop` handlers. They maintain a small local state file and set the terminal title to `Weave Router · <routed-model> ← <requested-model>` when the router provides a routed-model marker. On ordinary turns where the model is unchanged, the title remains the last known routed model; before the first routed response it shows `Weave Router · active`. The hook also emits a compact status message after a completed turn. It is not a replacement for Codex's requested-model line: that line continues to show the model selected in Codex configuration, while the Weave status identifies the model that actually served. Existing user and project hooks remain outside the managed block and are preserved on reinstall/uninstall.
+**Codex status integration.** Codex 0.150+ supports lifecycle hooks. The installer enables hooks and adds managed `SessionStart` and `Stop` handlers. They maintain a small local state file and set the terminal title to `Weave Router · <routed-model> ← <requested-model>` when the router provides a routed-model marker. On ordinary turns where the model is unchanged, the title remains the last known routed model; before the first routed response it shows `Weave Router · active`. The hooks intentionally emit no status messages: Codex renders hook output in the conversation, which makes a persistent router indicator noisy and easy to confuse with model output. It is not a replacement for Codex's requested-model line: that line continues to show the model selected in Codex configuration, while the Weave status identifies the model that actually served. Existing user and project hooks remain outside the managed block and are preserved on reinstall/uninstall.
 
 **Session savings.** The title also carries `· saved $X.XX` when the router has beaten the model Codex asked for. The number comes from the router — the hook reads `GET <base-url>/v1/sessions/<session-id>/cost` with the router key already in `config.toml` — and is never computed locally: Codex records only its *requested* model on every turn, never the one that served, so client-side pricing would compare a model against itself and always report zero. The fetch is detached and its result is cached for the following turn, so no turn ever blocks on the network; a slow, unreachable, or older router simply leaves the title model-only. A session where the router spent more than the requested model would have shows no clause at all rather than a negative number, and a total under a cent reads `saved <$0.01`. Set `WEAVE_CODEX_STATUS_SAVINGS=0` to turn the lookup off entirely.
 
@@ -449,7 +449,7 @@ errors invoking `cc-statusline.sh`. The script needs `jq` on PATH.
    header; the router's own default applies.
 2. Run `codex` and issue a turn. The terminal title should begin with
    `Weave Router · active`; after a routed-model marker it shows the latest
-   actual model. The hook also emits `Weave Router · …` after the turn.
+   actual model. The hooks do not add status messages to the conversation.
    Provider should be `Weave Router`.
 3. Check the router's dashboard at `<base-url>/ui/dashboard` to see the HMM
    routed decision; Codex's `/status` shows its request model, not the

--- a/install/codex-status.sh
+++ b/install/codex-status.sh
@@ -231,10 +231,8 @@ hook_event_name="$(jq -r '.hook_event_name // ""' <<<"$payload")"
 if [ "$hook_event_name" = "SessionStart" ]; then
   if [ -f "$disabled_marker" ]; then
     emit_title "Codex · direct"
-    jq -cn '{systemMessage:"Codex direct · Weave Router is off"}'
   else
     emit_title "Weave Router · active"
-    jq -cn '{systemMessage:"Weave Router active · routed model appears in the terminal title"}'
   fi
   exit 0
 fi
@@ -307,6 +305,3 @@ else
   title="Weave Router · active$savings"
 fi
 emit_title "$title"
-if [ -n "$marker_model" ] || [ -n "$force_model" ]; then
-  printf '%s' "$title" | jq -Rc '{systemMessage: .}'
-fi

--- a/install/install.sh
+++ b/install/install.sh
@@ -3395,10 +3395,8 @@ hook_event_name="$(jq -r '.hook_event_name // ""' <<<"$payload")"
 if [ "$hook_event_name" = "SessionStart" ]; then
   if [ -f "$disabled_marker" ]; then
     emit_title "Codex · direct"
-    jq -cn '{systemMessage:"Codex direct · Weave Router is off"}'
   else
     emit_title "Weave Router · active"
-    jq -cn '{systemMessage:"Weave Router active · routed model appears in the terminal title"}'
   fi
   exit 0
 fi
@@ -3471,9 +3469,6 @@ else
   title="Weave Router · active$savings"
 fi
 emit_title "$title"
-if [ -n "$marker_model" ] || [ -n "$force_model" ]; then
-  printf '%s' "$title" | jq -Rc '{systemMessage: .}'
-fi
 CODEX_STATUS_EOF
   fi
   chmod 700 "$codex_status_file"

--- a/install/tests/codex-status_test.sh
+++ b/install/tests/codex-status_test.sh
@@ -18,7 +18,11 @@ XDG_CACHE_HOME="$cache" WEAVE_CODEX_STATUS_TITLE_FILE="$title_file" \
 }
 
 printf '%s\n' '{"session_id":"session-1","model":"gpt-5.6-terra","last_assistant_message":"✦ **Weave Router** → claude-sonnet-5 · best pick for this turn"}' \
-  | XDG_CACHE_HOME="$cache" WEAVE_CODEX_STATUS_TITLE_FILE="$title_file" "$helper"
+  | XDG_CACHE_HOME="$cache" WEAVE_CODEX_STATUS_TITLE_FILE="$title_file" "$helper" >"$work/marker.out"
+[ ! -s "$work/marker.out" ] || {
+  echo "Stop hook emitted a duplicate status message" >&2
+  exit 1
+}
 [ "$(cat "$title_file")" = "Weave Router · claude-sonnet-5 ← gpt-5.6-terra" ] || {
   echo "Stop hook did not publish the routed model" >&2
   exit 1
@@ -56,8 +60,8 @@ printf '%s\n' "$session_start" \
   echo "disabled SessionStart hook did not keep the direct title" >&2
   exit 1
 }
-grep -Fq 'Weave Router is off' "$work/session-start.out" || {
-  echo "disabled SessionStart hook did not explain the direct state" >&2
+[ ! -s "$work/session-start.out" ] || {
+  echo "disabled SessionStart hook emitted a status message" >&2
   exit 1
 }
 printf '%s\n' '{"hook_event_name":"Stop","session_id":"session-1","model":"gpt-5.6-sol"}' \


### PR DESCRIPTION
## Summary

- Stop Codex lifecycle hooks from injecting router status messages into the conversation.
- Keep the existing terminal-title state and savings behavior unchanged.
- Add regression coverage for silent SessionStart and Stop hooks, including the embedded install.sh helper.
- Update the Codex installation documentation to describe the quiet behavior.

Codex renders hook `systemMessage` output in the transcript. The previous helper used that output for a persistent indicator, which produced repeated status lines mixed into the user-visible conversation. The terminal title is the router-owned persistent surface available without changing Codex.

## Verification

- `bash install/tests/codex-status_test.sh`
- `bash install/tests/codex_install_test.sh`
- `bash -n install/codex-status.sh install/install.sh install/tests/codex-status_test.sh`
- `git diff --check`

🤖 Generated with [Weave Router](https://router.workweave.ai)