### PR TITLE
fix(router): gate readiness on postgres health

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -1261,7 +1261,8 @@ func main() {
 	// fallback keeps non-cluster routers bootable.
 	deployedModels, _ := rtr.(*cluster.Multiversion)
 	analyticsSvc := analytics.NewService(repo.Analytics, time.Now)
-	server.Register(engine, authSvc, proxySvc, deployedModels, hmmRosterModels, deploymentMode, billingSvc, hmmReadinessChecker, hmmRosterSource, analyticsSvc)
+	readinessChecker := newReadinessChecker(pool, hmmReadinessChecker)
+	server.Register(engine, authSvc, proxySvc, deployedModels, hmmRosterModels, deploymentMode, billingSvc, readinessChecker, hmmRosterSource, analyticsSvc)
 
 	srv := &http.Server{
 		Addr:    ":" + config.GetOr("PORT", "8080"),

--- a/cmd/router/readiness.go
+++ b/cmd/router/readiness.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"workweave/router/internal/api/admin"
+)
+
+type databasePinger interface {
+	Ping(context.Context) error
+}
+
+type readinessChecker struct {
+	database databasePinger
+	hmm      admin.HealthChecker
+}
+
+func newReadinessChecker(database databasePinger, hmm admin.HealthChecker) admin.HealthChecker {
+	return readinessChecker{database: database, hmm: hmm}
+}
+
+func (c readinessChecker) CheckHealth(ctx context.Context) error {
+	if err := c.database.Ping(ctx); err != nil {
+		return fmt.Errorf("postgres readiness check failed: %w", err)
+	}
+	if c.hmm == nil {
+		return nil
+	}
+	if err := c.hmm.CheckHealth(ctx); err != nil {
+		return fmt.Errorf("HMM readiness check failed: %w", err)
+	}
+	return nil
+}

--- a/cmd/router/readiness_test.go
+++ b/cmd/router/readiness_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/api/admin"
+)
+
+type databasePingerFunc func(context.Context) error
+
+func (f databasePingerFunc) Ping(ctx context.Context) error {
+	return f(ctx)
+}
+
+type healthCheckerFunc func(context.Context) error
+
+func (f healthCheckerFunc) CheckHealth(ctx context.Context) error {
+	return f(ctx)
+}
+
+func TestReadinessCheckerRequiresDatabase(t *testing.T) {
+	databaseErr := errors.New("connection reset by peer")
+	checker := newReadinessChecker(databasePingerFunc(func(context.Context) error {
+		return databaseErr
+	}), healthCheckerFunc(func(context.Context) error {
+		t.Fatal("HMM readiness should not run when PostgreSQL is unavailable")
+		return nil
+	}))
+
+	err := checker.CheckHealth(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, databaseErr)
+	assert.ErrorContains(t, err, "postgres readiness check failed")
+}
+
+func TestReadinessCheckerChecksHMMAfterDatabase(t *testing.T) {
+	var checks []string
+	hmmErr := errors.New("sidecar unavailable")
+	checker := newReadinessChecker(databasePingerFunc(func(context.Context) error {
+		checks = append(checks, "postgres")
+		return nil
+	}), healthCheckerFunc(func(context.Context) error {
+		checks = append(checks, "hmm")
+		return hmmErr
+	}))
+
+	err := checker.CheckHealth(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, hmmErr)
+	assert.Equal(t, []string{"postgres", "hmm"}, checks)
+}
+
+func TestReadinessCheckerWithoutHMM(t *testing.T) {
+	checker := newReadinessChecker(databasePingerFunc(func(context.Context) error {
+		return nil
+	}), nil)
+
+	assert.NoError(t, checker.CheckHealth(context.Background()))
+}
+
+var _ admin.HealthChecker = readinessChecker{}


### PR DESCRIPTION
## Summary

- require a successful PostgreSQL pool ping before the router reports ready
- preserve optional HMM readiness checks after the database check
- add unit coverage for database failures, HMM failures, ordering, and no-HMM deployments

## Validation

- `go vet ./...`
- `go test ./...`
- `wv router tc`
- `wv router t`

The WorkWeave parent repository should bump its `router-internal/router` gitlink after this PR merges.