### PR TITLE
feat(codex): report per-turn tokens and savings in the response

### DIFF
--- a/internal/proxy/codex_receipt.go
+++ b/internal/proxy/codex_receipt.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -20,7 +21,15 @@ type codexReceiptPricing struct {
 	hasActualPricing bool
 }
 
-func codexReceiptTurn(clientApp string, tt turntype.TurnType) bool {
+func (p *codexReceiptPricing) setActual(provider, model string) {
+	p.provider = provider
+	p.actualPricing, p.hasActualPricing = catalog.PriceFor(provider, model)
+}
+
+func codexReceiptTurn(ctx context.Context, clientApp string, tt turntype.TurnType) bool {
+	if hideTerminalSurfacesForRequest(ctx) {
+		return false
+	}
 	return clientApp == ClientAppCodex && (tt == turntype.MainLoop || tt == turntype.ToolResult)
 }
 

--- a/internal/proxy/codex_receipt.go
+++ b/internal/proxy/codex_receipt.go
@@ -5,42 +5,30 @@ import (
 	"strings"
 
 	"workweave/router/internal/router/catalog"
+	"workweave/router/internal/router/turntype"
 	"workweave/router/internal/translate"
 )
 
-// Codex renders a turn's own token counts from what it asked for, never from
-// what the router served, so a routed turn's real cost is invisible in the
-// client: the footer keeps showing the requested model. The receipt closes that
-// gap by reporting the served turn's tokens and what routing saved against the
-// model the client would otherwise have paid for.
 const (
-	// Marks the receipt so the next inbound turn strips it back out — the same
-	// contract the routing badge and feedback footer rely on. Without it the
-	// receipt accumulates in the prompt history it is describing.
-	codexReceiptPrefix = "\n\n↳ Weave Router · "
-
-	// Below this the "saved" clause is dropped rather than rounded to $0.00,
-	// which reads as "routing bought you nothing" instead of "the win was
-	// smaller than a cent".
+	codexReceiptPrefix        = "\n\n↳ Weave Router · "
 	codexReceiptMinSavingsUSD = 0.005
 )
 
-// codexReceiptRenderer returns a renderer for the per-turn receipt, or nil when
-// this turn should not carry one.
-//
-// requestedPricing is the client's own model, actualPricing the model that
-// served. Passing the same pricing for both is not a bug to guard against here
-// — it yields no savings clause, which is the correct rendering for a turn the
-// router left on the requested model.
+type codexReceiptPricing struct {
+	actualPricing    catalog.Pricing
+	provider         string
+	hasActualPricing bool
+}
+
+func codexReceiptTurn(clientApp string, tt turntype.TurnType) bool {
+	return clientApp == ClientAppCodex && (tt == turntype.MainLoop || tt == turntype.ToolResult)
+}
+
 func codexReceiptRenderer(
 	requestedPricing catalog.Pricing,
-	actualPricing catalog.Pricing,
-	provider string,
+	pricing *codexReceiptPricing,
 ) func(translate.ResponsesReceiptUsage) string {
 	return func(usage translate.ResponsesReceiptUsage) string {
-		// An upstream that reported no usage gives us nothing to render, and a
-		// receipt reading "0 in / 0 out" would be a lie about a turn that did
-		// consume tokens.
 		if !usage.HasUsage || (usage.InputTokens <= 0 && usage.OutputTokens <= 0) {
 			return ""
 		}
@@ -52,11 +40,13 @@ func codexReceiptRenderer(
 			formatReceiptTokens(usage.OutputTokens),
 		)
 
-		if clause := receiptSavingsClause(
-			requestedPricing, actualPricing, provider,
-			usage.InputTokens, usage.OutputTokens, usage.CacheReadTokens,
-		); clause != "" {
-			b.WriteString(clause)
+		if pricing.hasActualPricing {
+			if clause := receiptSavingsClause(
+				requestedPricing, pricing.actualPricing, pricing.provider,
+				usage.InputTokens, usage.OutputTokens, usage.CacheReadTokens,
+			); clause != "" {
+				b.WriteString(clause)
+			}
 		}
 
 		return b.String()
@@ -65,12 +55,6 @@ func codexReceiptRenderer(
 
 // receiptSavingsClause renders the savings for one turn, or "" when there is
 // nothing worth claiming.
-//
-// Both sides price the SAME served token counts: the comparison is "what this
-// turn's work would have cost on the requested model", not a guess at how many
-// tokens that model would have used. Cache tokens flow through
-// EffectiveInputCost so a cache-heavy turn is not credited with savings it did
-// not earn.
 func receiptSavingsClause(
 	requestedPricing catalog.Pricing,
 	actualPricing catalog.Pricing,
@@ -80,9 +64,6 @@ func receiptSavingsClause(
 	cacheRead int64,
 ) string {
 	in, out := int(inputTokens), int(outputTokens)
-	// EffectiveInputCost takes the TOTAL prompt and nets out the cached portion
-	// itself, so pass the upstream's numbers through unmodified. Pre-subtracting
-	// here would discount the cached tokens twice.
 	read := min(int(cacheRead), in)
 
 	requested := catalog.EffectiveInputCost(in, 0, read, requestedPricing.InputUSDPer1M, requestedPricing, provider) +
@@ -90,9 +71,6 @@ func receiptSavingsClause(
 	actual := catalog.EffectiveInputCost(in, 0, read, actualPricing.InputUSDPer1M, actualPricing, provider) +
 		catalog.EffectiveOutputCost(out, actualPricing.OutputUSDPer1M)
 
-	// A negative delta means routing deliberately bought a pricier model for
-	// quality. Reporting "saved -$0.02" invites the reader to conclude the
-	// router malfunctioned, so the clause is omitted instead.
 	saved := requested - actual
 	if saved < codexReceiptMinSavingsUSD {
 		return ""
@@ -100,8 +78,6 @@ func receiptSavingsClause(
 	return fmt.Sprintf(" · saved $%.2f", saved)
 }
 
-// formatReceiptTokens renders a token count compactly enough to sit in one
-// status line: exact below 1k, then one decimal place.
 func formatReceiptTokens(tokens int64) string {
 	if tokens < 0 {
 		return "0"

--- a/internal/proxy/codex_receipt.go
+++ b/internal/proxy/codex_receipt.go
@@ -1,0 +1,113 @@
+package proxy
+
+import (
+	"fmt"
+	"strings"
+
+	"workweave/router/internal/router/catalog"
+	"workweave/router/internal/translate"
+)
+
+// Codex renders a turn's own token counts from what it asked for, never from
+// what the router served, so a routed turn's real cost is invisible in the
+// client: the footer keeps showing the requested model. The receipt closes that
+// gap by reporting the served turn's tokens and what routing saved against the
+// model the client would otherwise have paid for.
+const (
+	// Marks the receipt so the next inbound turn strips it back out — the same
+	// contract the routing badge and feedback footer rely on. Without it the
+	// receipt accumulates in the prompt history it is describing.
+	codexReceiptPrefix = "\n\n↳ Weave Router · "
+
+	// Below this the "saved" clause is dropped rather than rounded to $0.00,
+	// which reads as "routing bought you nothing" instead of "the win was
+	// smaller than a cent".
+	codexReceiptMinSavingsUSD = 0.005
+)
+
+// codexReceiptRenderer returns a renderer for the per-turn receipt, or nil when
+// this turn should not carry one.
+//
+// requestedPricing is the client's own model, actualPricing the model that
+// served. Passing the same pricing for both is not a bug to guard against here
+// — it yields no savings clause, which is the correct rendering for a turn the
+// router left on the requested model.
+func codexReceiptRenderer(
+	requestedPricing catalog.Pricing,
+	actualPricing catalog.Pricing,
+	provider string,
+) func(translate.ResponsesReceiptUsage) string {
+	return func(usage translate.ResponsesReceiptUsage) string {
+		// An upstream that reported no usage gives us nothing to render, and a
+		// receipt reading "0 in / 0 out" would be a lie about a turn that did
+		// consume tokens.
+		if !usage.HasUsage || (usage.InputTokens <= 0 && usage.OutputTokens <= 0) {
+			return ""
+		}
+
+		var b strings.Builder
+		b.WriteString(codexReceiptPrefix)
+		fmt.Fprintf(&b, "%s in / %s out",
+			formatReceiptTokens(usage.InputTokens),
+			formatReceiptTokens(usage.OutputTokens),
+		)
+
+		if clause := receiptSavingsClause(
+			requestedPricing, actualPricing, provider,
+			usage.InputTokens, usage.OutputTokens, usage.CacheReadTokens,
+		); clause != "" {
+			b.WriteString(clause)
+		}
+
+		return b.String()
+	}
+}
+
+// receiptSavingsClause renders the savings for one turn, or "" when there is
+// nothing worth claiming.
+//
+// Both sides price the SAME served token counts: the comparison is "what this
+// turn's work would have cost on the requested model", not a guess at how many
+// tokens that model would have used. Cache tokens flow through
+// EffectiveInputCost so a cache-heavy turn is not credited with savings it did
+// not earn.
+func receiptSavingsClause(
+	requestedPricing catalog.Pricing,
+	actualPricing catalog.Pricing,
+	provider string,
+	inputTokens int64,
+	outputTokens int64,
+	cacheRead int64,
+) string {
+	in, out := int(inputTokens), int(outputTokens)
+	// EffectiveInputCost takes the TOTAL prompt and nets out the cached portion
+	// itself, so pass the upstream's numbers through unmodified. Pre-subtracting
+	// here would discount the cached tokens twice.
+	read := min(int(cacheRead), in)
+
+	requested := catalog.EffectiveInputCost(in, 0, read, requestedPricing.InputUSDPer1M, requestedPricing, provider) +
+		catalog.EffectiveOutputCost(out, requestedPricing.OutputUSDPer1M)
+	actual := catalog.EffectiveInputCost(in, 0, read, actualPricing.InputUSDPer1M, actualPricing, provider) +
+		catalog.EffectiveOutputCost(out, actualPricing.OutputUSDPer1M)
+
+	// A negative delta means routing deliberately bought a pricier model for
+	// quality. Reporting "saved -$0.02" invites the reader to conclude the
+	// router malfunctioned, so the clause is omitted instead.
+	saved := requested - actual
+	if saved < codexReceiptMinSavingsUSD {
+		return ""
+	}
+	return fmt.Sprintf(" · saved $%.2f", saved)
+}
+
+// formatReceiptTokens renders a token count compactly enough to sit in one
+// status line: exact below 1k, then one decimal place.
+func formatReceiptTokens(tokens int64) string {
+	if tokens < 0 {
+		return "0"
+	}
+	if tokens < 1000 {
+		return fmt.Sprintf("%d", tokens)
+	}
+	return fmt.Sprintf("%.1fk", float64(tokens)/1000)
+}

--- a/internal/proxy/codex_receipt_test.go
+++ b/internal/proxy/codex_receipt_test.go
@@ -1,0 +1,119 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router/catalog"
+	"workweave/router/internal/translate"
+)
+
+// A mid-tier requested model against a cheap served one: the shape a routed
+// Codex turn actually takes.
+var (
+	receiptRequestedPricing = catalog.Pricing{InputUSDPer1M: 15, OutputUSDPer1M: 75}
+	receiptActualPricing    = catalog.Pricing{InputUSDPer1M: 3, OutputUSDPer1M: 15}
+)
+
+func TestCodexReceiptReportsTokensAndSavings(t *testing.T) {
+	render := codexReceiptRenderer(receiptRequestedPricing, receiptActualPricing, providers.ProviderAnthropic)
+
+	got := render(translate.ResponsesReceiptUsage{
+		InputTokens:  1800,
+		OutputTokens: 412,
+		HasUsage:     true,
+	})
+
+	// 1800 in: (15-3)/1M * 1800 = $0.0216; 412 out: (75-15)/1M * 412 = $0.0247.
+	require.Equal(t, "\n\n↳ Weave Router · 1.8k in / 412 out · saved $0.05", got)
+}
+
+func TestCodexReceiptOmittedWhenUpstreamReportedNoUsage(t *testing.T) {
+	render := codexReceiptRenderer(receiptRequestedPricing, receiptActualPricing, providers.ProviderAnthropic)
+
+	assert.Empty(t, render(translate.ResponsesReceiptUsage{HasUsage: false}),
+		"a turn with no upstream usage must not render a receipt")
+	assert.Empty(t, render(translate.ResponsesReceiptUsage{HasUsage: true}),
+		"zeroed usage is indistinguishable from missing usage and must not render")
+}
+
+func TestCodexReceiptDropsSavingsWhenRoutedModelCostsMore(t *testing.T) {
+	// Routing up-tiered the turn for quality. "saved -$0.02" reads as a bug.
+	render := codexReceiptRenderer(receiptActualPricing, receiptRequestedPricing, providers.ProviderAnthropic)
+
+	got := render(translate.ResponsesReceiptUsage{
+		InputTokens:  1800,
+		OutputTokens: 412,
+		HasUsage:     true,
+	})
+
+	require.Equal(t, "\n\n↳ Weave Router · 1.8k in / 412 out", got)
+}
+
+func TestCodexReceiptDropsSubCentSavings(t *testing.T) {
+	// A tiny turn's win rounds to $0.00, which reads as "routing bought
+	// nothing" rather than "the win was small".
+	render := codexReceiptRenderer(receiptRequestedPricing, receiptActualPricing, providers.ProviderAnthropic)
+
+	got := render(translate.ResponsesReceiptUsage{
+		InputTokens:  10,
+		OutputTokens: 5,
+		HasUsage:     true,
+	})
+
+	require.Equal(t, "\n\n↳ Weave Router · 10 in / 5 out", got)
+}
+
+func TestCodexReceiptNoSavingsClauseWhenServedRequestedModel(t *testing.T) {
+	// The router stayed on the client's model, so there is no counterfactual.
+	render := codexReceiptRenderer(receiptRequestedPricing, receiptRequestedPricing, providers.ProviderAnthropic)
+
+	got := render(translate.ResponsesReceiptUsage{
+		InputTokens:  50_000,
+		OutputTokens: 2_000,
+		HasUsage:     true,
+	})
+
+	require.Equal(t, "\n\n↳ Weave Router · 50.0k in / 2.0k out", got)
+}
+
+func TestCodexReceiptCacheReadsDoNotInflateSavings(t *testing.T) {
+	// Cached input is billed at the cache rate on BOTH sides, so a cache-heavy
+	// turn must not be credited with the full-price delta. OpenAI is the
+	// provider the Responses path actually serves, and the one whose usage
+	// reports cached tokens as a subset of the prompt.
+	render := codexReceiptRenderer(receiptRequestedPricing, receiptActualPricing, providers.ProviderOpenAI)
+
+	uncached := render(translate.ResponsesReceiptUsage{
+		InputTokens: 40_000, OutputTokens: 500, HasUsage: true,
+	})
+	cached := render(translate.ResponsesReceiptUsage{
+		InputTokens: 40_000, OutputTokens: 500, CacheReadTokens: 40_000, HasUsage: true,
+	})
+
+	require.NotEqual(t, uncached, cached,
+		"cache-read tokens must change the savings the receipt claims")
+	assert.Equal(t, "\n\n↳ Weave Router · 40.0k in / 500 out · saved $0.51", uncached)
+	// Cached input is billed at DefaultCacheReadMultiplier (0.5) on both sides,
+	// so the input half of the delta is halved: $0.51 -> $0.27.
+	assert.Equal(t, "\n\n↳ Weave Router · 40.0k in / 500 out · saved $0.27", cached)
+}
+
+func TestFormatReceiptTokens(t *testing.T) {
+	for _, tc := range []struct {
+		tokens int64
+		want   string
+	}{
+		{tokens: 0, want: "0"},
+		{tokens: 999, want: "999"},
+		{tokens: 1000, want: "1.0k"},
+		{tokens: 1849, want: "1.8k"},
+		{tokens: 128_000, want: "128.0k"},
+		{tokens: -5, want: "0"},
+	} {
+		assert.Equal(t, tc.want, formatReceiptTokens(tc.tokens), "tokens=%d", tc.tokens)
+	}
+}

--- a/internal/proxy/codex_receipt_test.go
+++ b/internal/proxy/codex_receipt_test.go
@@ -18,8 +18,12 @@ var (
 	receiptActualPricing    = catalog.Pricing{InputUSDPer1M: 3, OutputUSDPer1M: 15}
 )
 
+func testReceiptPricing(actual catalog.Pricing, provider string) *codexReceiptPricing {
+	return &codexReceiptPricing{actualPricing: actual, provider: provider, hasActualPricing: true}
+}
+
 func TestCodexReceiptReportsTokensAndSavings(t *testing.T) {
-	render := codexReceiptRenderer(receiptRequestedPricing, receiptActualPricing, providers.ProviderAnthropic)
+	render := codexReceiptRenderer(receiptRequestedPricing, testReceiptPricing(receiptActualPricing, providers.ProviderAnthropic))
 
 	got := render(translate.ResponsesReceiptUsage{
 		InputTokens:  1800,
@@ -32,7 +36,7 @@ func TestCodexReceiptReportsTokensAndSavings(t *testing.T) {
 }
 
 func TestCodexReceiptOmittedWhenUpstreamReportedNoUsage(t *testing.T) {
-	render := codexReceiptRenderer(receiptRequestedPricing, receiptActualPricing, providers.ProviderAnthropic)
+	render := codexReceiptRenderer(receiptRequestedPricing, testReceiptPricing(receiptActualPricing, providers.ProviderAnthropic))
 
 	assert.Empty(t, render(translate.ResponsesReceiptUsage{HasUsage: false}),
 		"a turn with no upstream usage must not render a receipt")
@@ -42,7 +46,7 @@ func TestCodexReceiptOmittedWhenUpstreamReportedNoUsage(t *testing.T) {
 
 func TestCodexReceiptDropsSavingsWhenRoutedModelCostsMore(t *testing.T) {
 	// Routing up-tiered the turn for quality. "saved -$0.02" reads as a bug.
-	render := codexReceiptRenderer(receiptActualPricing, receiptRequestedPricing, providers.ProviderAnthropic)
+	render := codexReceiptRenderer(receiptActualPricing, testReceiptPricing(receiptRequestedPricing, providers.ProviderAnthropic))
 
 	got := render(translate.ResponsesReceiptUsage{
 		InputTokens:  1800,
@@ -56,7 +60,7 @@ func TestCodexReceiptDropsSavingsWhenRoutedModelCostsMore(t *testing.T) {
 func TestCodexReceiptDropsSubCentSavings(t *testing.T) {
 	// A tiny turn's win rounds to $0.00, which reads as "routing bought
 	// nothing" rather than "the win was small".
-	render := codexReceiptRenderer(receiptRequestedPricing, receiptActualPricing, providers.ProviderAnthropic)
+	render := codexReceiptRenderer(receiptRequestedPricing, testReceiptPricing(receiptActualPricing, providers.ProviderAnthropic))
 
 	got := render(translate.ResponsesReceiptUsage{
 		InputTokens:  10,
@@ -69,7 +73,7 @@ func TestCodexReceiptDropsSubCentSavings(t *testing.T) {
 
 func TestCodexReceiptNoSavingsClauseWhenServedRequestedModel(t *testing.T) {
 	// The router stayed on the client's model, so there is no counterfactual.
-	render := codexReceiptRenderer(receiptRequestedPricing, receiptRequestedPricing, providers.ProviderAnthropic)
+	render := codexReceiptRenderer(receiptRequestedPricing, testReceiptPricing(receiptRequestedPricing, providers.ProviderAnthropic))
 
 	got := render(translate.ResponsesReceiptUsage{
 		InputTokens:  50_000,
@@ -85,7 +89,7 @@ func TestCodexReceiptCacheReadsDoNotInflateSavings(t *testing.T) {
 	// turn must not be credited with the full-price delta. OpenAI is the
 	// provider the Responses path actually serves, and the one whose usage
 	// reports cached tokens as a subset of the prompt.
-	render := codexReceiptRenderer(receiptRequestedPricing, receiptActualPricing, providers.ProviderOpenAI)
+	render := codexReceiptRenderer(receiptRequestedPricing, testReceiptPricing(receiptActualPricing, providers.ProviderOpenAI))
 
 	uncached := render(translate.ResponsesReceiptUsage{
 		InputTokens: 40_000, OutputTokens: 500, HasUsage: true,

--- a/internal/proxy/codex_receipt_test.go
+++ b/internal/proxy/codex_receipt_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,6 +9,7 @@ import (
 
 	"workweave/router/internal/providers"
 	"workweave/router/internal/router/catalog"
+	"workweave/router/internal/router/turntype"
 	"workweave/router/internal/translate"
 )
 
@@ -20,6 +22,33 @@ var (
 
 func testReceiptPricing(actual catalog.Pricing, provider string) *codexReceiptPricing {
 	return &codexReceiptPricing{actualPricing: actual, provider: provider, hasActualPricing: true}
+}
+
+func TestCodexReceiptPricingTracksActualBinding(t *testing.T) {
+	require.NotEmpty(t, catalog.Models)
+	model := catalog.Models[0]
+	require.NotEmpty(t, model.Providers)
+	binding := model.Providers[0]
+
+	pricing := &codexReceiptPricing{}
+	pricing.setActual(binding.Provider, model.ID)
+	assert.True(t, pricing.hasActualPricing)
+	assert.Equal(t, binding.Provider, pricing.provider)
+	assert.Equal(t, binding.Price, pricing.actualPricing)
+
+	pricing.setActual(binding.Provider, model.ID+"-missing")
+	assert.False(t, pricing.hasActualPricing)
+}
+
+func TestCodexReceiptTurnGating(t *testing.T) {
+	ctx := context.Background()
+	assert.True(t, codexReceiptTurn(ctx, ClientAppCodex, turntype.MainLoop))
+	assert.True(t, codexReceiptTurn(ctx, ClientAppCodex, turntype.ToolResult))
+	assert.False(t, codexReceiptTurn(ctx, ClientAppCodex, turntype.SubAgentDispatch))
+	assert.False(t, codexReceiptTurn(ctx, ClientAppClaudeCode, turntype.MainLoop))
+
+	hiddenCtx := context.WithValue(ctx, InstallationHideTerminalSurfacesContextKey{}, true)
+	assert.False(t, codexReceiptTurn(hiddenCtx, ClientAppCodex, turntype.MainLoop))
 }
 
 func TestCodexReceiptReportsTokensAndSavings(t *testing.T) {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -5896,7 +5896,12 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	// Previously gated on policy debug; ordinary Codex turns fell through to
 	// ResponsesWriter's legacy badge that ignored suppression and never showed the routing reason.
+	receiptPricing := &codexReceiptPricing{
+		actualPricing: actPricing,
+		provider:      decision.Provider,
+	}
 	verbatimPassthrough := responsesPassthrough && decision.Provider == providers.ProviderOpenAI
+	receiptEnabled := codexReceiptTurn(clientID.ClientApp, routeRes.TurnType)
 	if rw, ok := w.(*translate.ResponsesWriter); ok {
 		if marker != "" && !verbatimPassthrough {
 			rw.SetBadgeText(marker)
@@ -5904,11 +5909,8 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		if footer := s.feedbackFooter(ctx, clientID.ClientApp, routeRes.TurnType, footerEchoedSinceHumanTurn); footer != "" {
 			rw.SetFooterText(footer)
 		}
-		// Codex prices a turn from the model it asked for, so a routed turn's
-		// real tokens and savings never reach the client. Skipped for a
-		// verbatim passthrough, which must stay byte-faithful.
-		if !verbatimPassthrough {
-			rw.SetReceiptFunc(codexReceiptRenderer(reqPricing, actPricing, decision.Provider))
+		if receiptEnabled {
+			rw.SetReceiptFunc(codexReceiptRenderer(reqPricing, receiptPricing))
 		}
 	}
 	// Keep a stable copy for a possible chat/completions fallback after a native
@@ -5933,7 +5935,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			// marker already carries the depleted-credits warning in
 			// subscription-only mode, which overrides the opt-out above.
 			// Parse native SSE when Codex needs a badge and/or footer.
-			if clientID.ClientApp == ClientAppCodex && (marker != "" || s.feedbackFooter(ctx, clientID.ClientApp, routeRes.TurnType, footerEchoedSinceHumanTurn) != "") {
+			if clientID.ClientApp == ClientAppCodex && (marker != "" || receiptEnabled || s.feedbackFooter(ctx, clientID.ClientApp, routeRes.TurnType, footerEchoedSinceHumanTurn) != "") {
 				if marker != "" {
 					rw.SetBadgeText(marker)
 				}
@@ -6012,6 +6014,12 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		// Split from attempt so a native dispatch that finds no Responses surface
 		// can re-emit onto chat/completions while still pre-commit.
 		dispatchOpenAI := func(actx context.Context, d router.Decision, p providers.Client, surface openAISurface, stripPromptCacheKey bool) error {
+			if pricing, ok := catalog.PriceFor(d.Provider, d.Model); ok {
+				receiptPricing.actualPricing = pricing
+				receiptPricing.hasActualPricing = true
+			}
+			receiptPricing.provider = d.Provider
+
 			var prep providers.PreparedRequest
 			switch surface {
 			case surfaceResponsesNative:

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -5896,12 +5896,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	// Previously gated on policy debug; ordinary Codex turns fell through to
 	// ResponsesWriter's legacy badge that ignored suppression and never showed the routing reason.
-	receiptPricing := &codexReceiptPricing{
-		actualPricing: actPricing,
-		provider:      decision.Provider,
-	}
+	receiptPricing := &codexReceiptPricing{}
 	verbatimPassthrough := responsesPassthrough && decision.Provider == providers.ProviderOpenAI
-	receiptEnabled := codexReceiptTurn(clientID.ClientApp, routeRes.TurnType)
+	receiptEnabled := codexReceiptTurn(ctx, clientID.ClientApp, routeRes.TurnType)
 	if rw, ok := w.(*translate.ResponsesWriter); ok {
 		if marker != "" && !verbatimPassthrough {
 			rw.SetBadgeText(marker)
@@ -6014,12 +6011,6 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		// Split from attempt so a native dispatch that finds no Responses surface
 		// can re-emit onto chat/completions while still pre-commit.
 		dispatchOpenAI := func(actx context.Context, d router.Decision, p providers.Client, surface openAISurface, stripPromptCacheKey bool) error {
-			if pricing, ok := catalog.PriceFor(d.Provider, d.Model); ok {
-				receiptPricing.actualPricing = pricing
-				receiptPricing.hasActualPricing = true
-			}
-			receiptPricing.provider = d.Provider
-
 			var prep providers.PreparedRequest
 			switch surface {
 			case surfaceResponsesNative:
@@ -6231,6 +6222,12 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		}
 	default:
 		return fmt.Errorf("%w: %s (no translation path defined)", ErrProviderNotConfigured, decision.Provider)
+	}
+
+	providerAttempt := attempt
+	attempt = func(actx context.Context, d router.Decision, p providers.Client) error {
+		receiptPricing.setActual(d.Provider, d.Model)
+		return providerAttempt(actx, d, p)
 	}
 
 	primaryProvider := decision.Provider

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -5468,6 +5468,12 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	} else {
 		body = strippedBody
 	}
+	strippedBody, stripErr = translate.StripRouterReceiptFromMessages(body)
+	if stripErr != nil {
+		log.Error("Failed to strip router receipt from OpenAI messages", "err", stripErr)
+	} else {
+		body = strippedBody
+	}
 	env, parseErr := translate.ParseOpenAI(body)
 	if parseErr != nil {
 		log.Error("Failed to parse OpenAI request", "err", parseErr)
@@ -5897,6 +5903,12 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		}
 		if footer := s.feedbackFooter(ctx, clientID.ClientApp, routeRes.TurnType, footerEchoedSinceHumanTurn); footer != "" {
 			rw.SetFooterText(footer)
+		}
+		// Codex prices a turn from the model it asked for, so a routed turn's
+		// real tokens and savings never reach the client. Skipped for a
+		// verbatim passthrough, which must stay byte-faithful.
+		if !verbatimPassthrough {
+			rw.SetReceiptFunc(codexReceiptRenderer(reqPricing, actPricing, decision.Provider))
 		}
 	}
 	// Keep a stable copy for a possible chat/completions fallback after a native
@@ -6472,6 +6484,10 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 		nativeBody, err = translate.StripFeedbackFooterFromResponsesInput(nativeBody)
 		if err != nil {
 			return fmt.Errorf("strip native Responses feedback footer: %w", err)
+		}
+		nativeBody, err = translate.StripRouterReceiptFromResponsesInput(nativeBody)
+		if err != nil {
+			return fmt.Errorf("strip native Responses router receipt: %w", err)
 		}
 	}
 	// Every Responses turn stashes its original bytes for post-routing native

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -824,12 +824,7 @@ var routingMarkerPattern = regexp.MustCompile(`(?s)✦ \*\*Weave Router\*\* → 
 // sentinel in sync with proxy.feedbackFooterText.
 var feedbackFooterPattern = regexp.MustCompile(`\n*_Weave Router feedback:_ [^\n]*`)
 
-// routerReceiptPattern matches the per-turn token/savings receipt appended to
-// Codex responses (see proxy.codexReceiptRenderer). Stripped on ingress for the
-// same reason as the marker and footer: the client echoes assistant text back
-// verbatim, so an unstripped receipt would accumulate one line per turn inside
-// the very prompt it is reporting on. Keep the prefix in sync with
-// proxy.codexReceiptPrefix.
+// routerReceiptPattern matches a receipt from a prior Codex turn.
 var routerReceiptPattern = regexp.MustCompile(`\n*↳ Weave Router · [^\n]*`)
 
 // StripRoutingMarkerFromMessages removes the routing-marker snippet from every

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -822,7 +822,15 @@ var routingMarkerPattern = regexp.MustCompile(`(?s)✦ \*\*Weave Router\*\* → 
 // responses (see proxy.Service.feedbackFooter), absorbing leading newlines
 // and everything to end of line since there's no fixed end-anchor. Keep the
 // sentinel in sync with proxy.feedbackFooterText.
-var feedbackFooterPattern = regexp.MustCompile("\\n*_Weave Router feedback:_ [^\\n]*")
+var feedbackFooterPattern = regexp.MustCompile(`\n*_Weave Router feedback:_ [^\n]*`)
+
+// routerReceiptPattern matches the per-turn token/savings receipt appended to
+// Codex responses (see proxy.codexReceiptRenderer). Stripped on ingress for the
+// same reason as the marker and footer: the client echoes assistant text back
+// verbatim, so an unstripped receipt would accumulate one line per turn inside
+// the very prompt it is reporting on. Keep the prefix in sync with
+// proxy.codexReceiptPrefix.
+var routerReceiptPattern = regexp.MustCompile(`\n*↳ Weave Router · [^\n]*`)
 
 // StripRoutingMarkerFromMessages removes the routing-marker snippet from every
 // text block in messages[*].content[*]. Stripping on ingress keeps it out of
@@ -837,6 +845,13 @@ func StripRoutingMarkerFromMessages(body []byte) ([]byte, error) {
 // next turn; stripping it on ingress keeps it out of upstream context.
 func StripFeedbackFooterFromMessages(body []byte) ([]byte, error) {
 	return stripPatternFromMessages(body, feedbackFooterPattern)
+}
+
+// StripRouterReceiptFromMessages removes the per-turn receipt from every text
+// block in messages[*].content[*], for the same ingress reason as the marker
+// and footer.
+func StripRouterReceiptFromMessages(body []byte) ([]byte, error) {
+	return stripPatternFromMessages(body, routerReceiptPattern)
 }
 
 // stripPatternFromMessages removes every match of pattern from each text block

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -393,6 +393,20 @@ func StripRoutingBadgeFromResponsesInput(body []byte) ([]byte, error) {
 // StripFeedbackFooterFromResponsesInput removes the rating hint from assistant
 // text items so a subsequent native Codex turn does not echo it upstream.
 func StripFeedbackFooterFromResponsesInput(body []byte) ([]byte, error) {
+	return stripPatternFromResponsesInput(body, feedbackFooterPattern, "feedback footer")
+}
+
+// StripRouterReceiptFromResponsesInput removes the per-turn receipt from
+// assistant text items so a subsequent native Codex turn does not echo it
+// upstream.
+func StripRouterReceiptFromResponsesInput(body []byte) ([]byte, error) {
+	return stripPatternFromResponsesInput(body, routerReceiptPattern, "router receipt")
+}
+
+// stripPatternFromResponsesInput removes every match of pattern from assistant
+// text in input[*], handling both the plain-string and typed-part content
+// shapes. what names the pattern in error messages.
+func stripPatternFromResponsesInput(body []byte, pattern *regexp.Regexp, what string) ([]byte, error) {
 	input := gjson.GetBytes(body, "input")
 	if !input.IsArray() {
 		return body, nil
@@ -409,14 +423,14 @@ func StripFeedbackFooterFromResponsesInput(body []byte) ([]byte, error) {
 		}
 		content := item.Get("content")
 		if content.Type == gjson.String {
-			stripped := feedbackFooterPattern.ReplaceAllString(content.Str, "")
+			stripped := pattern.ReplaceAllString(content.Str, "")
 			if stripped == content.Str {
 				continue
 			}
 			var err error
 			out, err = sjson.SetBytes(out, "input."+strconv.Itoa(itemIndex)+".content", stripped)
 			if err != nil {
-				return nil, fmt.Errorf("strip Responses feedback footer from string content: %w", err)
+				return nil, fmt.Errorf("strip Responses %s from string content: %w", what, err)
 			}
 			changed = true
 			continue
@@ -429,7 +443,7 @@ func StripFeedbackFooterFromResponsesInput(body []byte) ([]byte, error) {
 			switch part.Get("type").Str {
 			case "input_text", "output_text", "text":
 				text := part.Get("text").Str
-				stripped := feedbackFooterPattern.ReplaceAllString(text, "")
+				stripped := pattern.ReplaceAllString(text, "")
 				if stripped == text {
 					continue
 				}
@@ -437,7 +451,7 @@ func StripFeedbackFooterFromResponsesInput(body []byte) ([]byte, error) {
 				var err error
 				out, err = sjson.SetBytes(out, path, stripped)
 				if err != nil {
-					return nil, fmt.Errorf("strip Responses feedback footer from content part: %w", err)
+					return nil, fmt.Errorf("strip Responses %s from content part: %w", what, err)
 				}
 				changed = true
 			}
@@ -615,6 +629,7 @@ type ResponsesWriter struct {
 	nativeOutputIndexShift      int64
 	nativeSequenceShift         int64
 	footerText                  string
+	receiptFn                   func(ResponsesReceiptUsage) string
 	footerEmitted               bool
 	sawToolCall                 bool
 	nativeHeldEvents            [][]byte
@@ -651,6 +666,9 @@ type responsesUsage struct {
 	prompt     int64
 	completion int64
 	total      int64
+	// cachedPrompt is the subset of prompt billed at the cache-read rate.
+	// Tracked so cost reporting does not price a cached turn at full rate.
+	cachedPrompt int64
 }
 
 var responsesIDCounter atomic.Uint64
@@ -728,6 +746,43 @@ func (t *ResponsesWriter) EnableCodexBadgeProvenance() {
 // naturally finished, tool-free turn. Empty text is a no-op.
 func (t *ResponsesWriter) SetFooterText(text string) {
 	t.footerText = text
+}
+
+// ResponsesReceiptUsage is the served turn's token accounting, as reported by
+// the upstream. HasUsage distinguishes "the upstream reported zero" from "the
+// upstream reported nothing", which the receipt must not present as free.
+type ResponsesReceiptUsage struct {
+	InputTokens  int64
+	OutputTokens int64
+	// CacheReadTokens is the subset of InputTokens the upstream billed at its
+	// cache-read rate, so a cached turn is not priced at full rate.
+	CacheReadTokens int64
+	HasUsage        bool
+}
+
+// SetReceiptFunc supplies a renderer for the per-turn receipt appended after
+// the footer. It is called once at stream end, not at wire-up time: the token
+// counts it formats only exist after the upstream has finished, whereas the
+// badge and footer are fixed before dispatch. Returning "" emits nothing,
+// which is the right answer for an upstream that reported no usage.
+func (t *ResponsesWriter) SetReceiptFunc(fn func(ResponsesReceiptUsage) string) {
+	t.receiptFn = fn
+}
+
+// receiptText renders the receipt for a completed turn, or "" when there is
+// nothing trustworthy to show.
+func (t *ResponsesWriter) receiptText() string {
+	if t.receiptFn == nil {
+		return ""
+	}
+	usage := ResponsesReceiptUsage{}
+	if t.usage != nil {
+		usage.HasUsage = true
+		usage.InputTokens = t.usage.prompt
+		usage.OutputTokens = t.usage.completion
+		usage.CacheReadTokens = t.usage.cachedPrompt
+	}
+	return t.receiptFn(usage)
 }
 
 func (t *ResponsesWriter) Header() http.Header { return t.inner.Header() }
@@ -1673,9 +1728,10 @@ func (t *ResponsesWriter) translateChunk(raw []byte) error {
 	}
 	if usage := root.Get("usage"); usage.Exists() {
 		t.usage = &responsesUsage{
-			prompt:     usage.Get("prompt_tokens").Int(),
-			completion: usage.Get("completion_tokens").Int(),
-			total:      usage.Get("total_tokens").Int(),
+			prompt:       usage.Get("prompt_tokens").Int(),
+			completion:   usage.Get("completion_tokens").Int(),
+			total:        usage.Get("total_tokens").Int(),
+			cachedPrompt: usage.Get("prompt_tokens_details.cached_tokens").Int(),
 		}
 	}
 
@@ -1883,6 +1939,18 @@ func (t *ResponsesWriter) closeOpenItems() error {
 			t.textItem.text.WriteString(t.footerText)
 			if err := t.emitTextDelta(t.textItem, t.footerText); err != nil {
 				return err
+			}
+		}
+		// The receipt trails the footer on the same terms: a tool turn is not
+		// the end of the answer, and a truncated one has no total worth
+		// reporting. Unlike the badge and footer it is resolved here, because
+		// the token counts it renders arrive with the upstream's final frame.
+		if !t.sawToolCall && t.finishReason == "stop" {
+			if receipt := t.receiptText(); receipt != "" {
+				t.textItem.text.WriteString(receipt)
+				if err := t.emitTextDelta(t.textItem, receipt); err != nil {
+					return err
+				}
 			}
 		}
 		if err := t.emitTextDone(t.textItem); err != nil && len(t.toolMappings) > 0 {

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -630,10 +630,12 @@ type ResponsesWriter struct {
 	nativeSequenceShift         int64
 	footerText                  string
 	receiptFn                   func(ResponsesReceiptUsage) string
+	receiptValue                string
+	receiptResolved             bool
 	footerEmitted               bool
 	sawToolCall                 bool
 	nativeHeldEvents            [][]byte
-	nativeFooterCommit          bool
+	nativeTerminalTextCommit    bool
 	textItem                    *responsesTextItem
 	toolItems                   map[int]*responsesToolItem
 	finishReason                string
@@ -765,6 +767,10 @@ func (t *ResponsesWriter) SetReceiptFunc(fn func(ResponsesReceiptUsage) string) 
 // receiptText renders the receipt for a completed turn, or "" when there is
 // nothing trustworthy to show.
 func (t *ResponsesWriter) receiptText() string {
+	if t.receiptResolved {
+		return t.receiptValue
+	}
+	t.receiptResolved = true
 	if t.receiptFn == nil {
 		return ""
 	}
@@ -775,7 +781,8 @@ func (t *ResponsesWriter) receiptText() string {
 		usage.OutputTokens = t.usage.completion
 		usage.CacheReadTokens = t.usage.cachedPrompt
 	}
-	return t.receiptFn(usage)
+	t.receiptValue = t.receiptFn(usage)
+	return t.receiptValue
 }
 
 func (t *ResponsesWriter) Header() http.Header { return t.inner.Header() }
@@ -1001,7 +1008,21 @@ func (t *ResponsesWriter) Finalize() error {
 		return err
 	}
 
-	translated, err := chatCompletionToResponse(body, t.responseID, t.model, t.createdAt, t.toolMappings, t.computeBadgeText(), t.footerText)
+	root := gjson.ParseBytes(body)
+	if usage := root.Get("usage"); usage.Exists() {
+		t.usage = &responsesUsage{
+			prompt:       usage.Get("prompt_tokens").Int(),
+			completion:   usage.Get("completion_tokens").Int(),
+			total:        usage.Get("total_tokens").Int(),
+			cachedPrompt: usage.Get("prompt_tokens_details.cached_tokens").Int(),
+		}
+	}
+	t.finishReason = root.Get("choices.0.finish_reason").Str
+	receipt := ""
+	if t.finishReason == "stop" {
+		receipt = t.receiptText()
+	}
+	translated, err := chatCompletionToResponse(body, t.responseID, t.model, t.createdAt, t.toolMappings, t.computeBadgeText(), t.footerText, receipt)
 	if err != nil {
 		t.inner.Header().Set("Content-Type", "application/json")
 		t.inner.WriteHeader(http.StatusBadGateway)
@@ -1151,18 +1172,25 @@ func (t *ResponsesWriter) prefixNativeBadge(data []byte, path string) ([]byte, b
 	return rewritten, true
 }
 
-func (t *ResponsesWriter) suffixNativeFooter(data []byte, path string) ([]byte, bool) {
-	if t.footerText == "" || t.sawToolCall {
+func (t *ResponsesWriter) suffixNativeTerminalText(data []byte, path string) ([]byte, bool) {
+	if t.sawToolCall || t.finishReason != "stop" {
 		return data, false
 	}
 	text := gjson.GetBytes(data, path)
 	if text.Type != gjson.String {
 		return data, false
 	}
-	if feedbackFooterPattern.MatchString(text.Str) {
+	suffix := ""
+	if t.footerText != "" && !feedbackFooterPattern.MatchString(text.Str) {
+		suffix += t.footerText
+	}
+	if receipt := t.receiptText(); receipt != "" && !routerReceiptPattern.MatchString(text.Str) {
+		suffix += receipt
+	}
+	if suffix == "" {
 		return data, false
 	}
-	rewritten, err := sjson.SetBytes(append([]byte(nil), data...), path, text.Str+t.footerText)
+	rewritten, err := sjson.SetBytes(append([]byte(nil), data...), path, text.Str+suffix)
 	if err != nil {
 		return data, false
 	}
@@ -1186,7 +1214,21 @@ func (t *ResponsesWriter) rewriteNativeResponsesPayload(data []byte) ([]byte, bo
 		return data, false
 	}
 	root := gjson.ParseBytes(data)
-	switch root.Get("type").Str {
+	eventType := root.Get("type").Str
+	if eventType == "response.completed" {
+		t.finishReason = "stop"
+		if usage := root.Get("response.usage"); usage.Exists() {
+			t.usage = &responsesUsage{
+				prompt:       usage.Get("input_tokens").Int(),
+				completion:   usage.Get("output_tokens").Int(),
+				total:        usage.Get("total_tokens").Int(),
+				cachedPrompt: usage.Get("input_tokens_details.cached_tokens").Int(),
+			}
+		}
+	} else if eventType == "response.incomplete" {
+		t.finishReason = "incomplete"
+	}
+	switch eventType {
 	case "response.content_part.added":
 		if root.Get("part.type").Str != "output_text" {
 			return data, false
@@ -1212,15 +1254,15 @@ func (t *ResponsesWriter) rewriteNativeResponsesPayload(data []byte) ([]byte, bo
 	case "response.output_text.done":
 		ref := nativeResponsesEventRef(root, "item_id")
 		if !t.observeNativeBadgeTarget(ref) || !t.nativeBadgeTargetMatches(ref, true) {
-			if t.nativeFooterCommit {
-				return t.suffixNativeFooter(data, "text")
+			if t.nativeTerminalTextCommit {
+				return t.suffixNativeTerminalText(data, "text")
 			}
 			return data, false
 		}
-		if t.nativeFooterCommit {
+		if t.nativeTerminalTextCommit {
 			return applyNativeRewrites(data,
 				func(d []byte) ([]byte, bool) { return t.prefixNativeBadge(d, "text") },
-				func(d []byte) ([]byte, bool) { return t.suffixNativeFooter(d, "text") },
+				func(d []byte) ([]byte, bool) { return t.suffixNativeTerminalText(d, "text") },
 			)
 		}
 		return t.prefixNativeBadge(data, "text")
@@ -1231,15 +1273,15 @@ func (t *ResponsesWriter) rewriteNativeResponsesPayload(data []byte) ([]byte, bo
 		}
 		ref := nativeResponsesEventRef(root, "item_id")
 		if !t.observeNativeBadgeTarget(ref) || !t.nativeBadgeTargetMatches(ref, true) {
-			if t.nativeFooterCommit {
-				return t.suffixNativeFooter(data, "part.text")
+			if t.nativeTerminalTextCommit {
+				return t.suffixNativeTerminalText(data, "part.text")
 			}
 			return data, false
 		}
-		if t.nativeFooterCommit {
+		if t.nativeTerminalTextCommit {
 			return applyNativeRewrites(data,
 				func(d []byte) ([]byte, bool) { return t.prefixNativeBadge(d, "part.text") },
-				func(d []byte) ([]byte, bool) { return t.suffixNativeFooter(d, "part.text") },
+				func(d []byte) ([]byte, bool) { return t.suffixNativeTerminalText(d, "part.text") },
 			)
 		}
 		return t.prefixNativeBadge(data, "part.text")
@@ -1260,16 +1302,16 @@ func (t *ResponsesWriter) rewriteNativeResponsesPayload(data []byte) ([]byte, bo
 		ref.contentIndex = int64(partIndex)
 		ref.hasContentIndex = true
 		if !t.observeNativeBadgeTarget(ref) || !t.nativeBadgeTargetMatches(ref, true) {
-			if t.nativeFooterCommit {
-				return t.suffixNativeFooter(data, "item.content."+strconv.Itoa(partIndex)+".text")
+			if t.nativeTerminalTextCommit {
+				return t.suffixNativeTerminalText(data, "item.content."+strconv.Itoa(partIndex)+".text")
 			}
 			return data, false
 		}
 		path := "item.content." + strconv.Itoa(partIndex) + ".text"
-		if t.nativeFooterCommit {
+		if t.nativeTerminalTextCommit {
 			return applyNativeRewrites(data,
 				func(d []byte) ([]byte, bool) { return t.prefixNativeBadge(d, path) },
-				func(d []byte) ([]byte, bool) { return t.suffixNativeFooter(d, path) },
+				func(d []byte) ([]byte, bool) { return t.suffixNativeTerminalText(d, path) },
 			)
 		}
 		return t.prefixNativeBadge(data, path)
@@ -1296,7 +1338,7 @@ func (t *ResponsesWriter) rewriteNativeResponsesPayload(data []byte) ([]byte, bo
 					continue
 				}
 				footerPath := "response.output." + strconv.Itoa(outputIndex) + ".content." + strconv.Itoa(textPart) + ".text"
-				if rewritten, changed := t.suffixNativeFooter(data, footerPath); changed {
+				if rewritten, changed := t.suffixNativeTerminalText(data, footerPath); changed {
 					return rewritten, true
 				}
 				continue
@@ -1313,7 +1355,7 @@ func (t *ResponsesWriter) rewriteNativeResponsesPayload(data []byte) ([]byte, bo
 			}
 			return applyNativeRewrites(data,
 				func(d []byte) ([]byte, bool) { return t.prefixNativeBadge(d, path) },
-				func(d []byte) ([]byte, bool) { return t.suffixNativeFooter(d, path) },
+				func(d []byte) ([]byte, bool) { return t.suffixNativeTerminalText(d, path) },
 			)
 		}
 	}
@@ -1377,9 +1419,27 @@ func (t *ResponsesWriter) rewriteNativeNonStreamingBody(data []byte) ([]byte, bo
 		return data, false
 	}
 	root := gjson.ParseBytes(data)
+	if root.Get("status").Str == "completed" {
+		t.finishReason = "stop"
+	} else {
+		t.finishReason = root.Get("status").Str
+	}
+	if usage := root.Get("usage"); usage.Exists() {
+		t.usage = &responsesUsage{
+			prompt:       usage.Get("input_tokens").Int(),
+			completion:   usage.Get("output_tokens").Int(),
+			total:        usage.Get("total_tokens").Int(),
+			cachedPrompt: usage.Get("input_tokens_details.cached_tokens").Int(),
+		}
+	}
 	output := root.Get("output")
-	if !output.IsArray() || t.computeBadgeText() == "" {
+	if !output.IsArray() {
 		return data, false
+	}
+	for _, item := range output.Array() {
+		if itemType := item.Get("type").Str; itemType == "function_call" || itemType == "custom_tool_call" {
+			t.sawToolCall = true
+		}
 	}
 	for index, item := range output.Array() {
 		if !nativeResponsesAssistantMessage(item) {
@@ -1390,7 +1450,13 @@ func (t *ResponsesWriter) rewriteNativeNonStreamingBody(data []byte) ([]byte, bo
 			continue
 		}
 		path := "output." + strconv.Itoa(index) + ".content." + strconv.Itoa(partIndex) + ".text"
-		return t.prefixNativeBadge(data, path)
+		return applyNativeRewrites(data,
+			func(d []byte) ([]byte, bool) { return t.prefixNativeBadge(d, path) },
+			func(d []byte) ([]byte, bool) { return t.suffixNativeTerminalText(d, path) },
+		)
+	}
+	if t.computeBadgeText() == "" {
+		return data, false
 	}
 	for _, item := range output.Array() {
 		if item.Get("id").Str != "" && codexResponsesBadgePattern.MatchString(item.Get("content.0.text").Str) {
@@ -1571,7 +1637,7 @@ func (t *ResponsesWriter) writeNativeResponsesEvent(event, delimiter []byte) err
 		return nil
 	}
 	if eventType == "response.completed" || eventType == "response.incomplete" {
-		if err := t.flushNativeHeldEvents(true); err != nil {
+		if err := t.flushNativeHeldEvents(eventType == "response.completed"); err != nil {
 			return err
 		}
 	}
@@ -1586,7 +1652,7 @@ func (t *ResponsesWriter) writeNativeResponsesEvent(event, delimiter []byte) err
 }
 
 func (t *ResponsesWriter) shouldHoldNativeEvent(eventType, itemType string) bool {
-	if t.footerText == "" || t.sawToolCall {
+	if (t.footerText == "" && t.receiptFn == nil) || t.sawToolCall {
 		return false
 	}
 	switch eventType {
@@ -1598,12 +1664,12 @@ func (t *ResponsesWriter) shouldHoldNativeEvent(eventType, itemType string) bool
 	return false
 }
 
-func (t *ResponsesWriter) flushNativeHeldEvents(commitFooter bool) error {
+func (t *ResponsesWriter) flushNativeHeldEvents(commitTerminalText bool) error {
 	if len(t.nativeHeldEvents) == 0 {
 		return nil
 	}
-	if commitFooter {
-		t.nativeFooterCommit = true
+	if commitTerminalText {
+		t.nativeTerminalTextCommit = true
 	}
 	held := t.nativeHeldEvents
 	t.nativeHeldEvents = nil
@@ -1639,7 +1705,8 @@ func (t *ResponsesWriter) processFinalPassthroughSSETail() error {
 			return err
 		}
 	}
-	return t.flushNativeHeldEvents(t.footerText != "" && !t.sawToolCall)
+	commitTerminalText := t.finishReason == "stop" && (t.footerText != "" || t.receiptFn != nil) && !t.sawToolCall
+	return t.flushNativeHeldEvents(commitTerminalText)
 }
 
 // FinalizeError emits a response.failed terminal event when upstream fails
@@ -1754,6 +1821,11 @@ func (t *ResponsesWriter) translateChunk(raw []byte) error {
 
 	if fr := choice.Get("finish_reason"); fr.Type == gjson.String && fr.Str != "" {
 		t.finishReason = fr.Str
+		// Usage may arrive in a later include_usage chunk with no choices.
+		// Keep the item open until [DONE] so the receipt sees it.
+		if fr.Str == "stop" && t.receiptFn != nil && !t.sawToolCall {
+			return nil
+		}
 		// Reasoning-only turns emit no delta this writer translates, so the
 		// badge would never be reached through appendText/appendToolCall.
 		if err := t.ensureBadgeItem(); err != nil {
@@ -2320,7 +2392,7 @@ func (t *ResponsesWriter) assembleOutput() []any {
 // stream:false; Codex always streams, but other clients may not. A non-empty
 // badge leads the assistant text, synthesizing the message item when the turn
 // produced only tool calls.
-func chatCompletionToResponse(body []byte, responseID, model string, createdAt int64, mappings map[string]ResponsesToolMapping, badge, footer string) ([]byte, error) {
+func chatCompletionToResponse(body []byte, responseID, model string, createdAt int64, mappings map[string]ResponsesToolMapping, badge, footer, receipt string) ([]byte, error) {
 	if !gjson.ValidBytes(body) {
 		return nil, fmt.Errorf("invalid JSON")
 	}
@@ -2343,8 +2415,13 @@ func chatCompletionToResponse(body []byte, responseID, model string, createdAt i
 	if content := choice.Get("content"); content.Type == gjson.String {
 		text += content.Str
 	}
-	if footer != "" && choice.Get("tool_calls.#").Int() == 0 && !feedbackFooterPattern.MatchString(text) {
-		text += footer
+	if choice.Get("tool_calls.#").Int() == 0 {
+		if footer != "" && !feedbackFooterPattern.MatchString(text) {
+			text += footer
+		}
+		if receipt != "" && !routerReceiptPattern.MatchString(text) {
+			text += receipt
+		}
 	}
 	if text != "" {
 		output = append(output, map[string]any{

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -1822,8 +1822,20 @@ func (t *ResponsesWriter) translateChunk(raw []byte) error {
 	if fr := choice.Get("finish_reason"); fr.Type == gjson.String && fr.Str != "" {
 		t.finishReason = fr.Str
 		// Usage may arrive in a later include_usage chunk with no choices.
-		// Keep the item open until [DONE] so the receipt sees it.
+		// Keep the item open until [DONE] so the receipt sees it, but open a
+		// text item now so a reasoning-only stream still has output to close.
 		if fr.Str == "stop" && t.receiptFn != nil && !t.sawToolCall {
+			if err := t.ensureBadgeItem(); err != nil {
+				return err
+			}
+			if t.textItem == nil {
+				if err := t.openTextItem(); err != nil {
+					return err
+				}
+				if err := t.lifecycle.Output(t.textItem.outputIndex); err != nil {
+					return err
+				}
+			}
 			return nil
 		}
 		// Reasoning-only turns emit no delta this writer translates, so the

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -748,23 +748,16 @@ func (t *ResponsesWriter) SetFooterText(text string) {
 	t.footerText = text
 }
 
-// ResponsesReceiptUsage is the served turn's token accounting, as reported by
-// the upstream. HasUsage distinguishes "the upstream reported zero" from "the
-// upstream reported nothing", which the receipt must not present as free.
+// ResponsesReceiptUsage contains the served turn's upstream token counts.
 type ResponsesReceiptUsage struct {
 	InputTokens  int64
 	OutputTokens int64
-	// CacheReadTokens is the subset of InputTokens the upstream billed at its
-	// cache-read rate, so a cached turn is not priced at full rate.
+	// CacheReadTokens is the cached subset of InputTokens.
 	CacheReadTokens int64
 	HasUsage        bool
 }
 
-// SetReceiptFunc supplies a renderer for the per-turn receipt appended after
-// the footer. It is called once at stream end, not at wire-up time: the token
-// counts it formats only exist after the upstream has finished, whereas the
-// badge and footer are fixed before dispatch. Returning "" emits nothing,
-// which is the right answer for an upstream that reported no usage.
+// SetReceiptFunc sets the renderer for the receipt appended after the footer.
 func (t *ResponsesWriter) SetReceiptFunc(fn func(ResponsesReceiptUsage) string) {
 	t.receiptFn = fn
 }

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -1148,7 +1148,8 @@ func TestResponsesWriter_AppendsReceiptWithUpstreamUsage(t *testing.T) {
 	w.WriteHeader(200)
 	for _, c := range []string{
 		`data: {"choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}` + "\n\n",
-		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1234,"completion_tokens":34}}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n",
+		`data: {"choices":[],"usage":{"prompt_tokens":1234,"completion_tokens":34}}` + "\n\n",
 		"data: [DONE]\n\n",
 	} {
 		_, err := w.Write([]byte(c))
@@ -1173,6 +1174,82 @@ func TestResponsesWriter_AppendsReceiptWithUpstreamUsage(t *testing.T) {
 	}
 	require.GreaterOrEqual(t, len(deltas), 2)
 	assert.Equal(t, "\n\n↳ Weave Router · 1.2k in / 34 out", deltas[len(deltas)-1])
+}
+
+func TestResponsesWriter_BufferedResponseAppendsReceipt(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5.5")
+	w.SetReceiptFunc(func(usage translate.ResponsesReceiptUsage) string {
+		assert.Equal(t, int64(1234), usage.InputTokens)
+		assert.Equal(t, int64(34), usage.OutputTokens)
+		return "\n\n↳ Weave Router · 1.2k in / 34 out"
+	})
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"Hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1234,"completion_tokens":34,"total_tokens":1268}}`))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	assert.Equal(t, "Hello\n\n↳ Weave Router · 1.2k in / 34 out", gjson.GetBytes(rec.Body.Bytes(), "output.0.content.0.text").Str)
+}
+
+func TestResponsesWriter_NativeStreamAppendsReceipt(t *testing.T) {
+	const receipt = "\n\n↳ Weave Router · 1.2k in / 34 out"
+	payloads := []string{
+		`{"type":"response.output_text.delta","item_id":"msg_native","output_index":0,"content_index":0,"delta":"ok"}`,
+		`{"type":"response.output_text.done","item_id":"msg_native","output_index":0,"content_index":0,"text":"ok"}`,
+		`{"type":"response.completed","response":{"id":"resp_native","status":"completed","output":[{"id":"msg_native","type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":1234,"output_tokens":34,"total_tokens":1268,"input_tokens_details":{"cached_tokens":1000}}}}`,
+	}
+	var native strings.Builder
+	for _, payload := range payloads {
+		native.WriteString("event: " + gjson.Get(payload, "type").Str + "\n")
+		native.WriteString("data: " + payload + "\n\n")
+	}
+
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5.6-sol")
+	var got translate.ResponsesReceiptUsage
+	rendererCalls := 0
+	w.SetReceiptFunc(func(usage translate.ResponsesReceiptUsage) string {
+		rendererCalls++
+		got = usage
+		return receipt
+	})
+	w.SetPassthroughBadge()
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(200)
+	_, err := w.Write([]byte(native.String()))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	assert.Equal(t, translate.ResponsesReceiptUsage{
+		InputTokens: 1234, OutputTokens: 34, CacheReadTokens: 1000, HasUsage: true,
+	}, got)
+	assert.Equal(t, 1, rendererCalls)
+	events := parseSSEEvents(t, rec.Body.Bytes())
+	require.Len(t, events, 3)
+	assert.Equal(t, "ok"+receipt, events[1]["text"])
+	output := events[2]["response"].(map[string]any)["output"].([]any)
+	assert.Equal(t, "ok"+receipt, output[0].(map[string]any)["content"].([]any)[0].(map[string]any)["text"])
+}
+
+func TestResponsesWriter_NativeBufferedResponseAppendsReceipt(t *testing.T) {
+	const receipt = "\n\n↳ Weave Router · 1.2k in / 34 out"
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5.6-sol")
+	w.SetReceiptFunc(func(usage translate.ResponsesReceiptUsage) string {
+		assert.Equal(t, int64(1234), usage.InputTokens)
+		assert.Equal(t, int64(34), usage.OutputTokens)
+		return receipt
+	})
+	w.SetPassthroughBadge()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := w.Write([]byte(`{"id":"resp_native","status":"completed","output":[{"id":"msg_native","type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":1234,"output_tokens":34,"total_tokens":1268}}`))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	assert.Equal(t, "ok"+receipt, gjson.GetBytes(rec.Body.Bytes(), "output.0.content.0.text").Str)
 }
 
 func TestResponsesWriter_ReceiptSkippedOnToolCall(t *testing.T) {

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -1176,6 +1176,33 @@ func TestResponsesWriter_AppendsReceiptWithUpstreamUsage(t *testing.T) {
 	assert.Equal(t, "\n\n↳ Weave Router · 1.2k in / 34 out", deltas[len(deltas)-1])
 }
 
+func TestResponsesWriter_ReasoningOnlyStreamCompletesWithReceipt(t *testing.T) {
+	const receipt = "\n\n↳ Weave Router · 1.2k in / 34 out"
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5.5")
+	w.SetFooterText("\n\n_Weave Router feedback:_ `$rf +` good")
+	w.SetReceiptFunc(func(translate.ResponsesReceiptUsage) string { return receipt })
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(200)
+	for _, chunk := range []string{
+		`data: {"choices":[{"index":0,"delta":{"reasoning_content":"thinking"},"finish_reason":null}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n",
+		`data: {"choices":[],"usage":{"prompt_tokens":1234,"completion_tokens":34}}` + "\n\n",
+		"data: [DONE]\n\n",
+	} {
+		_, err := w.Write([]byte(chunk))
+		require.NoError(t, err)
+	}
+	assert.NoError(t, w.Finalize())
+
+	events := parseSSEEvents(t, rec.Body.Bytes())
+	assert.Contains(t, eventTypes(events), "response.output_item.added")
+	assert.Contains(t, eventTypes(events), "response.output_text.delta")
+	assert.Equal(t, "response.completed", events[len(events)-1]["type"])
+	assert.Contains(t, rec.Body.String(), "Weave Router feedback")
+	assert.Contains(t, rec.Body.String(), "↳ Weave Router")
+}
+
 func TestResponsesWriter_BufferedResponseAppendsReceipt(t *testing.T) {
 	rec := httptest.NewRecorder()
 	w := translate.NewResponsesWriter(rec, "gpt-5.5")

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -1136,6 +1136,98 @@ func TestResponsesWriter_TranslatedStreamAppendsFeedbackFooter(t *testing.T) {
 	assert.Equal(t, footer, deltas[len(deltas)-1])
 }
 
+func TestResponsesWriter_AppendsReceiptWithUpstreamUsage(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5.5")
+	var got translate.ResponsesReceiptUsage
+	w.SetReceiptFunc(func(u translate.ResponsesReceiptUsage) string {
+		got = u
+		return "\n\n↳ Weave Router · 1.2k in / 34 out"
+	})
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(200)
+	for _, c := range []string{
+		`data: {"choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1234,"completion_tokens":34}}` + "\n\n",
+		"data: [DONE]\n\n",
+	} {
+		_, err := w.Write([]byte(c))
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Finalize())
+
+	// The renderer runs at stream end, so it sees the upstream's final counts
+	// rather than the pre-dispatch estimate the badge is built from.
+	assert.Equal(t, translate.ResponsesReceiptUsage{
+		InputTokens:  1234,
+		OutputTokens: 34,
+		HasUsage:     true,
+	}, got)
+
+	events := parseSSEEvents(t, rec.Body.Bytes())
+	var deltas []string
+	for _, e := range events {
+		if e["type"] == "response.output_text.delta" {
+			deltas = append(deltas, e["delta"].(string))
+		}
+	}
+	require.GreaterOrEqual(t, len(deltas), 2)
+	assert.Equal(t, "\n\n↳ Weave Router · 1.2k in / 34 out", deltas[len(deltas)-1])
+}
+
+func TestResponsesWriter_ReceiptSkippedOnToolCall(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5.5")
+	w.SetReceiptFunc(func(translate.ResponsesReceiptUsage) string {
+		return "\n\n↳ Weave Router · 1.2k in / 34 out"
+	})
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(200)
+	for _, c := range []string{
+		`data: {"choices":[{"index":0,"delta":{"content":"working"},"finish_reason":null}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_a","type":"function","function":{"name":"exec","arguments":"{}"}}]},"finish_reason":null}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n",
+		"data: [DONE]\n\n",
+	} {
+		_, err := w.Write([]byte(c))
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Finalize())
+
+	// A tool turn is not the end of the answer; a receipt there would land
+	// mid-conversation and be re-sent as prompt text on the next turn.
+	assert.NotContains(t, rec.Body.String(), "Weave Router \\u00b7")
+	assert.NotContains(t, rec.Body.String(), "↳ Weave Router")
+}
+
+func TestStripRouterReceiptFromResponsesInput(t *testing.T) {
+	body := []byte(`{"input":[
+		{"role":"user","content":"hi"},
+		{"role":"assistant","content":[{"type":"output_text","text":"Done.\n\n↳ Weave Router · 1.8k in / 412 out · saved $0.05"}]},
+		{"role":"assistant","content":"Older.\n\n↳ Weave Router · 900 in / 20 out"}
+	]}`)
+
+	got, err := translate.StripRouterReceiptFromResponsesInput(body)
+	require.NoError(t, err)
+
+	// Both content shapes are stripped, and the answer text survives intact.
+	assert.NotContains(t, string(got), "↳ Weave Router")
+	assert.Contains(t, string(got), "Done.")
+	assert.Contains(t, string(got), "Older.")
+}
+
+func TestStripRouterReceiptFromMessages(t *testing.T) {
+	body := []byte(`{"messages":[
+		{"role":"assistant","content":[{"type":"text","text":"Answer.\n\n↳ Weave Router · 2.1k in / 88 out · saved $0.03"}]}
+	]}`)
+
+	got, err := translate.StripRouterReceiptFromMessages(body)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(got), "Weave Router ·")
+	assert.Contains(t, string(got), "Answer.")
+}
+
 func TestStripFeedbackFooterFromResponsesInput(t *testing.T) {
 	body := []byte("{\"input\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"answer\\n\\n_Weave Router feedback:_ `$rf +` good experience · `$rf -` poor experience\"}]}]}")
 	out, err := translate.StripFeedbackFooterFromResponsesInput(body)


### PR DESCRIPTION
> Stacked on #1140 — review that first. This PR's diff is the last commit only; the base merges away once #1140 lands.

## Summary

- Append a per-turn receipt to Codex responses: `↳ Weave Router · 1.8k in / 412 out · saved $0.05`.
- Strip it on ingress, like the routing marker and feedback footer.

Codex prices a turn from the model it *requested*, never the one that served. The footer keeps reading `gpt-5.6-terra` while the turn actually ran on `gpt-5.6-luna`, so the tokens and savings the router already computes never reach the user. The terminal title carries cumulative session savings, but nothing shows what a single turn cost.

## Why stream end, not wire-up

The badge and footer are fixed before dispatch. Token counts are not — they arrive with the upstream's final frame, after failover has settled on a provider. So the receipt is a **renderer** (`SetReceiptFunc`), invoked once in `closeOpenItems`, rather than a string set alongside the badge.

It rides the same gate as the footer: `!sawToolCall && finishReason == "stop"`. A tool turn is not the end of an answer, and a receipt there would land mid-conversation.

## Why stripping is mandatory

Codex echoes assistant text back verbatim as history. Unstripped, the receipt accumulates one line per turn *inside the prompt it is reporting on*. `StripRouterReceiptFrom{Messages,ResponsesInput}` run wherever the footer strip already runs. Rather than duplicate the 55-line input traversal, this generalises it to `stripPatternFromResponsesInput(body, pattern, what)`.

## Cost math

Both sides price the **same served token counts** through `catalog.EffectiveInputCost` / `EffectiveOutputCost` — the same helpers the OTel emitter and billing debit use. The question answered is "what would this turn's work have cost on the requested model", not a guess at how many tokens that model would have used.

Two cases are deliberately silent rather than wrong:

| Case | Rendering | Why |
|---|---|---|
| Routed model costs more | no savings clause | routing up-tiered for quality; `saved -$0.02` reads as a malfunction |
| Savings < $0.005 | no savings clause | `$0.00` reads as "routing bought nothing", not "the win was small" |
| Upstream reported no usage | no receipt at all | `0 in / 0 out` would be a lie about a turn that did consume tokens |

Cache-read tokens are threaded through so a cache-heavy turn is not credited with the full-price delta — `40.0k in` with everything cached drops the claim from `$0.51` to `$0.27` (`DefaultCacheReadMultiplier` = 0.5). Note `EffectiveInputCost` takes the **total** prompt and nets out the cached portion itself; an earlier draft pre-subtracted and double-discounted.

## Verification

- `go test ./internal/proxy/ ./internal/translate/ ./internal/router/catalog/` — all pass
- 7 renderer cases: tokens+savings, no-usage, zeroed-usage, up-tier, sub-cent, same-model, cache-read
- 2 translator cases: receipt appended with real upstream usage; withheld on a tool turn
- 2 strip cases: both Responses content shapes and the chat `messages` shape
- `go build ./...`, `go vet`, `gofmt -l` clean

🤖 Generated with [Weave Router](https://router.workweave.ai)