### PR TITLE
feat: expose router response costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,13 @@ dashboard, where selection is an organization-wide setting. See
 Keep liveness probes on `/health`. Point startup or readiness probes at
 `/readyz` when configured policy sidecars must be ready before traffic arrives.
 
+Routed non-stream responses include `x-router-cost-usd`,
+`x-router-cost-input-usd`, `x-router-cost-output-usd`,
+`x-router-cache-read-tokens`, and `x-router-cache-creation-tokens`. Streaming
+responses cannot carry the final cost in HTTP headers because headers flush
+before usage is known; stream clients should read the `weave_cost` object on
+the final Anthropic `message_delta` usage event.
+
 ## Deeper docs
 
 - 📐 [**Configuration reference**](docs/CONFIGURATION.md): every env var,

--- a/internal/proxy/conformance_golden_test.go
+++ b/internal/proxy/conformance_golden_test.go
@@ -120,6 +120,12 @@ func redactJSON(t *testing.T, data []byte) map[string]interface{} {
 	t.Helper()
 	var m map[string]interface{}
 	require.NoError(t, json.Unmarshal(data, &m), "response frame is not a JSON object: %s", string(data))
+	// weave_cost is router metadata appended to the terminal usage event. It is
+	// covered by the cost-response tests, while translation goldens intentionally
+	// remain focused on provider-to-Anthropic wire shape.
+	if usage, ok := m["usage"].(map[string]interface{}); ok {
+		delete(usage, "weave_cost")
+	}
 	redactVolatile(m)
 	return m
 }

--- a/internal/proxy/cost_response.go
+++ b/internal/proxy/cost_response.go
@@ -140,6 +140,15 @@ func (w *streamCostWriter) SetCostCalculator(calculator routerCostCalculator, in
 }
 
 func (w *streamCostWriter) Write(p []byte) (int, error) {
+	// Error fallback rendering writes a plain JSON envelope rather than an SSE
+	// event. Pass it through immediately instead of retaining it indefinitely
+	// while waiting for an SSE boundary that will never arrive.
+	if w.pending.Len() == 0 {
+		trimmed := bytes.TrimSpace(p)
+		if len(trimmed) > 0 && (trimmed[0] == '{' || trimmed[0] == '[') {
+			return w.inner.Write(p)
+		}
+	}
 	w.pending.Write(p)
 	for {
 		event, consumed := sse.SplitNext(w.pending.Bytes())

--- a/internal/proxy/cost_response.go
+++ b/internal/proxy/cost_response.go
@@ -1,0 +1,222 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"workweave/router/internal/router/catalog"
+	"workweave/router/internal/sse"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// responseCostBuffer holds non-streaming response bytes until usage has been
+// extracted and cost headers can be written before the body reaches the client.
+type responseCostBuffer struct {
+	inner       http.ResponseWriter
+	body        bytes.Buffer
+	status      int
+	writeHeader bool
+	wrote       bool
+	flushed     bool
+}
+
+func newResponseCostBuffer(inner http.ResponseWriter) *responseCostBuffer {
+	return &responseCostBuffer{inner: inner, status: http.StatusOK}
+}
+
+func (b *responseCostBuffer) Header() http.Header { return b.inner.Header() }
+
+func (b *responseCostBuffer) WriteHeader(status int) {
+	if b.writeHeader {
+		return
+	}
+	b.wrote = true
+	b.status = status
+	b.writeHeader = true
+}
+
+func (b *responseCostBuffer) Write(p []byte) (int, error) {
+	if !b.writeHeader {
+		b.WriteHeader(http.StatusOK)
+	}
+	return b.body.Write(p)
+}
+
+// FlushToClient commits the buffered status and body after cost headers have
+// been populated. It is safe to call more than once.
+func (b *responseCostBuffer) FlushToClient() error {
+	if b.flushed || !b.wrote {
+		return nil
+	}
+	b.flushed = true
+	b.inner.WriteHeader(b.status)
+	if _, err := b.inner.Write(b.body.Bytes()); err != nil {
+		return err
+	}
+	if flusher, ok := b.inner.(http.Flusher); ok {
+		flusher.Flush()
+	}
+	return nil
+}
+
+type routerResponseCost struct {
+	TotalUSD            float64 `json:"usd"`
+	InputUSD            float64 `json:"input_usd"`
+	OutputUSD           float64 `json:"output_usd"`
+	CacheReadTokens     int     `json:"cache_read_tokens"`
+	CacheCreationTokens int     `json:"cache_creation_tokens"`
+}
+
+type routerCostCalculator func(inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens int) routerResponseCost
+
+func routerCostCalculatorFor(model, provider string) routerCostCalculator {
+	pricing, ok := catalog.PriceFor(provider, model)
+	if !ok {
+		pricing, ok = catalog.PrimaryPriceFor(model)
+	}
+	if !ok {
+		return nil
+	}
+	return func(inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens int) routerResponseCost {
+		return routerResponseCostFromPricing(pricing, provider, inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens)
+	}
+}
+
+func routerResponseCostFromPricing(pricing catalog.Pricing, provider string, inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens int) routerResponseCost {
+	inputUSD := catalog.EffectiveInputCost(inputTokens, cacheCreationTokens, cacheReadTokens, pricing.InputUSDPer1M, pricing, provider)
+	outputUSD := catalog.EffectiveOutputCost(outputTokens, pricing.OutputUSDPer1M)
+	return routerResponseCost{
+		TotalUSD:            inputUSD + outputUSD,
+		InputUSD:            inputUSD,
+		OutputUSD:           outputUSD,
+		CacheReadTokens:     cacheReadTokens,
+		CacheCreationTokens: cacheCreationTokens,
+	}
+}
+
+func setRouterCostHeaders(h http.Header, cost routerResponseCost) {
+	h.Set(HeaderRouterCostUSD, strconv.FormatFloat(cost.TotalUSD, 'f', -1, 64))
+	h.Set(HeaderRouterCostInputUSD, strconv.FormatFloat(cost.InputUSD, 'f', -1, 64))
+	h.Set(HeaderRouterCostOutputUSD, strconv.FormatFloat(cost.OutputUSD, 'f', -1, 64))
+	h.Set(HeaderRouterCacheReadTokens, strconv.Itoa(cost.CacheReadTokens))
+	h.Set(HeaderRouterCacheCreationTokens, strconv.Itoa(cost.CacheCreationTokens))
+}
+
+// streamCostWriter adds the final turn's authoritative cost to the Anthropic
+// message_delta usage object while preserving all other SSE events verbatim.
+type streamCostWriter struct {
+	inner     http.ResponseWriter
+	pending   bytes.Buffer
+	calculate routerCostCalculator
+	// Translated Anthropic usage reports fresh input, while the bound pricing
+	// calculator expects OpenAI/Gemini input to include cached tokens.
+	inputIncludesCache   bool
+	messageStartInput    int
+	messageStartRead     int
+	messageStartCreation int
+}
+
+func newStreamCostWriter(inner http.ResponseWriter) *streamCostWriter {
+	return &streamCostWriter{inner: inner}
+}
+
+func (w *streamCostWriter) Header() http.Header { return w.inner.Header() }
+
+func (w *streamCostWriter) WriteHeader(status int) { w.inner.WriteHeader(status) }
+
+func (w *streamCostWriter) Flush() {
+	if flusher, ok := w.inner.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func (w *streamCostWriter) SetCostCalculator(calculator routerCostCalculator, inputIncludesCache bool) {
+	w.calculate = calculator
+	w.inputIncludesCache = inputIncludesCache
+}
+
+func (w *streamCostWriter) Write(p []byte) (int, error) {
+	w.pending.Write(p)
+	for {
+		event, consumed := sse.SplitNext(w.pending.Bytes())
+		if consumed == 0 {
+			break
+		}
+		event = w.annotateEvent(event)
+		if _, err := w.inner.Write(append(event, '\n', '\n')); err != nil {
+			return 0, err
+		}
+		w.pending.Next(consumed)
+	}
+	return len(p), nil
+}
+
+func (w *streamCostWriter) annotateEvent(event []byte) []byte {
+	eventType, data := sse.ParseEvent(event)
+	if string(eventType) == "message_start" {
+		usage := gjson.GetBytes(data, "message.usage")
+		w.messageStartInput = int(usage.Get("input_tokens").Int())
+		w.messageStartRead = int(usage.Get("cache_read_input_tokens").Int())
+		w.messageStartCreation = int(usage.Get("cache_creation_input_tokens").Int())
+		return event
+	}
+	if string(eventType) != "message_delta" || w.calculate == nil {
+		return event
+	}
+	stopReason := gjson.GetBytes(data, "delta.stop_reason")
+	if !stopReason.Exists() || stopReason.String() == "" || stopReason.String() == "null" {
+		return event
+	}
+	usage := gjson.GetBytes(data, "usage")
+	if !usage.Exists() {
+		return event
+	}
+	inputTokens := int(usage.Get("input_tokens").Int())
+	outputTokens := int(usage.Get("output_tokens").Int())
+	cacheCreation := int(usage.Get("cache_creation_input_tokens").Int())
+	cacheRead := int(usage.Get("cache_read_input_tokens").Int())
+	if inputTokens == 0 {
+		inputTokens = w.messageStartInput
+	}
+	if cacheCreation == 0 {
+		cacheCreation = w.messageStartCreation
+	}
+	if cacheRead == 0 {
+		cacheRead = w.messageStartRead
+	}
+	if w.inputIncludesCache {
+		inputTokens += cacheCreation + cacheRead
+	}
+	cost, err := json.Marshal(w.calculate(inputTokens, outputTokens, cacheCreation, cacheRead))
+	if err != nil {
+		return event
+	}
+	annotated, err := sjson.SetRawBytes(data, "usage.weave_cost", cost)
+	if err != nil {
+		return event
+	}
+	// Replace only the data payload, preserving event fields and line endings
+	// supplied by the upstream. This keeps the annotation transparent to SSE
+	// clients that rely on optional fields such as id/retry.
+	dataField := bytes.Index(event, []byte("data:"))
+	if dataField < 0 {
+		return event
+	}
+	payloadStart := dataField + len("data:")
+	for payloadStart < len(event) && (event[payloadStart] == ' ' || event[payloadStart] == '\t') {
+		payloadStart++
+	}
+	payloadEnd := len(event)
+	if lineEnd := bytes.IndexByte(event[payloadStart:], '\n'); lineEnd >= 0 {
+		payloadEnd = payloadStart + lineEnd
+	}
+	result := make([]byte, 0, len(event)-payloadEnd+payloadStart+len(annotated))
+	result = append(result, event[:payloadStart]...)
+	result = append(result, annotated...)
+	result = append(result, event[payloadEnd:]...)
+	return result
+}

--- a/internal/proxy/cost_response_test.go
+++ b/internal/proxy/cost_response_test.go
@@ -1,9 +1,12 @@
 package proxy
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"workweave/router/internal/providers"
 
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -34,6 +37,20 @@ func TestStreamCostWriterAnnotatesFinalMessageDelta(t *testing.T) {
 	require.True(t, annotated.Exists())
 	require.Equal(t, float64(1.25), annotated.Get("usd").Float())
 	require.Equal(t, int64(3), annotated.Get("cache_read_tokens").Int())
+}
+
+func TestStreamCostWriterPassesThroughJSONErrorEnvelope(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writer := newStreamCostWriter(rec)
+	err := &providers.UpstreamErrorResponse{
+		Status: http.StatusServiceUnavailable,
+		Body:   []byte(`{"type":"error","error":{"type":"api_error","message":"upstream unavailable"}}`),
+	}
+
+	flushUpstreamErrorAsAnthropic(writer, err)
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Contains(t, rec.Body.String(), "upstream unavailable")
 }
 
 func TestResponseCostBufferFlushesAfterHeaders(t *testing.T) {

--- a/internal/proxy/cost_response_test.go
+++ b/internal/proxy/cost_response_test.go
@@ -1,0 +1,66 @@
+package proxy
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestStreamCostWriterAnnotatesFinalMessageDelta(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writer := newStreamCostWriter(rec)
+	writer.SetCostCalculator(func(input, output, creation, read int) routerResponseCost {
+		return routerResponseCost{
+			TotalUSD:            1.25,
+			InputUSD:            0.75,
+			OutputUSD:           0.5,
+			CacheCreationTokens: creation,
+			CacheReadTokens:     read,
+		}
+	}, true)
+
+	_, err := writer.Write([]byte("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":10}}}\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":100,\"output_tokens\":7,\"cache_read_input_tokens\":3}}\n\n"))
+	require.NoError(t, err)
+
+	var annotated gjson.Result
+	for _, event := range strings.Split(rec.Body.String(), "\n\n") {
+		if strings.HasPrefix(event, "event: message_delta") {
+			annotated = gjson.Get(strings.TrimPrefix(strings.SplitN(event, "data: ", 2)[1], "data: "), "usage.weave_cost")
+		}
+	}
+	require.True(t, annotated.Exists())
+	require.Equal(t, float64(1.25), annotated.Get("usd").Float())
+	require.Equal(t, int64(3), annotated.Get("cache_read_tokens").Int())
+}
+
+func TestResponseCostBufferFlushesAfterHeaders(t *testing.T) {
+	rec := httptest.NewRecorder()
+	buffer := newResponseCostBuffer(rec)
+	_, err := buffer.Write([]byte(`{"ok":true}`))
+	require.NoError(t, err)
+	setRouterCostHeaders(buffer.Header(), routerResponseCost{
+		TotalUSD:            0.5,
+		InputUSD:            0.25,
+		OutputUSD:           0.25,
+		CacheReadTokens:     7,
+		CacheCreationTokens: 11,
+	})
+	require.NoError(t, buffer.FlushToClient())
+	require.Equal(t, "0.5", rec.Header().Get(HeaderRouterCostUSD))
+	require.Equal(t, "0.25", rec.Header().Get(HeaderRouterCostInputUSD))
+	require.Equal(t, "0.25", rec.Header().Get(HeaderRouterCostOutputUSD))
+	require.Equal(t, "7", rec.Header().Get(HeaderRouterCacheReadTokens))
+	require.Equal(t, "11", rec.Header().Get(HeaderRouterCacheCreationTokens))
+	require.Equal(t, `{"ok":true}`, rec.Body.String())
+}
+
+func TestResponseCostBufferDoesNotCommitEmptyResponse(t *testing.T) {
+	rec := httptest.NewRecorder()
+	buffer := newResponseCostBuffer(rec)
+	require.NoError(t, buffer.FlushToClient())
+	require.Empty(t, rec.Body.String())
+	require.False(t, rec.Flushed)
+}

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -63,6 +63,16 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		log.Error("Failed to parse Gemini request", "err", parseErr)
 		return fmt.Errorf("parse request: %w", parseErr)
 	}
+	var responseBuffer *responseCostBuffer
+	if !env.Stream() {
+		responseBuffer = newResponseCostBuffer(w)
+		w = responseBuffer
+		defer func() {
+			if flushErr := responseBuffer.FlushToClient(); flushErr != nil {
+				log.Error("Failed to flush buffered response", "err", flushErr)
+			}
+		}()
+	}
 	embedFlag := s.ResolveEmbedOnlyUserMessage(ctx)
 	feats := env.RoutingFeatures(embedFlag)
 	promptText := feats.PromptText
@@ -256,6 +266,9 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 
 	in, out := extractor.Tokens()
 	cacheCreation, cacheRead := extractor.CacheTokens()
+	if responseBuffer != nil && proxyErr == nil {
+		setRouterCostHeaders(w.Header(), routerResponseCostFromPricing(actPricing, decision.Provider, in, out, cacheCreation, cacheRead))
+	}
 	geminiUpstreamBuilder := otel.NewAttrBuilder(40).
 		String("request_id", requestID).
 		String("external_id", externalID).

--- a/internal/proxy/headers.go
+++ b/internal/proxy/headers.go
@@ -24,6 +24,16 @@ const (
 	// HeaderRouterFallbackAttempt carries the zero-based fallback attempt index
 	// that ultimately served the turn.
 	HeaderRouterFallbackAttempt = "x-router-fallback-attempt"
+	// HeaderRouterCostUSD carries actual input plus output cost in USD.
+	HeaderRouterCostUSD = "x-router-cost-usd"
+	// HeaderRouterCostInputUSD carries actual input cost in USD.
+	HeaderRouterCostInputUSD = "x-router-cost-input-usd"
+	// HeaderRouterCostOutputUSD carries actual output cost in USD.
+	HeaderRouterCostOutputUSD = "x-router-cost-output-usd"
+	// HeaderRouterCacheReadTokens carries cache-read token count.
+	HeaderRouterCacheReadTokens = "x-router-cache-read-tokens"
+	// HeaderRouterCacheCreationTokens carries cache-creation token count.
+	HeaderRouterCacheCreationTokens = "x-router-cache-creation-tokens"
 )
 
 // RouterCacheHit is the HeaderRouterCache value set when a response is served

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2169,6 +2169,11 @@ var headersToSkipOnHit = map[string]struct{}{
 	"X-Router-Context-Window": {},
 	"X-Router-Cache":          {},
 	"X-Router-Feedback-Url":   {},
+	http.CanonicalHeaderKey(HeaderRouterCostUSD):             {},
+	http.CanonicalHeaderKey(HeaderRouterCostInputUSD):        {},
+	http.CanonicalHeaderKey(HeaderRouterCostOutputUSD):       {},
+	http.CanonicalHeaderKey(HeaderRouterCacheReadTokens):     {},
+	http.CanonicalHeaderKey(HeaderRouterCacheCreationTokens): {},
 }
 
 // cloneCacheHeaders snapshots a header set for storage, dropping transient
@@ -2571,8 +2576,10 @@ func (s *Service) anthropicNativeAttempt(
 	preludeBuf *preludeBuffer,
 	marker string,
 	setExtractor func(*otel.UsageExtractor),
+	setStreamCost func(router.Decision, bool),
 ) dispatchAttempt {
 	return func(actx context.Context, d router.Decision, p providers.Client) error {
+		setStreamCost(d, false)
 		attemptSink := sink
 		if marker != "" {
 			attemptSink = translate.NewAnthropicRoutingMarkerWriter(sink, d.Model, marker)
@@ -2842,6 +2849,16 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	if parseErr != nil {
 		log.Error("Failed to parse Anthropic request", "err", parseErr)
 		return fmt.Errorf("parse request: %w", parseErr)
+	}
+	var responseBuffer *responseCostBuffer
+	if !env.Stream() {
+		responseBuffer = newResponseCostBuffer(w)
+		w = responseBuffer
+		defer func() {
+			if flushErr := responseBuffer.FlushToClient(); flushErr != nil {
+				log.Error("Failed to flush buffered response", "err", flushErr)
+			}
+		}()
 	}
 
 	apiKeyID, _ := ctx.Value(APIKeyIDContextKey{}).(string)
@@ -3421,7 +3438,10 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// wrapped below the capture layer so the footer never lands in
 	// cached/logged bodies. Transparent when streaming/feedback is off.
 	clientSink := w
+	var streamCost *streamCostWriter
 	if env.Stream() && !agentShadowMode {
+		streamCost = newStreamCostWriter(clientSink)
+		clientSink = streamCost
 		// Innermost wrap: arms only once preludeBuffer commits, so a keepalive
 		// can never strand a response the router still wants to retry.
 		if s.sseKeepalive > 0 {
@@ -3477,6 +3497,11 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// translators validate/repair model tool calls against it. Nil if no tools.
 	toolValidator := env.ToolValidator()
 	setExtractor := func(e *otel.UsageExtractor) { extractor = e }
+	setStreamCost := func(d router.Decision, inputIncludesCache bool) {
+		if streamCost != nil {
+			streamCost.SetCostCalculator(routerCostCalculatorFor(d.Model, d.Provider), inputIncludesCache)
+		}
+	}
 	// buildAttempt dispatches by translation family so new OpenAI-compat
 	// providers route automatically; a closure so in-turn model failover can
 	// re-emit for a candidate in a different family.
@@ -3490,7 +3515,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			}
 			crossFormat = false
 			logUpstreamBody(log, routeRes.SessionKey, target, feats, prep.Body)
-			native := s.anthropicNativeAttempt(env, r, prep, sink, preludeBuf, targetMarker, setExtractor)
+			native := s.anthropicNativeAttempt(env, r, prep, sink, preludeBuf, targetMarker, setExtractor, setStreamCost)
 			return func(actx context.Context, d router.Decision, p providers.Client) error {
 				err := native(actx, d, p)
 				// Cortex documents output_config.format, so the knob goes out as
@@ -3515,7 +3540,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 					preludeBuf.Discard()
 				}
 				logUpstreamBody(log, routeRes.SessionKey, target, feats, unstructuredPrep.Body)
-				return s.anthropicNativeAttempt(env, r, unstructuredPrep, sink, preludeBuf, targetMarker, setExtractor)(actx, d, p)
+				return s.anthropicNativeAttempt(env, r, unstructuredPrep, sink, preludeBuf, targetMarker, setExtractor, setStreamCost)(actx, d, p)
 			}, nil
 		case providers.FamilyOpenAICompat:
 			crossFormat = true
@@ -3528,6 +3553,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			// be re-emitted onto chat/completions before finalize commits the
 			// prelude buffer. Translators are stateful, so the retry calls again.
 			dispatchOpenAICompat := func(actx context.Context, d router.Decision, p providers.Client, useResponses, stripPromptCacheKey bool) (error, func(error) error) {
+				setStreamCost(d, true)
 				attemptOpts := targetOpts
 				attemptOpts.TargetProvider = d.Provider
 				attemptOpts.StripPromptCacheKey = stripPromptCacheKey
@@ -3655,6 +3681,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			// before finalize commits the prelude buffer and forecloses the retry.
 			// Translators are stateful, so a retry rebuilds the chain via a fresh call.
 			dispatchGemini := func(actx context.Context, d router.Decision, p providers.Client, pr providers.PreparedRequest) (error, func(error) error) {
+				setStreamCost(d, true)
 				respSummary = translate.ResponseSummary{}
 				var usage otel.UsageSink
 				if s.usageRequired() {
@@ -3885,7 +3912,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			baselineCtx = resolveAndInjectCredentials(baselineCtx, providers.ProviderAnthropic, baselineModel, r.Header)
 			baselineBindings := s.resolveBindingsForDispatch(baselineCtx, baselineDecision)
 			baselineMarker := suppressMarkerIfRequested(ctx, r.Header, baselineRoutingMarkerFor(routeRes, baselineModel))
-			baselineAttempt := s.anthropicNativeAttempt(env, r, baselinePrep, sink, preludeBuf, baselineMarker, setExtractor)
+			baselineAttempt := s.anthropicNativeAttempt(env, r, baselinePrep, sink, preludeBuf, baselineMarker, setExtractor, setStreamCost)
 			crossFormat = false
 			respSummary = translate.ResponseSummary{}
 			reqStats = providers.RequestMutationStats{}
@@ -3950,7 +3977,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 				"model", decision.Model,
 				"err", proxyErr,
 				"upstream_status", upstreamStatus(proxyErr))
-			subAttempt := s.anthropicNativeAttempt(env, r, subPrep, sink, preludeBuf, marker, setExtractor)
+			subAttempt := s.anthropicNativeAttempt(env, r, subPrep, sink, preludeBuf, marker, setExtractor, setStreamCost)
 			crossFormat = false
 			respSummary = translate.ResponseSummary{}
 			reqStats = providers.RequestMutationStats{}
@@ -4099,6 +4126,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	in, out := extractor.Tokens()
 	cacheCreation, cacheRead := extractor.CacheTokens()
+	if responseBuffer != nil && proxyErr == nil {
+		setRouterCostHeaders(w.Header(), routerResponseCostFromPricing(actPricing, decision.Provider, in, out, cacheCreation, cacheRead))
+	}
 	upstreamBuilder := otel.NewAttrBuilder(40).
 		String("request_id", requestID).
 		String("external_id", externalID).
@@ -5503,6 +5533,16 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		log.Error("Failed to parse OpenAI request", "err", parseErr)
 		return fmt.Errorf("parse request: %w", parseErr)
 	}
+	var responseBuffer *responseCostBuffer
+	if !env.Stream() {
+		responseBuffer = newResponseCostBuffer(w)
+		w = responseBuffer
+		defer func() {
+			if flushErr := responseBuffer.FlushToClient(); flushErr != nil {
+				log.Error("Failed to flush buffered response", "err", flushErr)
+			}
+		}()
+	}
 
 	// Bind session-scoped logger before stripping router-only history; see the
 	// matching Anthropic block for why the raw client session shape owns pins.
@@ -6286,6 +6326,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	in, out := extractor.Tokens()
 	cacheCreation, cacheRead := extractor.CacheTokens()
+	if responseBuffer != nil && proxyErr == nil {
+		setRouterCostHeaders(w.Header(), routerResponseCostFromPricing(actPricing, decision.Provider, in, out, cacheCreation, cacheRead))
+	}
 	openaiUpstreamBuilder := otel.NewAttrBuilder(40).
 		String("request_id", requestID).
 		String("external_id", externalID).

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -5534,7 +5534,8 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		return fmt.Errorf("parse request: %w", parseErr)
 	}
 	var responseBuffer *responseCostBuffer
-	if !env.Stream() {
+	_, isResponsesWriter := w.(*translate.ResponsesWriter)
+	if !env.Stream() && !isResponsesWriter {
 		responseBuffer = newResponseCostBuffer(w)
 		w = responseBuffer
 		defer func() {
@@ -6326,7 +6327,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	in, out := extractor.Tokens()
 	cacheCreation, cacheRead := extractor.CacheTokens()
-	if responseBuffer != nil && proxyErr == nil {
+	if !env.Stream() && proxyErr == nil {
 		setRouterCostHeaders(w.Header(), routerResponseCostFromPricing(actPricing, decision.Provider, in, out, cacheCreation, cacheRead))
 	}
 	openaiUpstreamBuilder := otel.NewAttrBuilder(40).

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -299,6 +299,16 @@ func (s *Service) bypassToAnthropic(
 		log.Error("Failed to emit Anthropic body on usage-bypass path", "err", emitErr)
 		return fmt.Errorf("emit bypass body: %w", emitErr)
 	}
+	var responseBuffer *responseCostBuffer
+	if !env.Stream() {
+		responseBuffer = newResponseCostBuffer(w)
+		w = responseBuffer
+		defer func() {
+			if flushErr := responseBuffer.FlushToClient(); flushErr != nil {
+				log.Error("Failed to flush buffered response", "err", flushErr)
+			}
+		}()
+	}
 
 	// Subscription-only mode: prepend a warning
 	// text block so the customer sees they're on their own subscription with

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -304,9 +304,15 @@ func (s *Service) bypassToAnthropic(
 	// text block so the customer sees they're on their own subscription with
 	// paid failover disabled, and how to restore full routing. The marker writer
 	// injects only on a streaming response and is transparent otherwise.
-	respW := w
+	respW := http.ResponseWriter(w)
+	var streamCost *streamCostWriter
+	if env.Stream() {
+		streamCost = newStreamCostWriter(respW)
+		streamCost.SetCostCalculator(routerCostCalculatorFor(decision.Model, decision.Provider), false)
+		respW = streamCost
+	}
 	if billing.SubscriptionOnlyFromContext(ctx) {
-		respW = translate.NewAnthropicRoutingMarkerWriter(w, decision.Model, subscriptionOnlyWarningMarker)
+		respW = translate.NewAnthropicRoutingMarkerWriter(respW, decision.Model, subscriptionOnlyWarningMarker)
 	}
 
 	// Tap the response stream so the bypass span carries token usage for
@@ -341,6 +347,9 @@ func (s *Service) bypassToAnthropic(
 	in, out := extractor.Tokens()
 	cacheCreation, cacheRead := extractor.CacheTokens()
 	pricing, _ := catalog.PriceFor(decision.Provider, decision.Model)
+	if !env.Stream() && proxyErr == nil {
+		setRouterCostHeaders(w.Header(), routerResponseCostFromPricing(pricing, decision.Provider, in, out, cacheCreation, cacheRead))
+	}
 	inputCost := catalog.EffectiveInputCost(in, cacheCreation, cacheRead, pricing.InputUSDPer1M, pricing, decision.Provider)
 	outputCost := catalog.EffectiveOutputCost(out, pricing.OutputUSDPer1M)
 

--- a/internal/proxy/usage_bypass_internal_test.go
+++ b/internal/proxy/usage_bypass_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -320,6 +321,38 @@ func TestBypass_NilError_ReturnsNil(t *testing.T) {
 
 	err := svc.bypassToAnthropic(context.Background(), env, feats, false, time.Now(), "req-1", "ext-1", turntype.MainLoop, req, rec)
 	require.NoError(t, err)
+}
+
+// TestBypass_NonStreamResponseIncludesCostHeaders verifies that usage-bypass
+// buffers non-stream responses until usage has been extracted and cost headers
+// have been populated. Without the buffer, the upstream body commits the
+// response before setRouterCostHeaders runs, so clients never see the headers.
+func TestBypass_NonStreamResponseIncludesCostHeaders(t *testing.T) {
+	const (
+		inputTokens  = 1200
+		outputTokens = 340
+	)
+	upstream := &bypassFakeProvider{respBody: `{"usage":{"input_tokens":1200,"output_tokens":340}}`}
+	svc := newBypassService(upstream)
+	svc.telemetry = newBypassCaptureTelemetry() // enables usage extraction
+
+	env := bypassAnthropicEnvelope(t)
+	feats := env.RoutingFeatures(false)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+
+	err := svc.bypassToAnthropic(context.Background(), env, feats, false, time.Now(), "req-cost", "ext-1", turntype.MainLoop, req, rec)
+	require.NoError(t, err)
+	require.Equal(t, upstream.respBody, rec.Body.String())
+
+	pricing, ok := catalog.PriceFor(providers.ProviderAnthropic, feats.Model)
+	require.True(t, ok, "test model must have catalog pricing")
+	want := routerResponseCostFromPricing(pricing, providers.ProviderAnthropic, inputTokens, outputTokens, 0, 0)
+	assert.Equal(t, strconv.FormatFloat(want.TotalUSD, 'f', -1, 64), rec.Header().Get(HeaderRouterCostUSD))
+	assert.Equal(t, strconv.FormatFloat(want.InputUSD, 'f', -1, 64), rec.Header().Get(HeaderRouterCostInputUSD))
+	assert.Equal(t, strconv.FormatFloat(want.OutputUSD, 'f', -1, 64), rec.Header().Get(HeaderRouterCostOutputUSD))
+	assert.Equal(t, "0", rec.Header().Get(HeaderRouterCacheReadTokens))
+	assert.Equal(t, "0", rec.Header().Get(HeaderRouterCacheCreationTokens))
 }
 
 // TestBypass_TransportError_ReroutesViaScorer: a raw transport error (connection

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -81,6 +81,25 @@ const (
 // analyticsSvc, when non-nil, mounts the /v1/analytics/* export surface;
 // nil leaves it unmounted (tests, deployments without telemetry storage).
 func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service, deployedModels admin.DeployedModelsSource, hmmModels admin.HMMRosterSource, mode DeploymentMode, billingSvc *billing.Service, readinessChecker admin.HealthChecker, hmmRosterSource policy.RosterSource, analyticsSvc *analytics.Service) {
+	// Browser clients need an explicit expose list before fetch can read the
+	// router's routing and cost metadata from a cross-origin response.
+	engine.Use(func(c *gin.Context) {
+		c.Header("Access-Control-Expose-Headers", strings.Join([]string{
+			proxy.HeaderRouterDecision,
+			proxy.HeaderRouterProvider,
+			proxy.HeaderRouterModel,
+			proxy.HeaderRouterContextWindow,
+			proxy.HeaderRouterCache,
+			proxy.HeaderRouterFallbackFrom,
+			proxy.HeaderRouterFallbackAttempt,
+			proxy.HeaderRouterCostUSD,
+			proxy.HeaderRouterCostInputUSD,
+			proxy.HeaderRouterCostOutputUSD,
+			proxy.HeaderRouterCacheReadTokens,
+			proxy.HeaderRouterCacheCreationTokens,
+		}, ", "))
+		c.Next()
+	})
 	// Managed mode: BYOK is opt-in per installation (see WithAuth).
 	byokRequiresOptIn := mode == DeploymentModeManaged
 


### PR DESCRIPTION
Expose actual routing costs through non-stream response headers and annotate final Anthropic streaming usage events with `weave_cost` for clients that cannot receive final headers.

Includes cache token metadata, CORS exposure, subscription-bypass stream support, cache-header replay protection, documentation, and focused tests.

Validation: `wv router tc`, `wv router t`, targeted proxy cost/conformance tests, `internal/server`, `internal/translate`, and `git diff --check`. The full proxy suite retains pre-existing failures on untouched HEAD.