### PR TITLE
fix(codex): stabilize feedback and routing surfaces

### DIFF
--- a/internal/proxy/marker_internal_test.go
+++ b/internal/proxy/marker_internal_test.go
@@ -438,3 +438,11 @@ func TestRoutingMarkerFor_SuppressesStickyTurnForAllClients(t *testing.T) {
 	}
 	assert.Empty(t, routingMarkerFor(res), "same-model suppression applies to Codex as well as Claude Code")
 }
+
+func TestRoutingMarkerFor_SuppressesEffortOnlyChange(t *testing.T) {
+	res := turnLoopResult{
+		Decision:         router.Decision{Model: "gpt-5.6-luna", Provider: "openai", Effort: "xhigh"},
+		PriorServedModel: "gpt-5.6-luna:xhigh",
+	}
+	assert.Empty(t, routingMarkerFor(res), "changing effort must not repeat the model-choice marker")
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -446,6 +446,10 @@ type nativeResponsesReasoningHashContextKey struct{}
 // nativeResponsesToolHashContextKey preserves native Responses tool identity.
 type nativeResponsesToolHashContextKey struct{}
 
+// codexFeedbackSkillContextKey marks a Responses request where Codex is
+// returning output from a user-invoked $rf skill.
+type codexFeedbackSkillContextKey struct{}
+
 // responsesFooterEchoedContextKey is set when the original Responses input
 // already carries a rating hint after the last human turn.
 type responsesFooterEchoedContextKey struct{}
@@ -620,14 +624,9 @@ func routingMarkerFor(res turnLoopResult) string {
 		return ""
 	}
 	// Same model as last turn: the user already knows. Empty prior model means
-	// the first turn of this session (or role), which still shows. Applies to
-	// both the planner-style marker and the sidecar-supplied display marker —
-	// the HMM sidecar renders `<model> · <cluster reason>` on every /route call
-	// regardless of whether the model actually changed, so a literal "fast route
-	// for this turn" / "best pick for this turn" repeating each turn would
-	// otherwise be visible even when nothing switched. Hard-pin carve-outs and
-	// first-turn (empty prior) cases still flow to the sidecar marker below.
-	if res.PriorServedModel == res.Decision.ServedIdentity() {
+	// the first turn of this session (or role), which still shows. Effort changes
+	// do not constitute a new model choice for this display surface.
+	if baseModelOf(res.PriorServedModel) == res.Decision.Model {
 		return ""
 	}
 	// A sidecar-supplied marker is a genuine per-turn status line (e.g.
@@ -5791,10 +5790,12 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	}
 	if cmd, hasCmd := env.ExtractRouterFeedbackCommand(); hasCmd {
 		log.Info("ProxyOpenAIChatCompletion router-feedback command")
-		if err := s.handleRouterFeedbackCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens, !cmd.FromToolResult); err != nil {
+		skillFeedback, _ := ctx.Value(codexFeedbackSkillContextKey{}).(bool)
+		synthetic := !cmd.FromToolResult || skillFeedback
+		if err := s.handleRouterFeedbackCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens, synthetic); err != nil {
 			return err
 		}
-		if !cmd.FromToolResult {
+		if synthetic {
 			s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
 			return nil
 		}
@@ -6765,6 +6766,9 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 		return fmt.Errorf("translate responses request: %w", err)
 	}
 	chatBody, model := conversion.Body, conversion.Model
+	if conversion.CodexFeedbackSkill {
+		ctx = context.WithValue(ctx, codexFeedbackSkillContextKey{}, true)
+	}
 	codexNativeRequest := codexResponsesRequest(ctx, r.Header)
 	nativeBody := conversion.OriginalBody
 	if clientAppCodex {

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -29,9 +29,12 @@ type ResponsesConversion struct {
 	OriginalBody []byte
 	Stream       bool
 	Model        string
-	Requirements router.TranslationRequirements
-	Report       []ResponseTransform
-	ToolMappings map[string]ResponsesToolMapping
+	// CodexFeedbackSkill reports a user-invoked $rf/$router-feedback skill
+	// whose emitted directive arrived in a later tool-result item.
+	CodexFeedbackSkill bool
+	Requirements       router.TranslationRequirements
+	Report             []ResponseTransform
+	ToolMappings       map[string]ResponsesToolMapping
 }
 
 // ResponseTransform reports an ingress conversion outcome with a stable code.

--- a/internal/translate/responses_codex.go
+++ b/internal/translate/responses_codex.go
@@ -49,42 +49,46 @@ func codexFeedbackSkillInvocation(input gjson.Result) bool {
 	if !input.IsArray() {
 		return false
 	}
-	userInvoked := false
-	for _, item := range input.Array() {
-		if item.Get("type").Str == "message" && item.Get("role").Str == "user" {
-			content := item.Get("content")
-			if codexFeedbackCommandContent(content) {
-				userInvoked = true
-			} else if !codexFeedbackSkillInstructions(content) {
-				userInvoked = false
-			}
+	items := input.Array()
+	lastUserIndex := -1
+	for index, item := range items {
+		if item.Get("type").Str != "message" || item.Get("role").Str != "user" {
 			continue
 		}
-		if !userInvoked {
+		if codexFeedbackSkillInstructions(item.Get("content")) {
 			continue
 		}
+		lastUserIndex = index
+	}
+	if lastUserIndex < 0 || !codexFeedbackCommandContent(items[lastUserIndex].Get("content")) {
+		return false
+	}
+	for _, item := range items[lastUserIndex+1:] {
 		itemType := item.Get("type").Str
 		if itemType != "function_call_output" && itemType != "custom_tool_call_output" {
 			continue
 		}
-		output := item.Get("output")
-		if output.Type == gjson.String && routerFeedbackCommandFound(output.Str) {
-			return true
-		}
-		if !output.IsArray() {
-			continue
-		}
-		var text strings.Builder
-		for _, part := range output.Array() {
-			if part.Get("type").Str == "input_text" {
-				text.WriteString(part.Get("text").Str)
-			}
-		}
-		if routerFeedbackCommandFound(text.String()) {
+		if codexFeedbackToolOutput(item.Get("output")) {
 			return true
 		}
 	}
 	return false
+}
+
+func codexFeedbackToolOutput(output gjson.Result) bool {
+	if output.Type == gjson.String {
+		return routerFeedbackCommandFound(output.Str)
+	}
+	if !output.IsArray() {
+		return false
+	}
+	var text strings.Builder
+	for _, part := range output.Array() {
+		if part.Get("type").Str == "input_text" {
+			text.WriteString(part.Get("text").Str)
+		}
+	}
+	return routerFeedbackCommandFound(text.String())
 }
 
 func codexFeedbackSkillInstructions(content gjson.Result) bool {
@@ -130,6 +134,7 @@ func routerFeedbackCommandFound(text string) bool {
 	_, found, _ := parseRouterFeedbackCommand(text)
 	return found
 }
+
 func convertPortableCodexResponses(body []byte) (ResponsesConversion, error) {
 	if err := validateResponsesRequest(body); err != nil {
 		return ResponsesConversion{}, err

--- a/internal/translate/responses_codex.go
+++ b/internal/translate/responses_codex.go
@@ -45,6 +45,91 @@ type portableCodexResponsesConverter struct {
 	tools           []map[string]any
 }
 
+func codexFeedbackSkillInvocation(input gjson.Result) bool {
+	if !input.IsArray() {
+		return false
+	}
+	userInvoked := false
+	for _, item := range input.Array() {
+		if item.Get("type").Str == "message" && item.Get("role").Str == "user" {
+			content := item.Get("content")
+			if codexFeedbackCommandContent(content) {
+				userInvoked = true
+			} else if !codexFeedbackSkillInstructions(content) {
+				userInvoked = false
+			}
+			continue
+		}
+		if !userInvoked {
+			continue
+		}
+		itemType := item.Get("type").Str
+		if itemType != "function_call_output" && itemType != "custom_tool_call_output" {
+			continue
+		}
+		output := item.Get("output")
+		if output.Type == gjson.String && routerFeedbackCommandFound(output.Str) {
+			return true
+		}
+		if !output.IsArray() {
+			continue
+		}
+		var text strings.Builder
+		for _, part := range output.Array() {
+			if part.Get("type").Str == "input_text" {
+				text.WriteString(part.Get("text").Str)
+			}
+		}
+		if routerFeedbackCommandFound(text.String()) {
+			return true
+		}
+	}
+	return false
+}
+
+func codexFeedbackSkillInstructions(content gjson.Result) bool {
+	if content.Type == gjson.String {
+		return strings.Contains(content.Str, "<skill>") && strings.Contains(content.Str, "</skill>")
+	}
+	if !content.IsArray() {
+		return false
+	}
+	for _, part := range content.Array() {
+		if part.Get("type").Str == "input_text" && codexFeedbackSkillInstructions(part.Get("text")) {
+			return true
+		}
+	}
+	return false
+}
+
+func codexFeedbackCommandContent(content gjson.Result) bool {
+	if content.Type == gjson.String {
+		return codexFeedbackCommandText(content.Str)
+	}
+	if !content.IsArray() {
+		return false
+	}
+	for _, part := range content.Array() {
+		if part.Get("type").Str == "input_text" && codexFeedbackCommandText(part.Get("text").Str) {
+			return true
+		}
+	}
+	return false
+}
+
+func codexFeedbackCommandText(text string) bool {
+	first, _, _ := strings.Cut(strings.TrimSpace(text), "\n")
+	if !strings.HasPrefix(first, "$") {
+		return false
+	}
+	_, _, found := matchRouterFeedbackCommand(first)
+	return found
+}
+
+func routerFeedbackCommandFound(text string) bool {
+	_, found, _ := parseRouterFeedbackCommand(text)
+	return found
+}
 func convertPortableCodexResponses(body []byte) (ResponsesConversion, error) {
 	if err := validateResponsesRequest(body); err != nil {
 		return ResponsesConversion{}, err
@@ -81,6 +166,7 @@ func convertPortableCodexResponses(body []byte) (ResponsesConversion, error) {
 	}
 
 	converter.collectDeclaredTools(root)
+	converter.result.CodexFeedbackSkill = codexFeedbackSkillInvocation(root.Get("input"))
 	messages := converter.convertInput(root.Get("input"))
 	var systemMessages []map[string]any
 	if instructions := root.Get("instructions").Str; instructions != "" {

--- a/internal/translate/responses_codex.go
+++ b/internal/translate/responses_codex.go
@@ -67,8 +67,10 @@ func codexFeedbackSkillInvocation(input gjson.Result) bool {
 		if itemType != "function_call_output" && itemType != "custom_tool_call_output" {
 			continue
 		}
-		matched = awaitingToolOutput && codexFeedbackToolOutput(item.Get("output"))
-		awaitingToolOutput = false
+		if awaitingToolOutput && codexFeedbackToolOutput(item.Get("output")) {
+			matched = true
+			awaitingToolOutput = false
+		}
 	}
 	return matched
 }

--- a/internal/translate/responses_codex.go
+++ b/internal/translate/responses_codex.go
@@ -49,30 +49,28 @@ func codexFeedbackSkillInvocation(input gjson.Result) bool {
 	if !input.IsArray() {
 		return false
 	}
-	items := input.Array()
-	lastUserIndex := -1
-	for index, item := range items {
-		if item.Get("type").Str != "message" || item.Get("role").Str != "user" {
-			continue
-		}
-		if codexFeedbackSkillInstructions(item.Get("content")) {
-			continue
-		}
-		lastUserIndex = index
-	}
-	if lastUserIndex < 0 || !codexFeedbackCommandContent(items[lastUserIndex].Get("content")) {
-		return false
-	}
-	for _, item := range items[lastUserIndex+1:] {
+	awaitingToolOutput := false
+	matched := false
+	for _, item := range input.Array() {
 		itemType := item.Get("type").Str
+		if itemType == "message" && item.Get("role").Str == "user" {
+			content := item.Get("content")
+			if codexFeedbackCommandContent(content) {
+				awaitingToolOutput = true
+				matched = false
+			} else if !codexFeedbackSkillInstructions(content) {
+				awaitingToolOutput = false
+				matched = false
+			}
+			continue
+		}
 		if itemType != "function_call_output" && itemType != "custom_tool_call_output" {
 			continue
 		}
-		if codexFeedbackToolOutput(item.Get("output")) {
-			return true
-		}
+		matched = awaitingToolOutput && codexFeedbackToolOutput(item.Get("output"))
+		awaitingToolOutput = false
 	}
-	return false
+	return matched
 }
 
 func codexFeedbackToolOutput(output gjson.Result) bool {

--- a/internal/translate/router_feedback_test.go
+++ b/internal/translate/router_feedback_test.go
@@ -411,6 +411,24 @@ func TestExtractRouterFeedbackCommand_CodexSkillResponsesToolResult(t *testing.T
 	assert.True(t, res.FromToolResult)
 	assert.Equal(t, translate.RouterFeedbackRatingUp, res.Rating)
 }
+
+func TestCodexFeedbackSkillDoesNotLatchAcrossTurns(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "gpt-5.6-terra",
+		"input": []any{
+			map[string]any{"type": "message", "role": "user", "content": "$rf +"},
+			map[string]any{"type": "message", "role": "user", "content": "<skill>\n<name>rf</name>\nrun the feedback skill\n</skill>"},
+			map[string]any{"type": "custom_tool_call", "call_id": "call_skill", "name": "exec", "input": "..."},
+			map[string]any{"type": "custom_tool_call_output", "call_id": "call_skill", "output": " /router-feedback +\n"},
+			map[string]any{"type": "message", "role": "user", "content": "continue working"},
+			map[string]any{"type": "custom_tool_call_output", "call_id": "call_other", "output": " /router-feedback +\n"},
+		},
+	})
+	converted, err := translate.ConvertResponsesToChatCompletionsWithOptions(body, translate.ResponsesConversionOptions{PortableCodex: true})
+	require.NoError(t, err)
+	assert.False(t, converted.CodexFeedbackSkill)
+}
+
 func TestExtractRouterFeedbackCommand_CodexExecDocumentationIsNotCommand(t *testing.T) {
 	body := mustMarshalJSON(t, map[string]any{
 		"model": "gpt-5.6-sol",

--- a/internal/translate/router_feedback_test.go
+++ b/internal/translate/router_feedback_test.go
@@ -384,6 +384,33 @@ func TestExtractRouterFeedbackCommand_CodexExecPreamble(t *testing.T) {
 	assert.Equal(t, "too slow", res.Feedback)
 }
 
+func TestExtractRouterFeedbackCommand_CodexSkillResponsesToolResult(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "gpt-5.6-terra",
+		"input": []any{
+			map[string]any{"type": "message", "role": "user", "content": "$rf +"},
+			map[string]any{"type": "message", "role": "user", "content": "<skill>\n<name>rf</name>\nrun the feedback skill\n</skill>"},
+			map[string]any{"type": "custom_tool_call", "call_id": "call_skill", "name": "exec", "input": "..."},
+			map[string]any{
+				"type": "custom_tool_call_output", "call_id": "call_skill",
+				"output": []any{
+					map[string]any{"type": "input_text", "text": "Script completed\nOutput:\n"},
+					map[string]any{"type": "input_text", "text": " /router-feedback +\n"},
+				},
+			},
+		},
+	})
+	converted, err := translate.ConvertResponsesToChatCompletionsWithOptions(body, translate.ResponsesConversionOptions{PortableCodex: true})
+	require.NoError(t, err)
+	assert.True(t, converted.CodexFeedbackSkill)
+
+	env, err := translate.ParseOpenAI(converted.Body)
+	require.NoError(t, err)
+	res, found := env.ExtractRouterFeedbackCommand()
+	require.True(t, found)
+	assert.True(t, res.FromToolResult)
+	assert.Equal(t, translate.RouterFeedbackRatingUp, res.Rating)
+}
 func TestExtractRouterFeedbackCommand_CodexExecDocumentationIsNotCommand(t *testing.T) {
 	body := mustMarshalJSON(t, map[string]any{
 		"model": "gpt-5.6-sol",

--- a/internal/translate/router_feedback_test.go
+++ b/internal/translate/router_feedback_test.go
@@ -391,13 +391,11 @@ func TestExtractRouterFeedbackCommand_CodexSkillResponsesToolResult(t *testing.T
 			map[string]any{"type": "message", "role": "user", "content": "$rf +"},
 			map[string]any{"type": "message", "role": "user", "content": "<skill>\n<name>rf</name>\nrun the feedback skill\n</skill>"},
 			map[string]any{"type": "custom_tool_call", "call_id": "call_skill", "name": "exec", "input": "..."},
-			map[string]any{
-				"type": "custom_tool_call_output", "call_id": "call_skill",
-				"output": []any{
-					map[string]any{"type": "input_text", "text": "Script completed\nOutput:\n"},
-					map[string]any{"type": "input_text", "text": " /router-feedback +\n"},
-				},
-			},
+			map[string]any{"type": "custom_tool_call_output", "call_id": "call_skill", "output": "Script completed\n"},
+			map[string]any{"type": "custom_tool_call_output", "call_id": "call_skill", "output": []any{
+				map[string]any{"type": "input_text", "text": "Script completed\nOutput:\n"},
+				map[string]any{"type": "input_text", "text": " /router-feedback +\n"},
+			}},
 		},
 	})
 	converted, err := translate.ConvertResponsesToChatCompletionsWithOptions(body, translate.ResponsesConversionOptions{PortableCodex: true})


### PR DESCRIPTION
## Summary

- Return a synthetic acknowledgment when a user-invoked Codex `$rf` skill emits its `/router-feedback` directive through a tool result, instead of leaving Codex with no response and allowing the skill to loop.
- Suppress repeated routing badges when only the effort suffix changes (for example, `gpt-5.6-luna:xhigh` to `gpt-5.6-luna`).
- Add regression coverage for the exact Codex Responses tool-result shape and effort-only model identity changes.

## Validation

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `git diff --check`

🤖 Generated with [Weave Router](https://router.workweave.ai)