### PR TITLE
ci: add changed-file non-Go checks

### DIFF
--- a/.github/workflows/non_go_checks.yml
+++ b/.github/workflows/non_go_checks.yml
@@ -1,0 +1,105 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Non-Go checks
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: non-go-checks-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  changed-files:
+    name: TypeScript, ShellCheck, and Ruff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Test changed-file selection
+        run: scripts/tests/changed_non_go_files_test.sh
+
+      - name: Collect changed files
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          manifest_dir="$RUNNER_TEMP/non-go-checks"
+          mkdir -p "$manifest_dir"
+
+          for category in typescript shell python; do
+            scripts/changed_non_go_files.sh "$BASE_SHA" "$HEAD_SHA" "$category" > "$manifest_dir/$category"
+            if [ -s "$manifest_dir/$category" ]; then
+              echo "$category=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "$category=false" >> "$GITHUB_OUTPUT"
+            fi
+          done
+
+      - name: Set up Node
+        if: steps.changes.outputs.typescript == 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Typecheck frontend
+        if: steps.changes.outputs.typescript == 'true'
+        working-directory: frontend
+        run: |
+          npm ci --no-audit --no-fund
+          npm run typecheck
+
+      - name: Install ShellCheck
+        if: steps.changes.outputs.shell == 'true'
+        env:
+          SHELLCHECK_VERSION: 0.11.0
+          SHELLCHECK_SHA256: 8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/shellcheck.tar.xz"
+          curl --fail --location --silent --show-error \
+            --output "$archive" \
+            "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          echo "$SHELLCHECK_SHA256  $archive" | sha256sum --check
+          tar -xJf "$archive" -C "$RUNNER_TEMP"
+          echo "$RUNNER_TEMP/shellcheck-v${SHELLCHECK_VERSION}" >> "$GITHUB_PATH"
+
+      - name: Check changed shell scripts
+        if: steps.changes.outputs.shell == 'true'
+        run: |
+          set -euo pipefail
+          shell_files=()
+          while IFS= read -r -d '' path; do
+            shell_files+=("$path")
+          done < "$RUNNER_TEMP/non-go-checks/shell"
+          shellcheck --severity=warning "${shell_files[@]}"
+
+      - name: Set up Python
+        if: steps.changes.outputs.python == 'true'
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12.3"
+
+      - name: Install Ruff
+        if: steps.changes.outputs.python == 'true'
+        run: python -m pip install --disable-pip-version-check ruff==0.16.6
+
+      - name: Check changed Python files
+        if: steps.changes.outputs.python == 'true'
+        run: |
+          set -euo pipefail
+          python_files=()
+          while IFS= read -r -d '' path; do
+            python_files+=("$path")
+          done < "$RUNNER_TEMP/non-go-checks/python"
+          ruff check --isolated --select E4,E7,E9,F --target-version py312 -- "${python_files[@]}"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",

--- a/scripts/changed_non_go_files.sh
+++ b/scripts/changed_non_go_files.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: $0 BASE_REF HEAD_REF typescript|shell|python" >&2
+  exit 2
+fi
+
+base_ref="$1"
+head_ref="$2"
+category="$3"
+
+case "$category" in
+  typescript | shell | python) ;;
+  *)
+    echo "unknown file category: $category" >&2
+    exit 2
+    ;;
+esac
+
+git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null
+git rev-parse --verify --quiet "${head_ref}^{commit}" >/dev/null
+git merge-base "$base_ref" "$head_ref" >/dev/null
+
+git diff --name-only --diff-filter=ACMR -z "${base_ref}...${head_ref}" -- |
+  while IFS= read -r -d '' path; do
+    [ -f "$path" ] || continue
+
+    case "$category" in
+      typescript)
+        case "$path" in
+          frontend/*.ts | frontend/*.tsx | frontend/package.json | frontend/package-lock.json | frontend/tsconfig.json)
+            printf '%s\0' "$path"
+            ;;
+        esac
+        ;;
+      shell)
+        case "$path" in
+          *.sh)
+            printf '%s\0' "$path"
+            ;;
+          *)
+            first_line=""
+            IFS= read -r first_line < "$path" || true
+            if [[ "$first_line" =~ ^#!.*[/[:space:]](ba|z|k)?sh([[:space:]]|$) ]]; then
+              printf '%s\0' "$path"
+            fi
+            ;;
+        esac
+        ;;
+      python)
+        case "$path" in
+          *.py) printf '%s\0' "$path" ;;
+        esac
+        ;;
+    esac
+  done

--- a/scripts/tests/changed_non_go_files_test.sh
+++ b/scripts/tests/changed_non_go_files_test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+selector="$repo_root/scripts/changed_non_go_files.sh"
+fixture_repo="$(mktemp -d)"
+trap 'rm -rf "$fixture_repo"' EXIT
+
+git -C "$fixture_repo" init --quiet
+git -C "$fixture_repo" config user.email "checks@example.com"
+git -C "$fixture_repo" config user.name "Changed-file checks"
+
+mkdir -p "$fixture_repo/frontend/src" "$fixture_repo/install" "$fixture_repo/scripts"
+printf '{"private":true}\n' > "$fixture_repo/frontend/package.json"
+printf 'export const oldValue = 1;\n' > "$fixture_repo/frontend/src/old.ts"
+printf '#!/usr/bin/env python3\nprint("deleted")\n' > "$fixture_repo/scripts/deleted file.py"
+printf 'documentation\n' > "$fixture_repo/README.md"
+git -C "$fixture_repo" add frontend install scripts README.md
+git -C "$fixture_repo" commit --quiet -m baseline
+base_ref="$(git -C "$fixture_repo" rev-parse HEAD)"
+
+printf '{"private":true,"scripts":{"typecheck":"tsc --noEmit"}}\n' > "$fixture_repo/frontend/package.json"
+printf 'export const currentValue = 2;\n' > "$fixture_repo/frontend/src/new component.tsx"
+printf '#!/usr/bin/env bash\necho extensionless\n' > "$fixture_repo/install/spin"
+printf '#!/usr/bin/env bash\necho spaced\n' > "$fixture_repo/install/space script.sh"
+printf 'print("lint me")\n' > "$fixture_repo/scripts/check me.py"
+rm "$fixture_repo/scripts/deleted file.py"
+printf 'updated documentation\n' > "$fixture_repo/README.md"
+git -C "$fixture_repo" add frontend install scripts README.md
+git -C "$fixture_repo" commit --quiet -m head
+head_ref="$(git -C "$fixture_repo" rev-parse HEAD)"
+
+assert_files() {
+  category="$1"
+  shift
+  expected=("$@")
+  actual=()
+  while IFS= read -r -d '' path; do
+    actual+=("$path")
+  done < <(cd "$fixture_repo" && "$selector" "$base_ref" "$head_ref" "$category")
+
+  if [ "${#actual[@]}" -ne "${#expected[@]}" ]; then
+    printf 'expected %s %s files, got %s: %s\n' "$category" "${#expected[@]}" "${#actual[@]}" "${actual[*]}" >&2
+    exit 1
+  fi
+
+  for index in "${!expected[@]}"; do
+    if [ "${actual[$index]}" != "${expected[$index]}" ]; then
+      printf 'expected %s file %s to be %q, got %q\n' "$category" "$index" "${expected[$index]}" "${actual[$index]}" >&2
+      exit 1
+    fi
+  done
+}
+
+assert_files typescript \
+  "frontend/package.json" \
+  "frontend/src/new component.tsx"
+assert_files shell \
+  "install/space script.sh" \
+  "install/spin"
+assert_files python \
+  "scripts/check me.py"
+
+echo "changed non-Go file selection passed"


### PR DESCRIPTION
## Summary

- typecheck the existing frontend TypeScript project when its TypeScript sources or npm/tsconfig inputs change
- run pinned ShellCheck 0.11.0 and Ruff 0.16.6 only on changed, non-deleted files
- preserve filenames exactly with NUL-delimited Git output and test spaces, deletions, config changes, and extensionless shell scripts
- pin third-party actions to immutable commits and verify the ShellCheck release checksum

## Validation

- `make check` (sqlc 1.30.0)
- `scripts/tests/changed_non_go_files_test.sh`
- `shellcheck --severity=warning scripts/changed_non_go_files.sh scripts/tests/changed_non_go_files_test.sh`
- `npm ci --prefix frontend --no-audit --no-fund`
- `npm run typecheck --prefix frontend`
- `npm run build --prefix frontend`
- `ruff check --isolated --select E4,E7,E9,F --target-version py312 -- scripts/embed_register_probes.py scripts/export_qwen3_onnx.py install/pi-router/test/mock_router.py`
- `actionlint .github/workflows/non_go_checks.yml`

No CODEOWNERS or ownership-policy changes are included.