### PR TITLE
feat(codex): self-refresh the status helper on lifecycle hooks

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -278,6 +278,17 @@ nothing lands in a repo working tree.
 | `WEAVE_STATUSLINE_UPDATE_INTERVAL_DAYS`     | `7`     | How often either check may run.                                |
 | `WEAVE_STATUSLINE_URL`                      | GitHub raw | Source for the statusline (self-hosters who fork).          |
 | `WEAVE_COMMANDS_URL_BASE`                   | GitHub raw | Source directory for the slash-command wrappers.            |
+| `WEAVE_CODEX_STATUS_UPDATE=0`               | on      | Disable the Codex status helper's self-refresh.                |
+| `WEAVE_CODEX_STATUS_UPDATE_INTERVAL_DAYS`   | `7`     | How often the Codex helper may check for a new copy.           |
+| `WEAVE_CODEX_STATUS_URL`                    | GitHub raw | Source for the Codex status helper (self-hosters who fork). |
+
+**Codex refreshes itself too.** The status helper checks for a newer copy of
+itself on the same schedule and swaps it in atomically, so an install picks up
+router fixes without waiting for someone to remember to re-run the installer.
+The check runs only on a real lifecycle hook — never on the `off`/`on`/`status`
+toggles — in a detached fork, so no Codex turn blocks on it, and it skips the
+replacement when the bytes are unchanged. The `WEAVE_STATUSLINE_*` variables
+above are accepted as fallbacks for users who configure both clients together.
 
 **Codex status integration.** Codex 0.150+ supports lifecycle hooks. The installer enables hooks and adds managed `SessionStart` and `Stop` handlers. They maintain a small local state file and set the terminal title to `Weave Router · <routed-model> ← <requested-model>` when the router provides a routed-model marker. On ordinary turns where the model is unchanged, the title remains the last known routed model; before the first routed response it shows `Weave Router · active`. The hooks intentionally emit no status messages: Codex renders hook output in the conversation, which makes a persistent router indicator noisy and easy to confuse with model output. It is not a replacement for Codex's requested-model line: that line continues to show the model selected in Codex configuration, while the Weave status identifies the model that actually served. Existing user and project hooks remain outside the managed block and are preserved on reinstall/uninstall.
 

--- a/install/codex-status.sh
+++ b/install/codex-status.sh
@@ -46,9 +46,10 @@ weave_self_refresh() {
 
   local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/weave-router"
   mkdir -p "$cache_dir" 2>/dev/null || return 0
-  local script_slug
+  local script_slug path_digest
   script_slug="$(printf '%s' "$self" | tr -c 'A-Za-z0-9._-' '_')"
-  local stamp="$cache_dir/checked-at${script_slug}-codex"
+  path_digest="$(printf '%s' "$self" | cksum | awk '{print $1}')"
+  local stamp="$cache_dir/checked-at${script_slug}-${path_digest}-codex"
 
   local now stamp_mtime
   now="$(date +%s 2>/dev/null)" || return 0

--- a/install/codex-status.sh
+++ b/install/codex-status.sh
@@ -19,6 +19,75 @@
 
 set -euo pipefail
 
+# ---------- background self-refresh ----------
+#
+# Codex runs this helper on SessionStart and after every turn. Once per
+# interval, use that lifecycle as the update check so installed helpers pick
+# up router fixes without requiring the user to rerun the installer. The
+# download is detached and swapped atomically; the current hook always
+# finishes against the copy it started with.
+#
+# Set WEAVE_CODEX_STATUS_UPDATE=0 to disable it. Self-hosters can point
+# WEAVE_CODEX_STATUS_URL at their own helper source. The common
+# WEAVE_STATUSLINE_UPDATE and WEAVE_STATUSLINE_UPDATE_INTERVAL_DAYS variables
+# remain accepted as aliases for users who configure both clients together.
+weave_self_refresh() {
+  [ "${WEAVE_CODEX_STATUS_UPDATE:-${WEAVE_STATUSLINE_UPDATE:-1}}" = "0" ] && return 0
+  command -v curl >/dev/null 2>&1 || return 0
+
+  local self="${BASH_SOURCE[0]:-$0}"
+  [ -f "$self" ] && [ -w "$self" ] || return 0
+
+  local interval_days="${WEAVE_CODEX_STATUS_UPDATE_INTERVAL_DAYS:-${WEAVE_STATUSLINE_UPDATE_INTERVAL_DAYS:-7}}"
+  case "$interval_days" in
+    ''|*[!0-9]*) return 0 ;;
+  esac
+  local interval_seconds=$(( interval_days * 86400 ))
+
+  local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/weave-router"
+  mkdir -p "$cache_dir" 2>/dev/null || return 0
+  local script_slug
+  script_slug="$(printf '%s' "$self" | tr -c 'A-Za-z0-9._-' '_')"
+  local stamp="$cache_dir/checked-at${script_slug}-codex"
+
+  local now stamp_mtime
+  now="$(date +%s 2>/dev/null)" || return 0
+  if [ -f "$stamp" ]; then
+    stamp_mtime="$(stat -c %Y "$stamp" 2>/dev/null || stat -f %m "$stamp" 2>/dev/null)" || stamp_mtime=0
+  else
+    stamp_mtime=0
+  fi
+  if [ -n "${stamp_mtime:-}" ] && [ "$stamp_mtime" -gt 0 ] \
+     && [ $(( now - stamp_mtime )) -lt "$interval_seconds" ]; then
+    return 0
+  fi
+
+  # Stamp before forking so concurrent SessionStart/Stop hooks share one
+  # download. A failed download consumes the interval; the next hook retries.
+  : >"$stamp" 2>/dev/null || return 0
+
+  local url="${WEAVE_CODEX_STATUS_URL:-https://raw.githubusercontent.com/workweave/router/main/install/codex-status.sh}"
+  local tmp="${self}.tmp.$$"
+  (
+    exec </dev/null
+    if curl -fsSL --max-time 15 "$url" -o "$tmp" 2>/dev/null \
+       && [ -s "$tmp" ] \
+       && head -n 1 "$tmp" | grep -q '^#!.*bash' \
+       && [ "$(wc -c <"$tmp")" -ge 1024 ]; then
+      if cmp -s "$tmp" "$self"; then
+        rm -f "$tmp"
+      else
+        chmod 700 "$tmp" 2>/dev/null || true
+        mv "$tmp" "$self" 2>/dev/null || rm -f "$tmp"
+      fi
+    else
+      rm -f "$tmp"
+    fi
+  ) >/dev/null 2>&1 &
+  disown 2>/dev/null || true
+  return 0
+}
+
 state_root="${XDG_CACHE_HOME:-$HOME/.cache}/weave-router/codex"
 helper_dir="$(cd "$(dirname "$0")" 2>/dev/null && pwd -P)"
 disabled_marker="$helper_dir/.weave-router-disabled"
@@ -224,6 +293,7 @@ esac
 
 payload="$(cat)"
 [ -n "$payload" ] || exit 0
+weave_self_refresh 2>/dev/null || true
 command -v jq >/dev/null 2>&1 || exit 0
 jq -e . >/dev/null 2>&1 <<<"$payload" || exit 0
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -3210,9 +3210,10 @@ weave_self_refresh() {
 
   local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/weave-router"
   mkdir -p "$cache_dir" 2>/dev/null || return 0
-  local script_slug
+  local script_slug path_digest
   script_slug="$(printf '%s' "$self" | tr -c 'A-Za-z0-9._-' '_')"
-  local stamp="$cache_dir/checked-at${script_slug}-codex"
+  path_digest="$(printf '%s' "$self" | cksum | awk '{print $1}')"
+  local stamp="$cache_dir/checked-at${script_slug}-${path_digest}-codex"
 
   local now stamp_mtime
   now="$(date +%s 2>/dev/null)" || return 0

--- a/install/install.sh
+++ b/install/install.sh
@@ -3183,6 +3183,75 @@ install_codex_status_script() {
 
 set -euo pipefail
 
+# ---------- background self-refresh ----------
+#
+# Codex runs this helper on SessionStart and after every turn. Once per
+# interval, use that lifecycle as the update check so installed helpers pick
+# up router fixes without requiring the user to rerun the installer. The
+# download is detached and swapped atomically; the current hook always
+# finishes against the copy it started with.
+#
+# Set WEAVE_CODEX_STATUS_UPDATE=0 to disable it. Self-hosters can point
+# WEAVE_CODEX_STATUS_URL at their own helper source. The common
+# WEAVE_STATUSLINE_UPDATE and WEAVE_STATUSLINE_UPDATE_INTERVAL_DAYS variables
+# remain accepted as aliases for users who configure both clients together.
+weave_self_refresh() {
+  [ "${WEAVE_CODEX_STATUS_UPDATE:-${WEAVE_STATUSLINE_UPDATE:-1}}" = "0" ] && return 0
+  command -v curl >/dev/null 2>&1 || return 0
+
+  local self="${BASH_SOURCE[0]:-$0}"
+  [ -f "$self" ] && [ -w "$self" ] || return 0
+
+  local interval_days="${WEAVE_CODEX_STATUS_UPDATE_INTERVAL_DAYS:-${WEAVE_STATUSLINE_UPDATE_INTERVAL_DAYS:-7}}"
+  case "$interval_days" in
+    ''|*[!0-9]*) return 0 ;;
+  esac
+  local interval_seconds=$(( interval_days * 86400 ))
+
+  local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/weave-router"
+  mkdir -p "$cache_dir" 2>/dev/null || return 0
+  local script_slug
+  script_slug="$(printf '%s' "$self" | tr -c 'A-Za-z0-9._-' '_')"
+  local stamp="$cache_dir/checked-at${script_slug}-codex"
+
+  local now stamp_mtime
+  now="$(date +%s 2>/dev/null)" || return 0
+  if [ -f "$stamp" ]; then
+    stamp_mtime="$(stat -c %Y "$stamp" 2>/dev/null || stat -f %m "$stamp" 2>/dev/null)" || stamp_mtime=0
+  else
+    stamp_mtime=0
+  fi
+  if [ -n "${stamp_mtime:-}" ] && [ "$stamp_mtime" -gt 0 ] \
+     && [ $(( now - stamp_mtime )) -lt "$interval_seconds" ]; then
+    return 0
+  fi
+
+  # Stamp before forking so concurrent SessionStart/Stop hooks share one
+  # download. A failed download consumes the interval; the next hook retries.
+  : >"$stamp" 2>/dev/null || return 0
+
+  local url="${WEAVE_CODEX_STATUS_URL:-https://raw.githubusercontent.com/workweave/router/main/install/codex-status.sh}"
+  local tmp="${self}.tmp.$$"
+  (
+    exec </dev/null
+    if curl -fsSL --max-time 15 "$url" -o "$tmp" 2>/dev/null \
+       && [ -s "$tmp" ] \
+       && head -n 1 "$tmp" | grep -q '^#!.*bash' \
+       && [ "$(wc -c <"$tmp")" -ge 1024 ]; then
+      if cmp -s "$tmp" "$self"; then
+        rm -f "$tmp"
+      else
+        chmod 700 "$tmp" 2>/dev/null || true
+        mv "$tmp" "$self" 2>/dev/null || rm -f "$tmp"
+      fi
+    else
+      rm -f "$tmp"
+    fi
+  ) >/dev/null 2>&1 &
+  disown 2>/dev/null || true
+  return 0
+}
+
 state_root="${XDG_CACHE_HOME:-$HOME/.cache}/weave-router/codex"
 helper_dir="$(cd "$(dirname "$0")" 2>/dev/null && pwd -P)"
 disabled_marker="$helper_dir/.weave-router-disabled"
@@ -3388,6 +3457,7 @@ esac
 
 payload="$(cat)"
 [ -n "$payload" ] || exit 0
+weave_self_refresh 2>/dev/null || true
 command -v jq >/dev/null 2>&1 || exit 0
 jq -e . >/dev/null 2>&1 <<<"$payload" || exit 0
 

--- a/install/tests/codex-status_test.sh
+++ b/install/tests/codex-status_test.sh
@@ -8,6 +8,12 @@ helper="$script_dir/../codex-status.sh"
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
 
+# The hook self-updates from GitHub. Left on, every case below would race a
+# download that replaces the helper under test with the published copy, so the
+# suite would be testing main rather than the working tree. Cases that exercise
+# the updater re-enable it with an explicit file:// source.
+export WEAVE_CODEX_STATUS_UPDATE=0
+
 title_file="$work/title"
 cache="$work/cache"
 XDG_CACHE_HOME="$cache" WEAVE_CODEX_STATUS_TITLE_FILE="$title_file" \
@@ -207,6 +213,74 @@ printf '%s\n' '{"session_id":"session-3","model":"gpt-5.6-terra","last_assistant
 sleep 0.5
 [ ! -f "$optout_cache/weave-router/codex/session-3.cost" ] || {
   echo "WEAVE_CODEX_STATUS_SAVINGS=0 still fetched the session cost" >&2
+  exit 1
+}
+
+# ---------- background self-refresh ----------
+#
+# Codex only reruns the installer when a user remembers to, so the lifecycle
+# hook doubles as the update check. A `file://` source keeps this offline.
+
+refresh_home="$work/refresh-home"
+mkdir -p "$refresh_home"
+refresh_helper="$work/refresh/weave-status.sh"
+mkdir -p "$(dirname "$refresh_helper")"
+cp "$helper" "$refresh_helper"
+chmod 700 "$refresh_helper"
+
+newer_helper="$work/newer-codex-status.sh"
+{
+  printf '%s\n' '#!/usr/bin/env bash'
+  printf '%s\n' '# <!-- weave-router managed codex status -->'
+  printf '%s\n' '# newer upstream copy'
+  # The updater rejects anything under 1 KiB, so pad past that floor.
+  awk 'BEGIN { while (i++ < 40) print "# padding padding padding padding padding padding" }'
+  printf '%s\n' 'exit 0'
+} >"$newer_helper"
+
+run_refresh_turn() {
+  printf '%s\n' '{"session_id":"session-refresh","model":"gpt-5.6-terra","last_assistant_message":"✦ **Weave Router** → claude-sonnet-5 · best pick"}' \
+    | HOME="$refresh_home" XDG_CACHE_HOME="$work/cache-refresh" \
+      WEAVE_CODEX_STATUS_UPDATE=1 WEAVE_CODEX_STATUS_URL="file://$newer_helper" \
+      WEAVE_CODEX_STATUS_TITLE_FILE="$title_file" "$@" "$refresh_helper" >/dev/null
+}
+
+run_refresh_turn
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  cmp -s "$refresh_helper" "$newer_helper" && break
+  sleep 0.2
+done
+cmp -s "$refresh_helper" "$newer_helper" || {
+  echo "the hook did not pick up a newer helper" >&2
+  exit 1
+}
+
+# A second turn must not re-download inside the interval, so a helper edited
+# after the stamp was written stays put.
+printf '%s\n' '#!/usr/bin/env bash' >"$refresh_helper"
+printf '%s\n' 'exit 0' >>"$refresh_helper"
+chmod 700 "$refresh_helper"
+before_rate_limit="$(cat "$refresh_helper")"
+run_refresh_turn
+sleep 0.5
+[ "$(cat "$refresh_helper")" = "$before_rate_limit" ] || {
+  echo "self-refresh ignored its own rate limit" >&2
+  exit 1
+}
+
+# Opting out must suppress the download even when the interval has elapsed.
+optout_helper="$work/refresh-optout/weave-status.sh"
+mkdir -p "$(dirname "$optout_helper")"
+cp "$helper" "$optout_helper"
+chmod 700 "$optout_helper"
+optout_before="$(cat "$optout_helper")"
+printf '%s\n' '{"session_id":"session-refresh-off","model":"gpt-5.6-terra","last_assistant_message":"✦ **Weave Router** → claude-sonnet-5 · best pick"}' \
+  | HOME="$refresh_home" XDG_CACHE_HOME="$work/cache-refresh-optout" \
+    WEAVE_CODEX_STATUS_URL="file://$newer_helper" WEAVE_CODEX_STATUS_UPDATE=0 \
+    WEAVE_CODEX_STATUS_TITLE_FILE="$title_file" "$optout_helper" >/dev/null
+sleep 0.5
+[ "$(cat "$optout_helper")" = "$optout_before" ] || {
+  echo "WEAVE_CODEX_STATUS_UPDATE=0 still replaced the helper" >&2
   exit 1
 }
 

--- a/install/tests/codex-status_test.sh
+++ b/install/tests/codex-status_test.sh
@@ -256,10 +256,12 @@ cmp -s "$refresh_helper" "$newer_helper" || {
 }
 
 # A second turn must not re-download inside the interval, so a helper edited
-# after the stamp was written stays put.
-printf '%s\n' '#!/usr/bin/env bash' >"$refresh_helper"
-printf '%s\n' 'exit 0' >>"$refresh_helper"
+# after the stamp was written stays put. Recopy the real helper first — the
+# first turn replaced it with the stub from $newer_helper, which never
+# enters weave_self_refresh.
+cp "$helper" "$refresh_helper"
 chmod 700 "$refresh_helper"
+printf '\n# mutated after stamp\n' >>"$refresh_helper"
 before_rate_limit="$(cat "$refresh_helper")"
 run_refresh_turn
 sleep 0.5


### PR DESCRIPTION
## Summary

- Give the Codex status helper the same background self-refresh Claude Code's statusline already has, so an install picks up router fixes without waiting for someone to re-run the installer.
- Gate the check to real lifecycle hooks only: the `off`/`on`/`status` toggles are config edits, not turns.
- Disable the network path by default in the regression suite and add coverage for adopt / rate-limit / opt-out.

The helper was written once at install time and never touched again. A user
who did not re-run `npx @workweave/router --codex` kept whatever shipped that
day, which is how a merged helper fix can sit unused on an existing install.

The check is detached (`curl --max-time 15`), rate-limited to once every
`WEAVE_CODEX_STATUS_UPDATE_INTERVAL_DAYS` (default 7) against a stamp under
`${XDG_CACHE_HOME}/weave-router/` keyed by absolute script path, so user and
project scopes rate-limit independently and nothing lands in a repo working
tree. It validates the download (non-empty, bash shebang, >=1 KiB), skips the
`mv` when the bytes are unchanged, and preserves the helper's `0700` mode —
it sits next to the router key.

### Why the hook path, not the toggles

Running the refresh before argument handling meant `--on` also fetched. That
is not hypothetical: it replaced the helper under test with `main`'s published
copy mid-run, which is exactly the "my edit keeps reverting" symptom. Reading
the payload first makes "this is a turn" the precondition for a network call.

### Why the suite disables it by default

Every pre-existing case runs the helper in place with no `WEAVE_CODEX_STATUS_URL`,
so the default GitHub source would race a download that overwrites the subject
under test — the suite would silently test `main` instead of the working tree.
The three updater cases re-enable it with an explicit `file://` source, so the
whole suite stays offline.

## Verification

- `bash install/tests/codex-status_test.sh` — passes, including the three new cases (newer copy adopted, rate limit honoured, `WEAVE_CODEX_STATUS_UPDATE=0` respected)
- `bash install/tests/codex_install_test.sh`
- Byte-identical `install.sh` heredoc confirmed against `install/codex-status.sh`
- `bash -n` on both copies and the test

🤖 Generated with [Weave Router](https://router.workweave.ai)