### PR TITLE
feat: persist per-turn spiral signals for escalation training

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -660,6 +660,11 @@ func main() {
 	// Shadow mode is log-only, so it ships enabled; the switch just sheds the
 	// per-turn signal-scan cost if it misbehaves.
 	spiralShadowEnabled := config.GetOr("ROUTER_SPIRAL_SHADOW_ENABLED", "true") == "true"
+	// Per-turn signal snapshot on telemetry rows. Ships enabled: it is the
+	// escalation dataset's only source of negative examples, and it writes
+	// nothing for installations that opted out of AI training or set content
+	// capture to off. The switch sheds the extra columns if write volume bites.
+	turnSignalCaptureEnabled := config.GetOr("ROUTER_TURN_SIGNAL_CAPTURE_ENABLED", "true") == "true"
 	// Session-level struggle detector, also log-only and shipped enabled.
 	// Switch sheds the per-turn check if it misbehaves; exists for symmetry with the spiral detector.
 	struggleShadowEnabled := config.GetOr("ROUTER_STRUGGLE_SHADOW_ENABLED", "true") == "true"
@@ -992,6 +997,7 @@ func main() {
 		flags.KeyStruggleEscalationHoldout: strconv.Itoa(struggleEscalationHoldoutPct),
 		flags.KeyStruggleEvidenceArming:    boolDefault(struggleEvidenceArming),
 		flags.KeySpiralShadowEnabled:       boolDefault(spiralShadowEnabled),
+		flags.KeyTurnSignalCapture:         boolDefault(turnSignalCaptureEnabled),
 		flags.KeyLoopEscalationEnabled:     boolDefault(loopEscalationEnabled),
 		flags.KeyLoopEscalationHoldoutPct:  strconv.Itoa(loopEscalationHoldoutPct),
 		flags.KeyTextRepetitionBreak:       boolDefault(textRepetitionBreakEnabled),
@@ -1060,6 +1066,7 @@ func main() {
 		WithLoopEscalationConfig(loopEscalationEnabled, loopEscalationHoldoutPct).
 		WithLoopEscalationStore(repo.Telemetry).
 		WithSpiralShadowConfig(spiralShadowEnabled).
+		WithTurnSignalCapture(turnSignalCaptureEnabled).
 		WithSpiralShadowStore(repo.Telemetry).
 		WithStruggleShadowConfig(struggleShadowEnabled).
 		WithStruggleShadowStore(repo.Telemetry).
@@ -1084,6 +1091,7 @@ func main() {
 	logger.Info("Cross-vendor Claude Code orchestration tools configured", "enabled", ccOrchToolsCrossVendor)
 	logger.Info("Loop escalation configured", "enabled", loopEscalationEnabled, "holdout_pct", loopEscalationHoldoutPct)
 	logger.Info("Spiral shadow detector configured", "enabled", spiralShadowEnabled)
+	logger.Info("Turn signal capture configured", "enabled", turnSignalCaptureEnabled)
 	logger.Info("Text-repetition break configured", "enabled", textRepetitionBreakEnabled)
 	logger.Info("Planner configured", "enabled", plannerEnabled, "threshold_usd", plannerCfg.ThresholdUSD, "expected_remaining_turns", plannerCfg.ExpectedRemainingTurns, "tier_upgrade_enabled", plannerCfg.TierUpgradeEnabled, "cold_pin_follow_fresh", plannerCfg.ColdPinFollowFresh, "corrected_economics", plannerCfg.CorrectedEconomics, "prefix_trim_free_switch", prefixTrimFreeSwitch, "routing_targets_count", len(routingTargets))
 	logger.Info("Tool-result scoring configured", "enabled", scoreToolResultTurns)

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -660,10 +660,9 @@ func main() {
 	// Shadow mode is log-only, so it ships enabled; the switch just sheds the
 	// per-turn signal-scan cost if it misbehaves.
 	spiralShadowEnabled := config.GetOr("ROUTER_SPIRAL_SHADOW_ENABLED", "true") == "true"
-	// Per-turn signal snapshot on telemetry rows. Ships enabled: it is the
-	// escalation dataset's only source of negative examples, and it writes
-	// nothing for installations that opted out of AI training or set content
-	// capture to off. The switch sheds the extra columns if write volume bites.
+	// Per-turn signal snapshot on telemetry rows. Ships enabled; only source
+	// of negative examples. Skipped regardless for opted-out installations.
+	// Kill switch: ROUTER_TURN_SIGNAL_CAPTURE_ENABLED.
 	turnSignalCaptureEnabled := config.GetOr("ROUTER_TURN_SIGNAL_CAPTURE_ENABLED", "true") == "true"
 	// Session-level struggle detector, also log-only and shipped enabled.
 	// Switch sheds the per-turn check if it misbehaves; exists for symmetry with the spiral detector.

--- a/db/migrations/0072_telemetry-turn-signals.down.sql
+++ b/db/migrations/0072_telemetry-turn-signals.down.sql
@@ -1,0 +1,21 @@
+BEGIN;
+
+DROP INDEX router.model_router_request_telemetry_turn_signals_idx;
+
+ALTER TABLE router.model_router_request_telemetry
+    DROP CONSTRAINT model_router_request_telemetry_turn_signals_privacy_check,
+    DROP COLUMN spiral_reasons,
+    DROP COLUMN spiral_edit_attempted,
+    DROP COLUMN spiral_steps_since_progress,
+    DROP COLUMN spiral_ping_pong_len,
+    DROP COLUMN spiral_message_count,
+    DROP COLUMN spiral_tool_call_count,
+    DROP COLUMN spiral_monologue_len,
+    DROP COLUMN spiral_repeat_frac,
+    DROP COLUMN spiral_same_file_path_hash,
+    DROP COLUMN spiral_max_same_file_edits,
+    DROP COLUMN spiral_tool_results,
+    DROP COLUMN spiral_errored_results,
+    DROP COLUMN spiral_err_streak;
+
+COMMIT;

--- a/db/migrations/0072_telemetry-turn-signals.up.sql
+++ b/db/migrations/0072_telemetry-turn-signals.up.sql
@@ -1,0 +1,77 @@
+BEGIN;
+
+-- Nullable as a group: NULL means the snapshot was not recorded, while zero
+-- is a measured value. The proxy writes the group only when AI training is
+-- allowed and the effective content-capture mode is hashed or full.
+ALTER TABLE router.model_router_request_telemetry
+    ADD COLUMN spiral_err_streak           INT,
+    ADD COLUMN spiral_errored_results      INT,
+    ADD COLUMN spiral_tool_results         INT,
+    ADD COLUMN spiral_max_same_file_edits  INT,
+    ADD COLUMN spiral_same_file_path_hash  VARCHAR,
+    ADD COLUMN spiral_repeat_frac          DOUBLE PRECISION,
+    ADD COLUMN spiral_monologue_len        INT,
+    ADD COLUMN spiral_tool_call_count      INT,
+    ADD COLUMN spiral_message_count        INT,
+    ADD COLUMN spiral_ping_pong_len        INT,
+    ADD COLUMN spiral_steps_since_progress INT,
+    ADD COLUMN spiral_edit_attempted       BOOLEAN,
+    ADD COLUMN spiral_reasons              VARCHAR[],
+    ADD CONSTRAINT model_router_request_telemetry_turn_signals_privacy_check CHECK (
+        (
+            num_nonnulls(
+                spiral_err_streak,
+                spiral_errored_results,
+                spiral_tool_results,
+                spiral_max_same_file_edits,
+                spiral_repeat_frac,
+                spiral_monologue_len,
+                spiral_tool_call_count,
+                spiral_message_count,
+                spiral_ping_pong_len,
+                spiral_steps_since_progress,
+                spiral_edit_attempted,
+                spiral_reasons
+            ) = 0
+            AND spiral_same_file_path_hash IS NULL
+        )
+        OR (
+            training_allowed
+            AND capture_mode IN ('hashed', 'full')
+            AND num_nonnulls(
+                spiral_err_streak,
+                spiral_errored_results,
+                spiral_tool_results,
+                spiral_max_same_file_edits,
+                spiral_repeat_frac,
+                spiral_monologue_len,
+                spiral_tool_call_count,
+                spiral_message_count,
+                spiral_ping_pong_len,
+                spiral_steps_since_progress,
+                spiral_edit_attempted,
+                spiral_reasons
+            ) = 12
+        )
+    );
+
+COMMENT ON COLUMN router.model_router_request_telemetry.spiral_err_streak IS 'Consecutive errored tool_results at the tail of history at request time';
+COMMENT ON COLUMN router.model_router_request_telemetry.spiral_errored_results IS 'Errored tool_results across the whole history at request time';
+COMMENT ON COLUMN router.model_router_request_telemetry.spiral_tool_results IS 'Total tool_results across the whole history at request time';
+COMMENT ON COLUMN router.model_router_request_telemetry.spiral_max_same_file_edits IS 'Edits targeting the single most-edited file path';
+COMMENT ON COLUMN router.model_router_request_telemetry.spiral_same_file_path_hash IS 'Truncated sha256 of the most-edited file path: confirms "the same file" across turns without persisting customer file names';
+COMMENT ON COLUMN router.model_router_request_telemetry.spiral_repeat_frac IS 'Fraction of the last 12 tool-call signatures that are duplicates; 0 before 12 calls exist';
+COMMENT ON COLUMN router.model_router_request_telemetry.spiral_monologue_len IS 'Consecutive tool-less assistant messages since the last real user input';
+COMMENT ON COLUMN router.model_router_request_telemetry.spiral_tool_call_count IS 'Assistant tool_use blocks across the whole history at request time';
+COMMENT ON COLUMN router.model_router_request_telemetry.spiral_message_count IS 'Messages in the inbound history at request time';
+COMMENT ON COLUMN router.model_router_request_telemetry.spiral_ping_pong_len IS 'Length of the trailing A/B/A/B alternation between exactly two tool-call signatures';
+COMMENT ON COLUMN router.model_router_request_telemetry.spiral_steps_since_progress IS 'Tool calls made since the last non-errored edit/write result; meaningless unless spiral_edit_attempted is true';
+COMMENT ON COLUMN router.model_router_request_telemetry.spiral_edit_attempted IS 'Whether the session has attempted any edit yet; qualifies spiral_steps_since_progress';
+COMMENT ON COLUMN router.model_router_request_telemetry.spiral_reasons IS 'Signal classes whose thresholds this turn crossed (err_streak, same_file_thrash, repetition, monologue, ping_pong, no_progress); empty array when the snapshot was recorded and nothing fired';
+
+-- Order recorded turns within a session without indexing excluded rows.
+CREATE INDEX model_router_request_telemetry_turn_signals_idx
+    ON router.model_router_request_telemetry (session_key, role, timestamp)
+    WHERE spiral_tool_call_count IS NOT NULL;
+
+COMMIT;

--- a/db/queries/model_router_request_telemetry.sql
+++ b/db/queries/model_router_request_telemetry.sql
@@ -120,7 +120,20 @@ INSERT INTO router.model_router_request_telemetry (
     authority_shadow_corrected_outcome,
     authority_shadow_corrected_savings_usd_micros,
     authority_shadow_stay_score,
-    authority_shadow_fresh_score
+    authority_shadow_fresh_score,
+    spiral_err_streak,
+    spiral_errored_results,
+    spiral_tool_results,
+    spiral_max_same_file_edits,
+    spiral_same_file_path_hash,
+    spiral_repeat_frac,
+    spiral_monologue_len,
+    spiral_tool_call_count,
+    spiral_message_count,
+    spiral_ping_pong_len,
+    spiral_steps_since_progress,
+    spiral_edit_attempted,
+    spiral_reasons
 ) VALUES (
     @installation_id::uuid,
     sqlc.narg('api_key_id')::uuid,
@@ -209,7 +222,20 @@ INSERT INTO router.model_router_request_telemetry (
     sqlc.narg('authority_shadow_corrected_outcome')::varchar,
     sqlc.narg('authority_shadow_corrected_savings_usd_micros')::bigint,
     sqlc.narg('authority_shadow_stay_score')::double precision,
-    sqlc.narg('authority_shadow_fresh_score')::double precision
+    sqlc.narg('authority_shadow_fresh_score')::double precision,
+    sqlc.narg('spiral_err_streak')::int,
+    sqlc.narg('spiral_errored_results')::int,
+    sqlc.narg('spiral_tool_results')::int,
+    sqlc.narg('spiral_max_same_file_edits')::int,
+    sqlc.narg('spiral_same_file_path_hash')::varchar,
+    sqlc.narg('spiral_repeat_frac')::double precision,
+    sqlc.narg('spiral_monologue_len')::int,
+    sqlc.narg('spiral_tool_call_count')::int,
+    sqlc.narg('spiral_message_count')::int,
+    sqlc.narg('spiral_ping_pong_len')::int,
+    sqlc.narg('spiral_steps_since_progress')::int,
+    sqlc.narg('spiral_edit_attempted')::boolean,
+    sqlc.narg('spiral_reasons')::varchar[]
 )
 ON CONFLICT (installation_id, request_id, span_type) DO NOTHING;
 

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -49,6 +49,7 @@ const (
 	KeyStruggleEscalationHoldout Key = "struggle_escalation_holdout_pct"
 	KeyStruggleEvidenceArming    Key = "struggle_evidence_arming"
 	KeySpiralShadowEnabled       Key = "spiral_shadow_enabled"
+	KeyTurnSignalCapture         Key = "turn_signal_capture_enabled"
 	KeyLoopEscalationEnabled     Key = "loop_escalation_enabled"
 	KeyLoopEscalationHoldoutPct  Key = "loop_escalation_holdout_pct"
 	KeyTextRepetitionBreak       Key = "text_repetition_break_enabled"
@@ -83,7 +84,7 @@ type Definition struct {
 // RegistryVersion changes whenever Registry's membership changes. Publish uses
 // it to make pruning safe during rolling deploys: a revision with an older
 // registry version may not delete definitions published by a newer revision.
-const RegistryVersion = 4
+const RegistryVersion = 5
 
 // Registry is the curated allowlist of flags that may carry a per-organization
 // override. It is deliberately explicit rather than derived from the env var
@@ -124,6 +125,13 @@ var Registry = []Definition{
 		EnvVar:         "ROUTER_SPIRAL_SHADOW_ENABLED",
 		Kind:           KindBool,
 		Description:    "Per-turn spiral detector (log-only).",
+		OrgOverridable: true,
+	},
+	{
+		Key:            KeyTurnSignalCapture,
+		EnvVar:         "ROUTER_TURN_SIGNAL_CAPTURE_ENABLED",
+		Kind:           KindBool,
+		Description:    "Persist the per-turn behavioral signal snapshot onto telemetry rows. Skipped regardless for installations that opted out of AI training or set content capture to off.",
 		OrgOverridable: true,
 	},
 	{

--- a/internal/postgres/telemetry.go
+++ b/internal/postgres/telemetry.go
@@ -175,6 +175,19 @@ func (r *TelemetryRepo) InsertRequestTelemetry(ctx context.Context, p proxy.Inse
 		AuthorityShadowCorrectedSavingsUsdMicros: int64PtrFromUSD(p.AuthorityShadowCorrectedSavingsUSD),
 		AuthorityShadowStayScore:                 p.AuthorityShadowStayScore,
 		AuthorityShadowFreshScore:                p.AuthorityShadowFreshScore,
+		SpiralErrStreak:                          p.SpiralErrStreak,
+		SpiralErroredResults:                     p.SpiralErroredResults,
+		SpiralToolResults:                        p.SpiralToolResults,
+		SpiralMaxSameFileEdits:                   p.SpiralMaxSameFileEdits,
+		SpiralSameFilePathHash:                   stringPtrOrNil(p.SpiralSameFilePathHash),
+		SpiralRepeatFrac:                         p.SpiralRepeatFrac,
+		SpiralMonologueLen:                       p.SpiralMonologueLen,
+		SpiralToolCallCount:                      p.SpiralToolCallCount,
+		SpiralMessageCount:                       p.SpiralMessageCount,
+		SpiralPingPongLen:                        p.SpiralPingPongLen,
+		SpiralStepsSinceProgress:                 p.SpiralStepsSinceProgress,
+		SpiralEditAttempted:                      p.SpiralEditAttempted,
+		SpiralReasons:                            p.SpiralReasons,
 	})
 }
 

--- a/internal/proxy/flag_resolution.go
+++ b/internal/proxy/flag_resolution.go
@@ -40,6 +40,12 @@ func (s *Service) ResolveSpiralShadowEnabled(ctx context.Context) bool {
 	return flags.BoolOr(ctx, flags.KeySpiralShadowEnabled, s.spiralShadowEnabled)
 }
 
+// ResolveTurnSignalCaptureEnabled reports whether per-turn behavioral
+// snapshots may be persisted. Installation privacy gates still take precedence.
+func (s *Service) ResolveTurnSignalCaptureEnabled(ctx context.Context) bool {
+	return flags.BoolOr(ctx, flags.KeyTurnSignalCapture, s.turnSignalCaptureEnabled)
+}
+
 // ResolveLoopEscalationEnabled reports whether a detected cyclic loop may
 // escalate the routed model. Detection telemetry is recorded either way.
 func (s *Service) ResolveLoopEscalationEnabled(ctx context.Context) bool {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -242,6 +242,10 @@ type Service struct {
 	// death-march signals; see spiral_detection.go). Defaults true — shadow mode
 	// changes no routing behavior.
 	spiralShadowEnabled bool
+
+	// turnSignalCaptureEnabled gates per-turn snapshots independently of the
+	// threshold-only shadow detector. Privacy gates always take precedence.
+	turnSignalCaptureEnabled bool
 	// textRepetitionBreakEnabled gates the enforcing assistant-text repetition
 	// detector (see text_repetition.go). Defaults true; kill switch is
 	// ROUTER_TEXT_REPETITION_BREAK_ENABLED.
@@ -1356,6 +1360,7 @@ func NewService(r router.Router, providerMap map[string]providers.Client, emitte
 		prefixTrimFreeSwitch:         true,
 		spiralTracker:                newSpiralTracker(),
 		spiralShadowEnabled:          true,
+		turnSignalCaptureEnabled:     true,
 		struggleTracker:              newStruggleTracker(),
 		struggleShadowEnabled:        true,
 		textRepetitionBreakEnabled:   true,
@@ -1600,6 +1605,13 @@ func (s *Service) WithLoopEscalationStore(store LoopEscalationStore) *Service {
 // cost if it ever misbehaves.
 func (s *Service) WithSpiralShadowConfig(enabled bool) *Service {
 	s.spiralShadowEnabled = enabled
+	return s
+}
+
+// WithTurnSignalCapture sets the per-turn signal persistence kill switch.
+// It cannot override installation privacy settings.
+func (s *Service) WithTurnSignalCapture(enabled bool) *Service {
+	s.turnSignalCaptureEnabled = enabled
 	return s
 }
 
@@ -2968,11 +2980,14 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		}
 	}
 
-	// Snapshot before env rewrites: shared by the shadow detector and the
-	// evidence-arming gate below, both of which must see the client-sent body.
+	// All consumers need the original client history. Track computation
+	// separately because no threshold crossing is still a measured result.
 	var inboundSpiralSignals spiralSignals
-	var inboundSpiralReasons []string
-	if s.ResolveSpiralShadowEnabled(ctx) || s.ResolveStruggleEvidenceArming(ctx) {
+	var inboundSpiralReasons []spiralReason
+	inboundSpiralComputed := s.ResolveSpiralShadowEnabled(ctx) ||
+		s.ResolveStruggleEvidenceArming(ctx) ||
+		s.ResolveTurnSignalCaptureEnabled(ctx)
+	if inboundSpiralComputed {
 		inboundSpiralSignals = computeSpiralSignals(env, feats.MessageCount)
 		inboundSpiralReasons = spiralReasons(inboundSpiralSignals)
 	}
@@ -3210,7 +3225,10 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			// Use the bindRequestLogger digest, not routeRes.SessionKey (zero
 			// with no pin store), so the spiral event's session_key matches the
 			// telemetry row's in every mode for the offline join.
-			s.handleSpiralShadow(ctx, inboundSpiralSignals, inboundSpiralReasons, installationID, sessionKey, role, decision.Model, string(tt))
+			trainingAllowed, _ := ctx.Value(PolicyTrainingAllowedContextKey{}).(bool)
+			s.handleSpiralShadow(ctx, inboundSpiralSignals, inboundSpiralReasons,
+				installationID, sessionKey, role, decision.Model, string(tt),
+				trainingAllowed, s.effectiveCaptureMode(ctx))
 		}
 	}
 
@@ -4252,6 +4270,14 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		}
 		applyPlannerTelemetry(&tel, routeRes)
 		applyAuthorityShadowTelemetry(&tel, routeRes)
+		// Hard-pinned turn types carry history shapes that mimic failure signals,
+		// so only the detector's trusted turn types enter the training corpus.
+		signalTurn := tt == turntype.MainLoop || tt == turntype.ToolResult
+		applyTurnSignalTelemetry(&tel, inboundSpiralSignals, inboundSpiralReasons,
+			inboundSpiralComputed && signalTurn,
+			s.ResolveTurnSignalCaptureEnabled(ctx),
+			obs.TrainingAllowed,
+			s.effectiveCaptureMode(ctx))
 		s.fireTelemetry(tel)
 	}
 

--- a/internal/proxy/spiral_detection.go
+++ b/internal/proxy/spiral_detection.go
@@ -56,15 +56,28 @@ const (
 	spiralNoProgressThreshold = 15
 )
 
+type spiralReason string
+
 // Spiral signal-class taxonomy. One event per (session, role, reason).
 const (
-	spiralReasonErrStreak      = "err_streak"
-	spiralReasonSameFileThrash = "same_file_thrash"
-	spiralReasonRepetition     = "repetition"
-	spiralReasonMonologue      = "monologue"
-	spiralReasonPingPong       = "ping_pong"
-	spiralReasonNoProgress     = "no_progress"
+	spiralReasonErrStreak      spiralReason = "err_streak"
+	spiralReasonSameFileThrash              = "same_file_thrash"
+	spiralReasonRepetition                  = "repetition"
+	spiralReasonMonologue                   = "monologue"
+	spiralReasonPingPong                    = "ping_pong"
+	spiralReasonNoProgress                  = "no_progress"
 )
+
+func spiralReasonStrings(reasons []spiralReason) []string {
+	if reasons == nil {
+		return nil
+	}
+	values := make([]string, len(reasons))
+	for i, reason := range reasons {
+		values[i] = string(reason)
+	}
+	return values
+}
 
 // SpiralShadowStore persists shadow spiral detections (router.spiral_shadow_events).
 // CountSpiralShadowEvents enforces the once-per-(session, reason) budget across replicas.
@@ -211,11 +224,11 @@ func stepsSinceProgress(outcomes []translate.ToolCallOutcome) (steps int, editAt
 
 // spiralReasons returns the signal classes whose thresholds the snapshot
 // crosses. Empty below the arming floor.
-func spiralReasons(s spiralSignals) []string {
+func spiralReasons(s spiralSignals) []spiralReason {
 	if s.toolCallCount < spiralMinToolCalls {
 		return nil
 	}
-	var reasons []string
+	var reasons []spiralReason
 	if s.errStats.TrailingErrStreak >= spiralErrStreakThreshold {
 		reasons = append(reasons, spiralReasonErrStreak)
 	}
@@ -266,16 +279,22 @@ func spiralFiredKey(sessionKey [sessionpin.SessionKeyLen]byte, role, reason stri
 func (s *Service) handleSpiralShadow(
 	ctx context.Context,
 	sig spiralSignals,
-	reasons []string,
+	reasons []spiralReason,
 	installationID uuid.UUID,
 	sessionKey [sessionpin.SessionKeyLen]byte,
 	role string,
 	routedModel string,
 	turnType string,
+	trainingAllowed bool,
+	capture ContentCaptureMode,
 ) {
+	if !turnSignalCaptureAllowed(trainingAllowed, capture) {
+		return
+	}
 	log := observability.FromContext(ctx)
 	for _, reason := range reasons {
-		key := spiralFiredKey(sessionKey, role, reason)
+		reasonText := string(reason)
+		key := spiralFiredKey(sessionKey, role, reasonText)
 		if _, seen := s.spiralTracker.fired.Get(key); seen {
 			continue
 		}
@@ -283,7 +302,7 @@ func (s *Service) handleSpiralShadow(
 		// Best-effort: a lookup failure proceeds — an extra row beats a
 		// lost one in shadow mode.
 		if s.spiralShadowStore != nil && installationID != uuid.Nil {
-			count, err := s.spiralShadowStore.CountSpiralShadowEvents(ctx, sessionKey[:], role, reason)
+			count, err := s.spiralShadowStore.CountSpiralShadowEvents(ctx, sessionKey[:], role, reasonText)
 			if err != nil {
 				log.Error("spiral-shadow: budget lookup failed", "err", err)
 			} else if count > 0 {
@@ -318,7 +337,7 @@ func (s *Service) handleSpiralShadow(
 				Role:               role,
 				RoutedModel:        routedModel,
 				TurnType:           turnType,
-				Reason:             reason,
+				Reason:             reasonText,
 				ErrStreak:          int32(sig.errStats.TrailingErrStreak),
 				ErroredResults:     int32(sig.errStats.Errored),
 				ToolResults:        int32(sig.errStats.Total),

--- a/internal/proxy/struggle_escalation.go
+++ b/internal/proxy/struggle_escalation.go
@@ -74,7 +74,7 @@ func (s *Service) handleStruggleEscalation(
 	installationID uuid.UUID,
 	sessionKey [sessionpin.SessionKeyLen]byte,
 	role string,
-	evidence []string,
+	evidence []spiralReason,
 ) {
 	log := observability.FromContext(ctx)
 
@@ -204,11 +204,12 @@ func (s *Service) handleStruggleEscalation(
 		}
 	}
 
+	evidenceReasons := spiralReasonStrings(evidence)
 	log.Info("router.struggle_escalation",
 		"struggling_model", strugglingModel,
 		"action", action,
 		"arming_mode", armingMode,
-		"evidence_reasons", evidence,
+		"evidence_reasons", evidenceReasons,
 		"escalation_target", escalationTarget,
 		"escalation_cluster", escalationCluster,
 		"user_forced", userForced,
@@ -232,7 +233,7 @@ func (s *Service) handleStruggleEscalation(
 			WallSeconds:         int64(wall.Seconds()),
 			SessionEverSwitched: pin.HasEverSwitched,
 			ArmingMode:          armingMode,
-			EvidenceReasons:     evidence,
+			EvidenceReasons:     evidenceReasons,
 		}
 		if err := s.struggleEscalationStore.InsertStruggleEscalationEvent(context.Background(), event); err != nil {
 			log.Error("struggle-escalation: event insert failed", "err", err)

--- a/internal/proxy/struggle_escalation_internal_test.go
+++ b/internal/proxy/struggle_escalation_internal_test.go
@@ -186,7 +186,7 @@ func TestHandleStruggleEscalation_EvidenceIsInertWhileTheFlagIsOff(t *testing.T)
 	})
 
 	svc.handleStruggleEscalation(context.Background(), uuid.New(), struggleTestKey(3), "default",
-		[]string{spiralReasonPingPong})
+		[]spiralReason{spiralReasonPingPong})
 
 	assert.Empty(t, pins.upserts, "evidence must not repin until the arming flag is on")
 	assert.Empty(t, events.events)
@@ -203,14 +203,14 @@ func TestHandleStruggleEscalation_EvidenceArmsBeforeTheThresholds(t *testing.T) 
 	}).WithStruggleEvidenceArming(true)
 
 	svc.handleStruggleEscalation(context.Background(), uuid.New(), struggleTestKey(4), "default",
-		[]string{spiralReasonPingPong, spiralReasonNoProgress})
+		[]spiralReason{spiralReasonPingPong, spiralReasonNoProgress})
 
 	require.Len(t, pins.upserts, 1)
 	assert.Equal(t, "claude-opus-5", pins.upserts[0].Model)
 
 	require.Len(t, events.events, 1)
 	assert.Equal(t, struggleArmingEvidence, events.events[0].ArmingMode)
-	assert.Equal(t, []string{spiralReasonPingPong, spiralReasonNoProgress}, events.events[0].EvidenceReasons)
+	assert.Equal(t, []string{string(spiralReasonPingPong), string(spiralReasonNoProgress)}, events.events[0].EvidenceReasons)
 }
 
 func TestHandleStruggleEscalation_EvidenceStaysOffTheOpeningTurns(t *testing.T) {
@@ -226,7 +226,7 @@ func TestHandleStruggleEscalation_EvidenceStaysOffTheOpeningTurns(t *testing.T) 
 	}).WithStruggleEvidenceArming(true)
 
 	svc.handleStruggleEscalation(context.Background(), uuid.New(), struggleTestKey(5), "default",
-		[]string{spiralReasonPingPong})
+		[]spiralReason{spiralReasonPingPong})
 
 	assert.Empty(t, pins.upserts, "an imported history must not repin on turn one")
 	assert.Empty(t, events.events)
@@ -246,7 +246,7 @@ func TestHandleStruggleEscalation_EvidenceCannotArmALateSession(t *testing.T) {
 	}).WithStruggleEvidenceArming(true)
 
 	svc.handleStruggleEscalation(context.Background(), uuid.New(), struggleTestKey(7), "default",
-		[]string{spiralReasonPingPong})
+		[]spiralReason{spiralReasonPingPong})
 
 	assert.Empty(t, pins.upserts, "late is deliberately unarmed; evidence must not smuggle it in")
 	assert.Empty(t, events.events)
@@ -263,7 +263,7 @@ func TestHandleStruggleEscalation_TimerArmingKeepsItsAttribution(t *testing.T) {
 	}).WithStruggleEvidenceArming(true)
 
 	svc.handleStruggleEscalation(context.Background(), uuid.New(), struggleTestKey(6), "default",
-		[]string{spiralReasonErrStreak})
+		[]spiralReason{spiralReasonErrStreak})
 
 	require.Len(t, events.events, 1)
 	assert.Equal(t, struggleArmingTurnWall, events.events[0].ArmingMode,

--- a/internal/proxy/telemetry.go
+++ b/internal/proxy/telemetry.go
@@ -174,9 +174,8 @@ type InsertTelemetryParams struct {
 	AuthorityShadowStayScore           *float64
 	AuthorityShadowFreshScore          *float64
 
-	// Spiral* is written as a nullable group: nil means not recorded, while zero
-	// is measured. The group supplies both classes for escalation training;
-	// spiral_shadow_events retains threshold crossings only.
+	// Spiral* fields are a nullable group: nil = not recorded, zero = measured;
+	// spiral_shadow_events holds threshold crossings only.
 	SpiralErrStreak          *int32
 	SpiralErroredResults     *int32
 	SpiralToolResults        *int32
@@ -315,16 +314,14 @@ func applyAuthorityShadowTelemetry(p *InsertTelemetryParams, res turnLoopResult)
 	p.AuthorityShadowCorrectedSavingsUSD = &corrected
 }
 
-// turnSignalCaptureAllowed requires both independent privacy settings. AI
-// training defaults false, and CaptureOff is both the zero-retention posture
-// and the fallback for an invalid capture mode, so both fail closed.
+// turnSignalCaptureAllowed requires both privacy gates. CaptureOff is the
+// fallback for an unknown mode, so both gates fail closed by default.
 func turnSignalCaptureAllowed(trainingAllowed bool, capture ContentCaptureMode) bool {
 	return trainingAllowed && (capture == CaptureHashed || capture == CaptureFull)
 }
 
-// applyTurnSignalTelemetry writes every value together after checking the
-// feature flag and both privacy settings. This preserves the difference between
-// a measured zero and an absent snapshot.
+// applyTurnSignalTelemetry fills p only when all gates pass, preserving
+// the distinction between a measured zero and an absent snapshot.
 func applyTurnSignalTelemetry(
 	p *InsertTelemetryParams,
 	sig spiralSignals,

--- a/internal/proxy/telemetry.go
+++ b/internal/proxy/telemetry.go
@@ -173,6 +173,24 @@ type InsertTelemetryParams struct {
 	AuthorityShadowCorrectedSavingsUSD *float64
 	AuthorityShadowStayScore           *float64
 	AuthorityShadowFreshScore          *float64
+
+	// Spiral* is written as a nullable group: nil means not recorded, while zero
+	// is measured. The group supplies both classes for escalation training;
+	// spiral_shadow_events retains threshold crossings only.
+	SpiralErrStreak          *int32
+	SpiralErroredResults     *int32
+	SpiralToolResults        *int32
+	SpiralMaxSameFileEdits   *int32
+	SpiralSameFilePathHash   string
+	SpiralRepeatFrac         *float64
+	SpiralMonologueLen       *int32
+	SpiralToolCallCount      *int32
+	SpiralMessageCount       *int32
+	SpiralPingPongLen        *int32
+	SpiralStepsSinceProgress *int32
+	SpiralEditAttempted      *bool
+	// SpiralReasons is non-nil and empty for a recorded turn with no crossings.
+	SpiralReasons []string
 }
 
 // TelemetrySummary holds aggregated totals for the dashboard cards.
@@ -295,4 +313,50 @@ func applyAuthorityShadowTelemetry(p *InsertTelemetryParams, res turnLoopResult)
 	p.AuthorityShadowCorrectedOutcome = plannerOutcome(shadow.Decision.ShadowOutcome)
 	corrected := shadow.Decision.ShadowExpectedSavingsUSD
 	p.AuthorityShadowCorrectedSavingsUSD = &corrected
+}
+
+// turnSignalCaptureAllowed requires both independent privacy settings. AI
+// training defaults false, and CaptureOff is both the zero-retention posture
+// and the fallback for an invalid capture mode, so both fail closed.
+func turnSignalCaptureAllowed(trainingAllowed bool, capture ContentCaptureMode) bool {
+	return trainingAllowed && (capture == CaptureHashed || capture == CaptureFull)
+}
+
+// applyTurnSignalTelemetry writes every value together after checking the
+// feature flag and both privacy settings. This preserves the difference between
+// a measured zero and an absent snapshot.
+func applyTurnSignalTelemetry(
+	p *InsertTelemetryParams,
+	sig spiralSignals,
+	reasons []spiralReason,
+	computed bool,
+	enabled bool,
+	trainingAllowed bool,
+	capture ContentCaptureMode,
+) {
+	if p == nil || !computed || !enabled || !turnSignalCaptureAllowed(trainingAllowed, capture) {
+		return
+	}
+	p.SpiralErrStreak = int32Ptr(int32(sig.errStats.TrailingErrStreak))
+	p.SpiralErroredResults = int32Ptr(int32(sig.errStats.Errored))
+	p.SpiralToolResults = int32Ptr(int32(sig.errStats.Total))
+	p.SpiralMaxSameFileEdits = int32Ptr(int32(sig.maxSameFileEdits))
+	p.SpiralSameFilePathHash = sig.sameFilePathHash
+	repeatFrac := sig.repeatFrac
+	p.SpiralRepeatFrac = &repeatFrac
+	p.SpiralMonologueLen = int32Ptr(int32(sig.monologueLen))
+	p.SpiralToolCallCount = int32Ptr(int32(sig.toolCallCount))
+	p.SpiralMessageCount = int32Ptr(int32(sig.messageCount))
+	p.SpiralPingPongLen = int32Ptr(int32(sig.pingPongLen))
+	p.SpiralStepsSinceProgress = int32Ptr(int32(sig.stepsSinceProgress))
+	editAttempted := sig.editAttempted
+	p.SpiralEditAttempted = &editAttempted
+	if reasons == nil {
+		reasons = []spiralReason{}
+	}
+	p.SpiralReasons = spiralReasonStrings(reasons)
+}
+
+func int32Ptr(v int32) *int32 {
+	return &v
 }

--- a/internal/proxy/turn_signal_telemetry_internal_test.go
+++ b/internal/proxy/turn_signal_telemetry_internal_test.go
@@ -1,0 +1,169 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+
+	"workweave/router/internal/translate"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTurnSignalCaptureAllowed(t *testing.T) {
+	tests := []struct {
+		name            string
+		trainingAllowed bool
+		capture         ContentCaptureMode
+		want            bool
+	}{
+		{"full capture and training allowed", true, CaptureFull, true},
+		{"hashed capture and training allowed", true, CaptureHashed, true},
+		{"AI training opted out", false, CaptureFull, false},
+		{"zero retention", true, CaptureOff, false},
+		{"neither allowed", false, CaptureOff, false},
+		{"unknown capture mode", true, ContentCaptureMode(99), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, turnSignalCaptureAllowed(tc.trainingAllowed, tc.capture))
+		})
+	}
+}
+
+func TestTurnSignalCaptureAllowed_FailsClosedOnDefaults(t *testing.T) {
+	assert.False(t, turnSignalCaptureAllowed(false, ParseCaptureMode("")))
+}
+
+func sampleSignals() spiralSignals {
+	return spiralSignals{
+		errStats: translate.ToolResultErrorStats{
+			Total:             23,
+			Errored:           11,
+			TrailingErrStreak: 4,
+		},
+		maxSameFileEdits:   7,
+		sameFilePathHash:   "a1b2c3d4e5f60718",
+		repeatFrac:         0.42,
+		monologueLen:       3,
+		toolCallCount:      31,
+		messageCount:       64,
+		pingPongLen:        8,
+		stepsSinceProgress: 19,
+		editAttempted:      true,
+	}
+}
+
+func TestApplyTurnSignalTelemetry_CopiesFullSnapshot(t *testing.T) {
+	var telemetry InsertTelemetryParams
+	reasons := []spiralReason{spiralReasonErrStreak, spiralReasonPingPong}
+	applyTurnSignalTelemetry(&telemetry, sampleSignals(), reasons, true, true, true, CaptureFull)
+
+	assertInt32Ptr := func(field string, got *int32, want int32) {
+		t.Helper()
+		require.NotNil(t, got, field)
+		assert.Equal(t, want, *got, field)
+	}
+	assertInt32Ptr("SpiralErrStreak", telemetry.SpiralErrStreak, 4)
+	assertInt32Ptr("SpiralErroredResults", telemetry.SpiralErroredResults, 11)
+	assertInt32Ptr("SpiralToolResults", telemetry.SpiralToolResults, 23)
+	assertInt32Ptr("SpiralMaxSameFileEdits", telemetry.SpiralMaxSameFileEdits, 7)
+	assertInt32Ptr("SpiralMonologueLen", telemetry.SpiralMonologueLen, 3)
+	assertInt32Ptr("SpiralToolCallCount", telemetry.SpiralToolCallCount, 31)
+	assertInt32Ptr("SpiralMessageCount", telemetry.SpiralMessageCount, 64)
+	assertInt32Ptr("SpiralPingPongLen", telemetry.SpiralPingPongLen, 8)
+	assertInt32Ptr("SpiralStepsSinceProgress", telemetry.SpiralStepsSinceProgress, 19)
+	assert.Equal(t, "a1b2c3d4e5f60718", telemetry.SpiralSameFilePathHash)
+	require.NotNil(t, telemetry.SpiralRepeatFrac)
+	assert.Equal(t, 0.42, *telemetry.SpiralRepeatFrac)
+	require.NotNil(t, telemetry.SpiralEditAttempted)
+	assert.True(t, *telemetry.SpiralEditAttempted)
+	assert.Equal(t, []string{string(spiralReasonErrStreak), string(spiralReasonPingPong)}, telemetry.SpiralReasons)
+}
+
+func TestApplyTurnSignalTelemetry_QuietTurnRecordsZeros(t *testing.T) {
+	var telemetry InsertTelemetryParams
+	applyTurnSignalTelemetry(&telemetry, spiralSignals{}, nil, true, true, true, CaptureFull)
+
+	require.NotNil(t, telemetry.SpiralErrStreak)
+	assert.Zero(t, *telemetry.SpiralErrStreak)
+	require.NotNil(t, telemetry.SpiralToolCallCount)
+	assert.Zero(t, *telemetry.SpiralToolCallCount)
+	require.NotNil(t, telemetry.SpiralEditAttempted)
+	assert.False(t, *telemetry.SpiralEditAttempted)
+	require.NotNil(t, telemetry.SpiralReasons)
+	assert.Empty(t, telemetry.SpiralReasons)
+}
+
+func TestApplyTurnSignalTelemetry_SkipsIneligibleTurns(t *testing.T) {
+	tests := []struct {
+		name            string
+		computed        bool
+		enabled         bool
+		trainingAllowed bool
+		capture         ContentCaptureMode
+	}{
+		{"AI training opted out", true, true, false, CaptureFull},
+		{"zero retention", true, true, true, CaptureOff},
+		{"capture disabled", true, false, true, CaptureFull},
+		{"snapshot not computed", false, true, true, CaptureFull},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var telemetry InsertTelemetryParams
+			applyTurnSignalTelemetry(&telemetry, sampleSignals(), []spiralReason{spiralReasonErrStreak},
+				tc.computed, tc.enabled, tc.trainingAllowed, tc.capture)
+
+			assert.Nil(t, telemetry.SpiralErrStreak)
+			assert.Nil(t, telemetry.SpiralToolCallCount)
+			assert.Nil(t, telemetry.SpiralRepeatFrac)
+			assert.Nil(t, telemetry.SpiralEditAttempted)
+			assert.Empty(t, telemetry.SpiralSameFilePathHash)
+			assert.Nil(t, telemetry.SpiralReasons)
+		})
+	}
+}
+
+func TestApplyTurnSignalTelemetry_NilParamsIsNoOp(t *testing.T) {
+	assert.NotPanics(t, func() {
+		applyTurnSignalTelemetry(nil, sampleSignals(), nil, true, true, true, CaptureFull)
+	})
+}
+
+type recordingSpiralStore struct {
+	events []SpiralShadowEvent
+}
+
+func (s *recordingSpiralStore) InsertSpiralShadowEvent(_ context.Context, event SpiralShadowEvent) error {
+	s.events = append(s.events, event)
+	return nil
+}
+
+func (s *recordingSpiralStore) CountSpiralShadowEvents(_ context.Context, _ []byte, _, _ string) (int64, error) {
+	return 0, nil
+}
+
+func TestHandleSpiralShadow_RespectsPrivacySettings(t *testing.T) {
+	tests := []struct {
+		name            string
+		trainingAllowed bool
+		capture         ContentCaptureMode
+		wantEvents      int
+	}{
+		{"allowed", true, CaptureFull, 1},
+		{"AI training opted out", false, CaptureFull, 0},
+		{"zero retention", true, CaptureOff, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &recordingSpiralStore{}
+			service := &Service{spiralTracker: newSpiralTracker(), spiralShadowStore: store}
+			var sessionKey [16]byte
+			service.handleSpiralShadow(context.Background(), sampleSignals(),
+				[]spiralReason{spiralReasonErrStreak}, uuid.New(), sessionKey,
+				"default", "test-model", "tool_result", tc.trainingAllowed, tc.capture)
+			assert.Len(t, store.events, tc.wantEvents)
+		})
+	}
+}

--- a/internal/sqlc/model_router_request_telemetry.sql.go
+++ b/internal/sqlc/model_router_request_telemetry.sql.go
@@ -1792,7 +1792,20 @@ INSERT INTO router.model_router_request_telemetry (
     authority_shadow_corrected_outcome,
     authority_shadow_corrected_savings_usd_micros,
     authority_shadow_stay_score,
-    authority_shadow_fresh_score
+    authority_shadow_fresh_score,
+    spiral_err_streak,
+    spiral_errored_results,
+    spiral_tool_results,
+    spiral_max_same_file_edits,
+    spiral_same_file_path_hash,
+    spiral_repeat_frac,
+    spiral_monologue_len,
+    spiral_tool_call_count,
+    spiral_message_count,
+    spiral_ping_pong_len,
+    spiral_steps_since_progress,
+    spiral_edit_attempted,
+    spiral_reasons
 ) VALUES (
     $1::uuid,
     $2::uuid,
@@ -1881,7 +1894,20 @@ INSERT INTO router.model_router_request_telemetry (
     $85::varchar,
     $86::bigint,
     $87::double precision,
-    $88::double precision
+    $88::double precision,
+    $89::int,
+    $90::int,
+    $91::int,
+    $92::int,
+    $93::varchar,
+    $94::double precision,
+    $95::int,
+    $96::int,
+    $97::int,
+    $98::int,
+    $99::int,
+    $100::boolean,
+    $101::varchar[]
 )
 ON CONFLICT (installation_id, request_id, span_type) DO NOTHING
 `
@@ -1975,6 +2001,19 @@ type InsertRequestTelemetryParams struct {
 	AuthorityShadowCorrectedSavingsUsdMicros *int64
 	AuthorityShadowStayScore                 *float64
 	AuthorityShadowFreshScore                *float64
+	SpiralErrStreak                          *int32
+	SpiralErroredResults                     *int32
+	SpiralToolResults                        *int32
+	SpiralMaxSameFileEdits                   *int32
+	SpiralSameFilePathHash                   *string
+	SpiralRepeatFrac                         *float64
+	SpiralMonologueLen                       *int32
+	SpiralToolCallCount                      *int32
+	SpiralMessageCount                       *int32
+	SpiralPingPongLen                        *int32
+	SpiralStepsSinceProgress                 *int32
+	SpiralEditAttempted                      *bool
+	SpiralReasons                            []string
 }
 
 // Records a completed proxied request for the dashboard UI and routing
@@ -2099,7 +2138,20 @@ type InsertRequestTelemetryParams struct {
 //	    authority_shadow_corrected_outcome,
 //	    authority_shadow_corrected_savings_usd_micros,
 //	    authority_shadow_stay_score,
-//	    authority_shadow_fresh_score
+//	    authority_shadow_fresh_score,
+//	    spiral_err_streak,
+//	    spiral_errored_results,
+//	    spiral_tool_results,
+//	    spiral_max_same_file_edits,
+//	    spiral_same_file_path_hash,
+//	    spiral_repeat_frac,
+//	    spiral_monologue_len,
+//	    spiral_tool_call_count,
+//	    spiral_message_count,
+//	    spiral_ping_pong_len,
+//	    spiral_steps_since_progress,
+//	    spiral_edit_attempted,
+//	    spiral_reasons
 //	) VALUES (
 //	    $1::uuid,
 //	    $2::uuid,
@@ -2188,7 +2240,20 @@ type InsertRequestTelemetryParams struct {
 //	    $85::varchar,
 //	    $86::bigint,
 //	    $87::double precision,
-//	    $88::double precision
+//	    $88::double precision,
+//	    $89::int,
+//	    $90::int,
+//	    $91::int,
+//	    $92::int,
+//	    $93::varchar,
+//	    $94::double precision,
+//	    $95::int,
+//	    $96::int,
+//	    $97::int,
+//	    $98::int,
+//	    $99::int,
+//	    $100::boolean,
+//	    $101::varchar[]
 //	)
 //	ON CONFLICT (installation_id, request_id, span_type) DO NOTHING
 func (q *Queries) InsertRequestTelemetry(ctx context.Context, arg InsertRequestTelemetryParams) error {
@@ -2281,6 +2346,19 @@ func (q *Queries) InsertRequestTelemetry(ctx context.Context, arg InsertRequestT
 		arg.AuthorityShadowCorrectedSavingsUsdMicros,
 		arg.AuthorityShadowStayScore,
 		arg.AuthorityShadowFreshScore,
+		arg.SpiralErrStreak,
+		arg.SpiralErroredResults,
+		arg.SpiralToolResults,
+		arg.SpiralMaxSameFileEdits,
+		arg.SpiralSameFilePathHash,
+		arg.SpiralRepeatFrac,
+		arg.SpiralMonologueLen,
+		arg.SpiralToolCallCount,
+		arg.SpiralMessageCount,
+		arg.SpiralPingPongLen,
+		arg.SpiralStepsSinceProgress,
+		arg.SpiralEditAttempted,
+		arg.SpiralReasons,
 	)
 	return err
 }

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -278,6 +278,32 @@ type RouterModelRouterRequestTelemetry struct {
 	AuthorityShadowFreshScore *float64
 	// The actual served-path pin tier for this turn (for example, authoritative_per_turn or hmm_ev_stay_ev_negative). NULL on rows written before this column existed or when no turn-loop tier was available.
 	PinTier *string
+	// Consecutive errored tool_results at the tail of history at request time
+	SpiralErrStreak *int32
+	// Errored tool_results across the whole history at request time
+	SpiralErroredResults *int32
+	// Total tool_results across the whole history at request time
+	SpiralToolResults *int32
+	// Edits targeting the single most-edited file path
+	SpiralMaxSameFileEdits *int32
+	// Truncated sha256 of the most-edited file path: confirms "the same file" across turns without persisting customer file names
+	SpiralSameFilePathHash *string
+	// Fraction of the last 12 tool-call signatures that are duplicates; 0 before 12 calls exist
+	SpiralRepeatFrac *float64
+	// Consecutive tool-less assistant messages since the last real user input
+	SpiralMonologueLen *int32
+	// Assistant tool_use blocks across the whole history at request time
+	SpiralToolCallCount *int32
+	// Messages in the inbound history at request time
+	SpiralMessageCount *int32
+	// Length of the trailing A/B/A/B alternation between exactly two tool-call signatures
+	SpiralPingPongLen *int32
+	// Tool calls made since the last non-errored edit/write result; meaningless unless spiral_edit_attempted is true
+	SpiralStepsSinceProgress *int32
+	// Whether the session has attempted any edit yet; qualifies spiral_steps_since_progress
+	SpiralEditAttempted *bool
+	// Signal classes whose thresholds this turn crossed (err_streak, same_file_thrash, repetition, monologue, ping_pong, no_progress); empty array when the snapshot was recorded and nothing fired
+	SpiralReasons []string
 }
 
 // End-user identities seen on inbound requests, scoped to an installation. Replaces the per-user API key pattern.


### PR DESCRIPTION
Store the already-computed spiral snapshot on eligible telemetry rows so
quiet turns become the negative class, instead of only keeping threshold
crossings in spiral_shadow_events.

Skip storage for installations that opted out of AI training or set
content capture to off, and enforce the same gate in the database.

Co-Authored-By: Weave Router <router@workweave.ai>