### PR TITLE
catalog: prefer Makora for GLM-5.3-Flash

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -276,7 +276,7 @@ func main() {
 	}
 
 	{
-		// Makora uses DeepSeek-canonical model IDs vs. the router's slash-form
+		// Makora uses provider-canonical model IDs vs. the router's slash-form
 		// slugs; modelIDMap comes from the catalog's per-binding UpstreamID.
 		makoraBaseURL := config.GetOr("MAKORA_BASE_URL", openaiCompatProvider.MakoraBaseURL)
 		registerDeploymentKeyedProvider(providerMap, envKeyedProviders, logger,
@@ -288,9 +288,9 @@ func main() {
 
 	{
 		// Primary binding for DeepSeek V4 Pro / GLM-5.1 / MiniMax M2.7 (top of
-		// artificialanalysis.ai throughput tables); prior providers stay as
-		// ordered fallbacks. Uses "Org/Model" IDs vs. the router's slash-form
-		// slugs; modelIDMap comes from the catalog's per-binding UpstreamID.
+		// artificialanalysis.ai throughput tables); also an ordered fallback for
+		// models led by another provider. Uses "Org/Model" IDs vs. the router's
+		// slash-form slugs; modelIDMap comes from each binding's UpstreamID.
 		togetherBaseURL := config.GetOr("TOGETHER_BASE_URL", openaiCompatProvider.TogetherBaseURL)
 		registerDeploymentKeyedProvider(providerMap, envKeyedProviders, logger,
 			providers.ProviderTogether, "Together", "TOGETHER_API_KEY", togetherBaseURL, byokOnly,

--- a/internal/providers/openaicompat/client.go
+++ b/internal/providers/openaicompat/client.go
@@ -24,9 +24,9 @@ import (
 const (
 	DefaultBaseURL   = "https://openrouter.ai/api/v1"
 	FireworksBaseURL = "https://api.fireworks.ai/inference/v1"
-	// MakoraBaseURL serves DeepSeek V4 Flash at higher throughput than
-	// commodity providers; pair with NewClientWithModelIDMap to rewrite slugs
-	// to Makora's upstream IDs.
+	// MakoraBaseURL serves the OSS catalog at higher throughput than commodity
+	// providers; pair with NewClientWithModelIDMap to rewrite slugs to Makora's
+	// upstream IDs.
 	MakoraBaseURL = "https://inference.makora.com/v1"
 	// TogetherBaseURL serves the OSS pool (DeepSeek, GLM, MiniMax, Qwen, Kimi)
 	// and is fastest on artificialanalysis.ai for several routed models; pair

--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -584,15 +584,21 @@ var Models = []Model{
 	}},
 	// GLM-5.3-Flash: first native-multimodal (image+video) in the GLM-5 line —
 	// ImageInput stays default. Thinking cannot be disabled — do not add it to
-	// openRouterReasoningHint. Together leads, Wafer trails. Priced at post-promo
-	// rate, not $0.075/$0.25 introductory (cf. gemini-3.7-flash). ContextWindow
-	// 1,048,576 (Together served max); 1,310,720 is Cloudflare-only.
+	// openRouterReasoningHint. Makora leads, followed by Together and the two
+	// Wafer surfaces; Fireworks is the final fallback. Priced at post-promo rate,
+	// not $0.075/$0.25 introductory (cf. gemini-3.7-flash). ContextWindow
+	// 1,048,576 (Makora/Together/Fireworks served max); 1,310,720 is
+	// Cloudflare-only.
 	{ID: "z-ai/glm-5.3-flash", Tier: TierLow, ContextWindow: 1_048_576, Providers: []ProviderBinding{
+		{Provider: providers.ProviderMakora, UpstreamID: "zai-org/GLM-5.3-Flash",
+			Price: Pricing{InputUSDPer1M: 0.150, OutputUSDPer1M: 0.500, CacheReadMultiplier: 0.03 / 0.150}},
 		{Provider: providers.ProviderTogether, UpstreamID: "zai-org/GLM-5.3-Flash",
 			Price: Pricing{InputUSDPer1M: 0.150, OutputUSDPer1M: 0.500, CacheReadMultiplier: 0.03 / 0.150}},
 		{Provider: providers.ProviderWafer, UpstreamID: "GLM-5.3-Flash",
 			Price: Pricing{InputUSDPer1M: 0.150, OutputUSDPer1M: 0.500, CacheReadMultiplier: 0.03 / 0.150}},
 		{Provider: providers.ProviderWaferAnthropic, UpstreamID: "GLM-5.3-Flash",
+			Price: Pricing{InputUSDPer1M: 0.150, OutputUSDPer1M: 0.500, CacheReadMultiplier: 0.03 / 0.150}},
+		{Provider: providers.ProviderFireworks, UpstreamID: "accounts/fireworks/models/glm-5p3-flash",
 			Price: Pricing{InputUSDPer1M: 0.150, OutputUSDPer1M: 0.500, CacheReadMultiplier: 0.03 / 0.150}},
 	}},
 	// Fireworks-dedicated rows below carry an OpenRouter trailing binding so

--- a/internal/router/catalog/catalog_test.go
+++ b/internal/router/catalog/catalog_test.go
@@ -365,10 +365,26 @@ func TestValidateDeployed_FlagsMissingAndUntiered(t *testing.T) {
 
 // TestResolveBinding_WaferTrailingBindings pin the trailing-binding order:
 // Wafer only resolves when the earlier providers are absent, so a deploy with
-// Together/Fireworks/OpenRouter wired never displaces them onto Wafer.
+// Makora/Together/Fireworks wired never displaces them onto Wafer.
 func TestResolveBinding_WaferTrailingBindings(t *testing.T) {
-	// glm-5.3-flash: Together leads; Wafer trails it, wafer_anthropic last.
-	b, ok := ResolveBinding("z-ai/glm-5.3-flash", map[string]struct{}{providers.ProviderTogether: {}, providers.ProviderWafer: {}})
+	// glm-5.3-flash: Makora leads; Together and Wafer trail it, Fireworks last.
+	b, ok := ResolveBinding("z-ai/glm-5.3-flash", map[string]struct{}{
+		providers.ProviderMakora: {}, providers.ProviderTogether: {}, providers.ProviderFireworks: {},
+	})
+	require.True(t, ok)
+	assert.Equal(t, providers.ProviderMakora, b.Provider)
+	assert.Equal(t, "zai-org/GLM-5.3-Flash", b.UpstreamID)
+
+	b, ok = ResolveBinding("z-ai/glm-5.3-flash", map[string]struct{}{providers.ProviderFireworks: {}})
+	require.True(t, ok)
+	assert.Equal(t, providers.ProviderFireworks, b.Provider)
+	assert.Equal(t, "accounts/fireworks/models/glm-5p3-flash", b.UpstreamID)
+
+	b, ok = ResolveBinding("z-ai/glm-5.3-flash", map[string]struct{}{providers.ProviderWafer: {}, providers.ProviderFireworks: {}})
+	require.True(t, ok)
+	assert.Equal(t, providers.ProviderWafer, b.Provider)
+
+	b, ok = ResolveBinding("z-ai/glm-5.3-flash", map[string]struct{}{providers.ProviderTogether: {}, providers.ProviderWafer: {}})
 	require.True(t, ok)
 	assert.Equal(t, providers.ProviderTogether, b.Provider)
 	assert.Equal(t, "zai-org/GLM-5.3-Flash", b.UpstreamID)
@@ -431,6 +447,18 @@ func TestResolveBinding_WaferTrailingBindings(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, providers.ProviderWaferAnthropic, b.Provider)
 	assert.Equal(t, "DeepSeek-V4-Flash-0731-Fast", b.UpstreamID)
+}
+
+func TestGLM53FlashProviderPricing(t *testing.T) {
+	for _, provider := range []string{providers.ProviderMakora, providers.ProviderFireworks} {
+		t.Run(provider, func(t *testing.T) {
+			p, ok := PriceFor(provider, "z-ai/glm-5.3-flash")
+			require.True(t, ok)
+			assert.InDelta(t, 0.150, p.InputUSDPer1M, 1e-9)
+			assert.InDelta(t, 0.500, p.OutputUSDPer1M, 1e-9)
+			assert.InDelta(t, 0.03/0.150, p.CacheReadMultiplier, 1e-9)
+		})
+	}
 }
 
 // TestWaferPricing pins the per-1M rates and cache multipliers as published on


### PR DESCRIPTION
## Summary
- Make Makora the primary provider for `z-ai/glm-5.3-flash`.
- Preserve Together and Wafer fallbacks, with Fireworks (`accounts/fireworks/models/glm-5p3-flash`) last.
- Add regression coverage for provider ordering and pricing, and update stale Makora comments.

## Validation
- `go test ./...`
- `wv router tc`
- `wv router t`