### PR TITLE
ci: enforce Go architecture and precise rollbacks

### DIFF
--- a/.github/workflows/check_migrations.yml
+++ b/.github/workflows/check_migrations.yml
@@ -43,6 +43,13 @@ jobs:
         run: |
           set -o pipefail
 
+          echo "Checking down migrations for imprecise rollback guards..."
+          if grep -niE 'IF[[:space:]]+EXISTS' db/migrations/*.down.sql; then
+            echo "::error::Down migrations must be precise rollbacks without IF EXISTS"
+            exit 1
+          fi
+          echo "  Down migrations use precise rollbacks"
+
           CHANGED_MIGRATIONS=$(git diff --diff-filter=A --name-only origin/${BASE_REF}...HEAD -- db/migrations/*.sql | sort)
 
           if [ -z "$CHANGED_MIGRATIONS" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,11 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      - name: Lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.6.2
+
       - name: Typecheck
         run: go build -o /dev/null ./...
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,45 @@
+version: "2"
+
+run:
+  tests: true
+
+linters:
+  default: none
+  enable:
+    - depguard
+    - errorlint
+    - govet
+  settings:
+    errorlint:
+      comparison: true
+      asserts: true
+      errorf: false
+    depguard:
+      rules:
+        leaf:
+          files:
+            - "**/internal/config/**"
+            - "**/internal/observability/*.go"
+            - "!**/*_test.go"
+          deny:
+            - pkg: workweave/router/internal
+              desc: leaf utilities cannot import internal packages
+        presentation:
+          files:
+            - "**/internal/api/**"
+            - "**/internal/server/**"
+            - "!**/*_test.go"
+          deny:
+            - pkg: workweave/router/internal/postgres
+            - pkg: workweave/router/internal/sqlc
+            - pkg: workweave/router/internal/translate
+            - pkg: workweave/router/internal/providers/
+            - pkg: github.com/jackc/pgx
+        pgx-only-postgres:
+          files:
+            - "**/internal/**"
+            - "!**/internal/postgres/**"
+            - "!**/internal/sqlc/**"
+            - "!**/*_test.go"
+          deny:
+            - pkg: github.com/jackc/pgx

--- a/db/migrations/0015_loop-escalation-events.down.sql
+++ b/db/migrations/0015_loop-escalation-events.down.sql
@@ -1,5 +1,5 @@
 BEGIN;
 
-DROP TABLE IF EXISTS router.loop_escalation_events;
+DROP TABLE router.loop_escalation_events;
 
 COMMIT;

--- a/db/migrations/0018_spiral-shadow-events.down.sql
+++ b/db/migrations/0018_spiral-shadow-events.down.sql
@@ -1,5 +1,5 @@
 BEGIN;
 
-DROP TABLE IF EXISTS router.spiral_shadow_events;
+DROP TABLE router.spiral_shadow_events;
 
 COMMIT;

--- a/db/migrations/0019_telemetry-response-outcome.down.sql
+++ b/db/migrations/0019_telemetry-response-outcome.down.sql
@@ -1,13 +1,13 @@
 BEGIN;
 
-DROP VIEW IF EXISTS router.production_request_telemetry;
+DROP VIEW router.production_request_telemetry;
 
 ALTER TABLE router.model_router_request_telemetry
-    DROP COLUMN IF EXISTS upstream_finish_reason,
-    DROP COLUMN IF EXISTS stop_reason,
-    DROP COLUMN IF EXISTS tool_use_blocks,
-    DROP COLUMN IF EXISTS invalid_tool_args_blocks,
-    DROP COLUMN IF EXISTS failover_used,
-    DROP COLUMN IF EXISTS degenerate_shadow;
+    DROP COLUMN upstream_finish_reason,
+    DROP COLUMN stop_reason,
+    DROP COLUMN tool_use_blocks,
+    DROP COLUMN invalid_tool_args_blocks,
+    DROP COLUMN failover_used,
+    DROP COLUMN degenerate_shadow;
 
 COMMIT;

--- a/db/migrations/0036_policy-shadow-decisions.down.sql
+++ b/db/migrations/0036_policy-shadow-decisions.down.sql
@@ -1,5 +1,5 @@
 BEGIN;
 
-DROP TABLE IF EXISTS router.policy_shadow_decisions;
+DROP TABLE router.policy_shadow_decisions;
 
 COMMIT;

--- a/internal/api/feedback/feedback.go
+++ b/internal/api/feedback/feedback.go
@@ -5,6 +5,7 @@
 package feedback
 
 import (
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"io"
@@ -17,7 +18,6 @@ import (
 	"workweave/router/internal/proxy"
 
 	"github.com/gin-gonic/gin"
-	"github.com/jackc/pgx/v5"
 )
 
 // maxBodyBytes caps the feedback submission payload. A rating + short comment is
@@ -59,7 +59,7 @@ func GetContextHandler(svc *proxy.Service) gin.HandlerFunc {
 		}
 
 		fctx, err := svc.GetFeedbackContext(c.Request.Context(), claims.InstallationID, claims.RequestID)
-		if errors.Is(err, pgx.ErrNoRows) {
+		if errors.Is(err, sql.ErrNoRows) {
 			// Token is valid but no telemetry row exists (telemetry disabled or
 			// pruned past retention). Render the page with just the request id
 			// so the user can still leave feedback.

--- a/internal/providers/google/native_integration_test.go
+++ b/internal/providers/google/native_integration_test.go
@@ -1,5 +1,4 @@
 //go:build google_integration
-// +build google_integration
 
 package google_test
 

--- a/internal/proxy/dispatch_error.go
+++ b/internal/proxy/dispatch_error.go
@@ -355,7 +355,7 @@ func ClassifyDispatchError(err error) (DispatchErrorClass, bool) {
 // "emit body: ". Falls back to err.Error().
 func unwrapToSentinelMessage(err error) string {
 	for e := err; e != nil; e = errors.Unwrap(e) {
-		if child := errors.Unwrap(e); child == translate.ErrAnthropicCacheControlOverflow || child == translate.ErrAnthropicCacheControlInvalid {
+		if child := errors.Unwrap(e); errors.Unwrap(child) == nil && (errors.Is(child, translate.ErrAnthropicCacheControlOverflow) || errors.Is(child, translate.ErrAnthropicCacheControlInvalid)) {
 			return e.Error()
 		}
 	}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,7 +1,49 @@
 // Package router defines the Router interface and its Decision/Request types.
 package router
 
-import "context"
+import (
+	"context"
+	"strings"
+)
+
+type effortLevel string
+
+const (
+	effortLow    effortLevel = "low"
+	effortMedium effortLevel = "medium"
+	effortHigh   effortLevel = "high"
+	effortMax    effortLevel = "max"
+	effortXHigh  effortLevel = "xhigh"
+)
+
+// CanonicalizeEffort maps user-facing aliases to canonical effort levels.
+// Unknown values pass through so request boundaries can reject them.
+func CanonicalizeEffort(level string) string {
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "fast", string(effortLow), "minimal", "min":
+		return string(effortLow)
+	case string(effortMedium), "med":
+		return string(effortMedium)
+	case string(effortHigh):
+		return string(effortHigh)
+	case string(effortMax):
+		return string(effortMax)
+	case "ultra", string(effortXHigh):
+		return string(effortXHigh)
+	default:
+		return level
+	}
+}
+
+// IsValidEffort reports whether level canonicalizes to a supported effort.
+func IsValidEffort(level string) bool {
+	switch CanonicalizeEffort(level) {
+	case string(effortLow), string(effortMedium), string(effortHigh), string(effortMax), string(effortXHigh):
+		return true
+	default:
+		return false
+	}
+}
 
 // WireFormat identifies the client-facing request representation. It is kept
 // independent from provider names so the router package remains an inner-ring

--- a/internal/server/middleware/force_effort_override.go
+++ b/internal/server/middleware/force_effort_override.go
@@ -5,7 +5,6 @@ import (
 
 	"workweave/router/internal/observability"
 	"workweave/router/internal/router"
-	"workweave/router/internal/translate"
 
 	"github.com/gin-gonic/gin"
 )
@@ -22,11 +21,11 @@ func WithForceEffortOverride() gin.HandlerFunc {
 			c.Next()
 			return
 		}
-		if !translate.IsValidEffort(raw) {
+		if !router.IsValidEffort(raw) {
 			abortInvalidKnob(c, ForceEffortOverrideHeader+" must be one of: low, medium, high, max, xhigh (or aliases fast/minimal/ultra).")
 			return
 		}
-		canonical := translate.CanonicalizeEffort(raw)
+		canonical := router.CanonicalizeEffort(raw)
 		// Merge with any existing routing knobs (e.g. from WithRoutingKnobsOverride)
 		// so ForceEffort doesn't silently drop a separately-configured Alpha/QualityBias.
 		merged := router.Overrides{ForceEffort: canonical}

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -1130,32 +1130,14 @@ const (
 // wire strings (low/medium/high/max/xhigh). Unknown values pass through so
 // IsValidEffort can reject typos at the boundary.
 func CanonicalizeEffort(level string) string {
-	switch strings.ToLower(strings.TrimSpace(level)) {
-	case "fast", "low", "minimal", "min":
-		return effortLow
-	case "medium", "med":
-		return effortMedium
-	case "high":
-		return effortHigh
-	case "max":
-		return effortMax
-	case "ultra", "xhigh":
-		return effortXhigh
-	default:
-		return level
-	}
+	return router.CanonicalizeEffort(level)
 }
 
 // IsValidEffort reports whether the canonicalized level is one the router
 // accepts as wire output. Returns false for typos so middleware can 400
 // rather than forward garbage to a provider.
 func IsValidEffort(level string) bool {
-	switch CanonicalizeEffort(level) {
-	case effortLow, effortMedium, effortHigh, effortMax, effortXhigh:
-		return true
-	default:
-		return false
-	}
+	return router.IsValidEffort(level)
 }
 
 // ResolveForceEffort canonicalizes level and applies the per-model cap

--- a/internal/translate/toolcheck/repair.go
+++ b/internal/translate/toolcheck/repair.go
@@ -1,6 +1,7 @@
 package toolcheck
 
 import (
+	"errors"
 	"strconv"
 	"strings"
 
@@ -34,8 +35,8 @@ func repairArgs(schema *jsonschema.Schema, args string, verr error) (out string,
 	out = args
 	current := verr
 	for pass := 0; pass < maxRepairPasses; pass++ {
-		validationErr, ok := current.(*jsonschema.ValidationError)
-		if !ok {
+		var validationErr *jsonschema.ValidationError
+		if !errors.As(current, &validationErr) {
 			return out, actions
 		}
 		passActions := applyLeafRepairs(&out, validationErr)

--- a/internal/translate/toolcheck/toolcheck.go
+++ b/internal/translate/toolcheck/toolcheck.go
@@ -14,6 +14,7 @@
 package toolcheck
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -343,8 +344,8 @@ func normalizeArgs(args string, required map[string]struct{}) (out string, actio
 // detailFromError renders the first leaf validation error as
 // "/instance/path: message", truncated.
 func detailFromError(err error) string {
-	verr, ok := err.(*jsonschema.ValidationError)
-	if !ok {
+	var verr *jsonschema.ValidationError
+	if !errors.As(err, &verr) {
 		return truncateDetail(err.Error())
 	}
 	leaf := firstLeaf(verr)


### PR DESCRIPTION
## Summary

- add a pinned golangci-lint v2 gate for govet, errorlint, and depguard
- enforce leaf, presentation, and pgx/sqlc import boundaries while clearing the current violations
- reject IF EXISTS in down migrations and make the existing rollbacks precise

## Validation

- `golangci-lint v2.6.2 run ./...`
- `go vet ./...`
- `go build -o /dev/null ./...`
- `go test -count=1 ./...`
- full Postgres migration `up -> down -all -> up` across all 77 migrations
- down-migration precision grep