### PR TITLE
ci: enforce Go boundaries and precise migrations

### DIFF
--- a/.github/workflows/check_migrations.yml
+++ b/.github/workflows/check_migrations.yml
@@ -39,6 +39,13 @@ jobs:
           fi
           echo "BASE_REF=${BASE_REF}" >> $GITHUB_ENV
 
+      - name: Check down migrations are precise
+        run: |
+          if grep -niE '\bIF EXISTS\b' db/migrations/*.down.sql; then
+            echo "::error::Down migrations must be precise rollbacks"
+            exit 1
+          fi
+
       - name: Check migration format and ordering
         run: |
           set -o pipefail

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,11 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      - name: Lint
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
+        with:
+          version: v2.6.2
+
       - name: Typecheck
         run: go build -o /dev/null ./...
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,44 @@
+version: "2"
+
+run:
+  tests: true
+
+linters:
+  default: none
+  enable:
+    - depguard
+    - errorlint
+  settings:
+    errorlint:
+      comparison: true
+      asserts: true
+      errorf: false
+    depguard:
+      rules:
+        leaf:
+          files:
+            - "**/internal/config/**"
+            - "**/internal/observability/*.go"
+            - "!**/*_test.go"
+          deny:
+            - pkg: workweave/router/internal
+              desc: leaf utilities cannot import internal packages
+        presentation:
+          files:
+            - "**/internal/api/**"
+            - "**/internal/server/**"
+            - "!**/*_test.go"
+          deny:
+            - pkg: workweave/router/internal/postgres
+            - pkg: workweave/router/internal/sqlc
+            - pkg: workweave/router/internal/translate
+            - pkg: workweave/router/internal/providers/
+            - pkg: github.com/jackc/pgx
+        pgx-only-postgres:
+          files:
+            - "**/internal/**"
+            - "!**/internal/postgres/**"
+            - "!**/internal/sqlc/**"
+            - "!**/*_test.go"
+          deny:
+            - pkg: github.com/jackc/pgx

--- a/db/migrations/0015_loop-escalation-events.down.sql
+++ b/db/migrations/0015_loop-escalation-events.down.sql
@@ -1,5 +1,5 @@
 BEGIN;
 
-DROP TABLE IF EXISTS router.loop_escalation_events;
+DROP TABLE router.loop_escalation_events;
 
 COMMIT;

--- a/db/migrations/0018_spiral-shadow-events.down.sql
+++ b/db/migrations/0018_spiral-shadow-events.down.sql
@@ -1,5 +1,5 @@
 BEGIN;
 
-DROP TABLE IF EXISTS router.spiral_shadow_events;
+DROP TABLE router.spiral_shadow_events;
 
 COMMIT;

--- a/db/migrations/0019_telemetry-response-outcome.down.sql
+++ b/db/migrations/0019_telemetry-response-outcome.down.sql
@@ -1,13 +1,13 @@
 BEGIN;
 
-DROP VIEW IF EXISTS router.production_request_telemetry;
+DROP VIEW router.production_request_telemetry;
 
 ALTER TABLE router.model_router_request_telemetry
-    DROP COLUMN IF EXISTS upstream_finish_reason,
-    DROP COLUMN IF EXISTS stop_reason,
-    DROP COLUMN IF EXISTS tool_use_blocks,
-    DROP COLUMN IF EXISTS invalid_tool_args_blocks,
-    DROP COLUMN IF EXISTS failover_used,
-    DROP COLUMN IF EXISTS degenerate_shadow;
+    DROP COLUMN upstream_finish_reason,
+    DROP COLUMN stop_reason,
+    DROP COLUMN tool_use_blocks,
+    DROP COLUMN invalid_tool_args_blocks,
+    DROP COLUMN failover_used,
+    DROP COLUMN degenerate_shadow;
 
 COMMIT;

--- a/db/migrations/0036_policy-shadow-decisions.down.sql
+++ b/db/migrations/0036_policy-shadow-decisions.down.sql
@@ -1,5 +1,5 @@
 BEGIN;
 
-DROP TABLE IF EXISTS router.policy_shadow_decisions;
+DROP TABLE router.policy_shadow_decisions;
 
 COMMIT;

--- a/internal/api/feedback/feedback.go
+++ b/internal/api/feedback/feedback.go
@@ -5,6 +5,7 @@
 package feedback
 
 import (
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"io"
@@ -17,7 +18,6 @@ import (
 	"workweave/router/internal/proxy"
 
 	"github.com/gin-gonic/gin"
-	"github.com/jackc/pgx/v5"
 )
 
 // maxBodyBytes caps the feedback submission payload. A rating + short comment is
@@ -59,7 +59,7 @@ func GetContextHandler(svc *proxy.Service) gin.HandlerFunc {
 		}
 
 		fctx, err := svc.GetFeedbackContext(c.Request.Context(), claims.InstallationID, claims.RequestID)
-		if errors.Is(err, pgx.ErrNoRows) {
+		if errors.Is(err, sql.ErrNoRows) {
 			// Token is valid but no telemetry row exists (telemetry disabled or
 			// pruned past retention). Render the page with just the request id
 			// so the user can still leave feedback.

--- a/internal/api/feedback/feedback_test.go
+++ b/internal/api/feedback/feedback_test.go
@@ -2,6 +2,7 @@ package feedback_test
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -14,7 +15,6 @@ import (
 	"workweave/router/internal/proxy"
 
 	"github.com/gin-gonic/gin"
-	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -71,7 +71,7 @@ func TestGetContextHandler_ValidTokenReturnsContext(t *testing.T) {
 func TestGetContextHandler_UnknownRequestStillRenders(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	signer := token.NewSigner("secret", time.Hour)
-	repo := &fakeFeedbackRepo{ctxErr: pgx.ErrNoRows}
+	repo := &fakeFeedbackRepo{ctxErr: sql.ErrNoRows}
 	engine := gin.New()
 	engine.GET("/v1/feedback/link/:token", feedbackapi.GetContextHandler(newService(repo, signer)))
 

--- a/internal/proxy/dispatch_error.go
+++ b/internal/proxy/dispatch_error.go
@@ -355,7 +355,11 @@ func ClassifyDispatchError(err error) (DispatchErrorClass, bool) {
 // "emit body: ". Falls back to err.Error().
 func unwrapToSentinelMessage(err error) string {
 	for e := err; e != nil; e = errors.Unwrap(e) {
-		if child := errors.Unwrap(e); child == translate.ErrAnthropicCacheControlOverflow || child == translate.ErrAnthropicCacheControlInvalid {
+		child := errors.Unwrap(e)
+		if errors.Unwrap(child) != nil {
+			continue
+		}
+		if errors.Is(child, translate.ErrAnthropicCacheControlOverflow) || errors.Is(child, translate.ErrAnthropicCacheControlInvalid) {
 			return e.Error()
 		}
 	}

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -259,7 +259,7 @@ func stripEffortSuffix(model string) (effort string, modelOut string) {
 	if !looksLikeEffortAlias(tail) {
 		return "", model
 	}
-	return translate.CanonicalizeEffort(tail), model[:idx]
+	return router.CanonicalizeEffort(tail), model[:idx]
 }
 
 // looksLikeEffortAlias guards against future catalog IDs that contain `:`,

--- a/internal/router/effort.go
+++ b/internal/router/effort.go
@@ -1,0 +1,39 @@
+package router
+
+import "strings"
+
+const (
+	effortLow    = "low"
+	effortMedium = "medium"
+	effortHigh   = "high"
+	effortMax    = "max"
+	effortXhigh  = "xhigh"
+)
+
+// CanonicalizeEffort maps user-facing aliases to canonical routing effort levels.
+func CanonicalizeEffort(level string) string {
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "fast", "low", "minimal", "min":
+		return effortLow
+	case "medium", "med":
+		return effortMedium
+	case "high":
+		return effortHigh
+	case "max":
+		return effortMax
+	case "ultra", "xhigh":
+		return effortXhigh
+	default:
+		return level
+	}
+}
+
+// IsValidEffort reports whether level is a recognized routing effort level or alias.
+func IsValidEffort(level string) bool {
+	switch CanonicalizeEffort(level) {
+	case effortLow, effortMedium, effortHigh, effortMax, effortXhigh:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/router/effort_test.go
+++ b/internal/router/effort_test.go
@@ -1,0 +1,48 @@
+package router_test
+
+import (
+	"testing"
+
+	"workweave/router/internal/router"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCanonicalizeEffort(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "low", want: "low"},
+		{input: "LOW", want: "low"},
+		{input: "fast", want: "low"},
+		{input: "minimal", want: "low"},
+		{input: "min", want: "low"},
+		{input: "medium", want: "medium"},
+		{input: "med", want: "medium"},
+		{input: "high", want: "high"},
+		{input: "max", want: "max"},
+		{input: "xhigh", want: "xhigh"},
+		{input: "ultra", want: "xhigh"},
+		{input: "ULTRA", want: "xhigh"},
+		{input: "garbage", want: "garbage"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, router.CanonicalizeEffort(tt.input))
+		})
+	}
+}
+
+func TestIsValidEffort(t *testing.T) {
+	for _, level := range []string{"low", "medium", "high", "max", "xhigh", "fast", "minimal", "ultra", "min", "med"} {
+		t.Run(level, func(t *testing.T) {
+			assert.True(t, router.IsValidEffort(level))
+		})
+	}
+	for _, level := range []string{"garbage", ""} {
+		t.Run(level+"_invalid", func(t *testing.T) {
+			assert.False(t, router.IsValidEffort(level))
+		})
+	}
+}

--- a/internal/router/hmm/mapping.go
+++ b/internal/router/hmm/mapping.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 
 	"workweave/router/internal/providers"
+	"workweave/router/internal/router"
 	"workweave/router/internal/router/catalog"
-	"workweave/router/internal/translate"
 )
 
 var rosterAliases = map[string]string{
@@ -46,10 +46,10 @@ func rosterIDFor(m catalog.Model) string {
 func SplitEffort(armID string) (baseID string, effort string) {
 	if idx := strings.LastIndex(armID, ":"); idx > 0 {
 		suffix := armID[idx+1:]
-		if translate.CanonicalizeEffort(suffix) != suffix {
+		if router.CanonicalizeEffort(suffix) != suffix {
 			return armID, ""
 		}
-		if translate.IsValidEffort(suffix) {
+		if router.IsValidEffort(suffix) {
 			return armID[:idx], suffix
 		}
 	}

--- a/internal/router/policy/resolver.go
+++ b/internal/router/policy/resolver.go
@@ -8,7 +8,6 @@ import (
 	"workweave/router/internal/providers"
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/catalog"
-	"workweave/router/internal/translate"
 )
 
 // RosterMapper maps a catalog model to the identifier understood by a policy
@@ -432,7 +431,7 @@ func splitEffort(armID string) (string, string) {
 	for i := len(armID) - 1; i > 0; i-- {
 		if armID[i] == ':' {
 			suffix := armID[i+1:]
-			if translate.CanonicalizeEffort(suffix) == suffix && translate.IsValidEffort(suffix) {
+			if router.CanonicalizeEffort(suffix) == suffix && router.IsValidEffort(suffix) {
 				return armID[:i], suffix
 			}
 			return armID, ""

--- a/internal/server/middleware/force_effort_override.go
+++ b/internal/server/middleware/force_effort_override.go
@@ -5,7 +5,6 @@ import (
 
 	"workweave/router/internal/observability"
 	"workweave/router/internal/router"
-	"workweave/router/internal/translate"
 
 	"github.com/gin-gonic/gin"
 )
@@ -22,11 +21,11 @@ func WithForceEffortOverride() gin.HandlerFunc {
 			c.Next()
 			return
 		}
-		if !translate.IsValidEffort(raw) {
+		if !router.IsValidEffort(raw) {
 			abortInvalidKnob(c, ForceEffortOverrideHeader+" must be one of: low, medium, high, max, xhigh (or aliases fast/minimal/ultra).")
 			return
 		}
-		canonical := translate.CanonicalizeEffort(raw)
+		canonical := router.CanonicalizeEffort(raw)
 		// Merge with any existing routing knobs (e.g. from WithRoutingKnobsOverride)
 		// so ForceEffort doesn't silently drop a separately-configured Alpha/QualityBias.
 		merged := router.Overrides{ForceEffort: canonical}

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -1126,45 +1126,13 @@ const (
 	effortXhigh  = "xhigh"
 )
 
-// CanonicalizeEffort maps user-facing aliases (fast/minimal/ultra) to canonical
-// wire strings (low/medium/high/max/xhigh). Unknown values pass through so
-// IsValidEffort can reject typos at the boundary.
-func CanonicalizeEffort(level string) string {
-	switch strings.ToLower(strings.TrimSpace(level)) {
-	case "fast", "low", "minimal", "min":
-		return effortLow
-	case "medium", "med":
-		return effortMedium
-	case "high":
-		return effortHigh
-	case "max":
-		return effortMax
-	case "ultra", "xhigh":
-		return effortXhigh
-	default:
-		return level
-	}
-}
-
-// IsValidEffort reports whether the canonicalized level is one the router
-// accepts as wire output. Returns false for typos so middleware can 400
-// rather than forward garbage to a provider.
-func IsValidEffort(level string) bool {
-	switch CanonicalizeEffort(level) {
-	case effortLow, effortMedium, effortHigh, effortMax, effortXhigh:
-		return true
-	default:
-		return false
-	}
-}
-
 // ResolveForceEffort canonicalizes level and applies the per-model cap
 // (xhigh → max on non-CapXhighEffort). Empty input → "".
 func ResolveForceEffort(caps router.ModelSpec, level string) string {
 	if level == "" {
 		return ""
 	}
-	canonical := CanonicalizeEffort(level)
+	canonical := router.CanonicalizeEffort(level)
 	if canonical == effortXhigh && !caps.Supports(router.CapXhighEffort) {
 		return effortMax
 	}

--- a/internal/translate/force_effort_test.go
+++ b/internal/translate/force_effort_test.go
@@ -150,53 +150,6 @@ func itoaLocal(n int) string {
 	return string(b[i:])
 }
 
-// TestCanonicalizeEffort maps alias and canonical forms; unrecognized values
-// pass through unchanged so IsValidEffort can distinguish typos.
-func TestCanonicalizeEffort(t *testing.T) {
-	cases := []struct {
-		in   string
-		want string
-	}{
-		{"low", "low"},
-		{"LOW", "low"},
-		{"fast", "low"},
-		{"minimal", "low"},
-		{"min", "low"},
-		{"medium", "medium"},
-		{"med", "medium"},
-		{"high", "high"},
-		{"max", "max"},
-		{"xhigh", "xhigh"},
-		{"ultra", "xhigh"},
-		{"ULTRA", "xhigh"},
-		{"garbage", "garbage"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.in, func(t *testing.T) {
-			assert.Equal(t, tc.want, translate.CanonicalizeEffort(tc.in))
-		})
-	}
-}
-
-// IsValidEffort accepts canonical levels and alias forms; rejects typos.
-func TestIsValidEffort(t *testing.T) {
-	valid := []string{
-		"low", "medium", "high", "max", "xhigh",
-		"fast", "minimal", "ultra", "min", "med",
-	}
-	for _, v := range valid {
-		t.Run(v, func(t *testing.T) {
-			assert.True(t, translate.IsValidEffort(v))
-		})
-	}
-	invalid := []string{"garbage", ""}
-	for _, v := range invalid {
-		t.Run(v+"_invalid", func(t *testing.T) {
-			assert.False(t, translate.IsValidEffort(v))
-		})
-	}
-}
-
 // TestResolveForceEffort applies per-model xhigh cap (xhigh→max on
 // non-CapXhighEffort targets).
 func TestResolveForceEffort(t *testing.T) {

--- a/internal/translate/toolcheck/repair.go
+++ b/internal/translate/toolcheck/repair.go
@@ -1,6 +1,7 @@
 package toolcheck
 
 import (
+	"errors"
 	"strconv"
 	"strings"
 
@@ -34,8 +35,8 @@ func repairArgs(schema *jsonschema.Schema, args string, verr error) (out string,
 	out = args
 	current := verr
 	for pass := 0; pass < maxRepairPasses; pass++ {
-		validationErr, ok := current.(*jsonschema.ValidationError)
-		if !ok {
+		var validationErr *jsonschema.ValidationError
+		if !errors.As(current, &validationErr) {
 			return out, actions
 		}
 		passActions := applyLeafRepairs(&out, validationErr)

--- a/internal/translate/toolcheck/toolcheck.go
+++ b/internal/translate/toolcheck/toolcheck.go
@@ -14,6 +14,7 @@
 package toolcheck
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -343,8 +344,8 @@ func normalizeArgs(args string, required map[string]struct{}) (out string, actio
 // detailFromError renders the first leaf validation error as
 // "/instance/path: message", truncated.
 func detailFromError(err error) string {
-	verr, ok := err.(*jsonschema.ValidationError)
-	if !ok {
+	var verr *jsonschema.ValidationError
+	if !errors.As(err, &verr) {
 		return truncateDetail(err.Error())
 	}
 	leaf := firstLeaf(verr)


### PR DESCRIPTION
## Summary

- add a digest-pinned golangci-lint action running v2.6.2 with errorlint and depguard
- enforce leaf, presentation, and pgx adapter import boundaries
- reject IF EXISTS in down migrations and make the ten existing rollback statements precise

## Implementation

- replace direct error comparisons and assertions with errors.Is/errors.As while preserving cache-control error-message selection
- move effort canonicalization into the router domain so middleware and router strategies do not depend on wire translation
- use database/sql ErrNoRows at the feedback presentation boundary; pgx documents that its sentinel unwraps to it

## Testing

- [x] golangci-lint v2.6.2 config verify
- [x] golangci-lint v2.6.2 run ./...
- [x] depguard negative check rejects a middleware-to-translate import
- [x] go vet ./...
- [x] go build -o /dev/null ./...
- [x] go test -count=1 ./...
- [x] all 77 migrations up/down/up on Postgres 15
- [x] no-IF-EXISTS and transaction-wrapper static checks

## Risk

Low. Runtime changes are mechanical boundary/error-handling fixes. Migration edits only remove permissive guards, and the complete rollback cycle passes.