### PR TITLE
ci(docs): add generated guide mirrors, Markdown link checker, and SQL convention gates

### DIFF
--- a/.github/workflows/check_repository_conventions.yml
+++ b/.github/workflows/check_repository_conventions.yml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Repository conventions
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check docs and SQL conventions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Check generated guides, documentation, and SQL queries
+        run: make check-repository-conventions

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 #   (and .env.local if present). Start Postgres via `make db` or point
 #   DATABASE_URL at any Postgres you already have running.
 
-.PHONY: generate generate-statusline build test test-verbose test-statusline test-install smoke initdb migrate-up migrate-down migrate-create seed setup full-setup db dev check fmt vet precommit install-hooks help install-cc uninstall-cc up up-hmm down down-hmm logs
+.PHONY: generate generate-agents generate-statusline check-repository-conventions check-docs check-sql build test test-verbose test-statusline test-install smoke initdb migrate-up migrate-down migrate-create seed setup full-setup db dev check fmt vet precommit install-hooks help install-cc uninstall-cc up up-hmm down down-hmm logs
 
 # Load DATABASE_URL from .env files (matches docker-compose defaults).
 -include .env.development
@@ -22,6 +22,19 @@ help: ## Show available targets
 
 generate: generate-statusline ## Regenerate all generated files (SQLC + statusline prices)
 	cd db && sqlc generate
+	./scripts/generate_agents.sh
+
+generate-agents: ## Regenerate AGENTS.md mirrors from canonical CLAUDE.md guides
+	./scripts/generate_agents.sh
+
+check-repository-conventions: check-docs check-sql ## Check generated guides, documentation, and SQL queries
+
+check-docs: ## Check guide mirrors, relative Markdown links, and Go symbol references
+	./scripts/generate_agents.sh --check
+	go run ./scripts/check_docs
+
+check-sql: ## Check SQLC query parameter and comment conventions
+	./scripts/check_sql_queries.sh
 
 generate-statusline: ## Sync cc-statusline.sh prices block from pricing.go
 	go run ./cmd/genprices
@@ -199,7 +212,7 @@ install-hooks: ## Install git pre-commit hook
 	chmod +x "$$HOOK_DIR/pre-commit"; \
 	echo "Pre-commit hook installed at $$HOOK_DIR/pre-commit"
 
-check: generate fmt vet build test test-statusline test-install ## Full CI-equivalent check
+check: generate check-repository-conventions fmt vet build test test-statusline test-install ## Full CI-equivalent check
 	@if ! git diff --quiet internal/sqlc/; then \
 		echo "error: sqlc generation produced uncommitted changes"; \
 		git diff internal/sqlc/; \

--- a/db/queries/flag_definitions.sql
+++ b/db/queries/flag_definitions.sql
@@ -43,6 +43,7 @@ DELETE FROM router.flag_definitions
 WHERE registry_version <= @registry_version::integer
   AND key <> ALL(@keys::text[]);
 
+-- Lists the published flag registry in stable key order.
 -- name: ListFlagDefinitions :many
 SELECT *
 FROM router.flag_definitions

--- a/db/queries/model_router_api_keys.sql
+++ b/db/queries/model_router_api_keys.sql
@@ -14,11 +14,11 @@ INSERT INTO router.model_router_api_keys (
 VALUES (
     @installation_id::uuid,
     @external_id::varchar,
-    @name,
+    sqlc.narg('name')::varchar,
     @key_prefix::varchar,
     @key_hash::varchar,
     @key_suffix::varchar,
-    @created_by,
+    sqlc.narg('created_by')::varchar,
     @scope::varchar
 )
 RETURNING *;

--- a/db/queries/model_router_external_api_keys.sql
+++ b/db/queries/model_router_external_api_keys.sql
@@ -30,8 +30,8 @@ VALUES (
     @key_prefix::varchar,
     @key_suffix::varchar,
     @key_fingerprint::varchar,
-    @name,
-    @base_url,
+    sqlc.narg('name')::varchar,
+    sqlc.narg('base_url')::text,
     sqlc.narg('model_aliases')::jsonb,
     sqlc.narg('identity_header_name')::text,
     sqlc.narg('identity_header_format')::text,
@@ -40,7 +40,7 @@ VALUES (
     @auth_type::text,
     sqlc.narg('auth_account')::text,
     sqlc.narg('auth_user')::text,
-    @created_by
+    sqlc.narg('created_by')::varchar
 )
 RETURNING *;
 

--- a/db/queries/model_router_installations.sql
+++ b/db/queries/model_router_installations.sql
@@ -1,3 +1,4 @@
+-- Creates an installation owned by the external tenant identifier.
 -- name: CreateModelRouterInstallation :one
 INSERT INTO router.model_router_installations (
     external_id,
@@ -7,7 +8,7 @@ INSERT INTO router.model_router_installations (
 VALUES (
     @external_id::varchar,
     @name::varchar,
-    @created_by
+    sqlc.narg('created_by')::varchar
 )
 RETURNING *;
 
@@ -19,6 +20,7 @@ WHERE id = @id::uuid
   AND external_id = @external_id::varchar
   AND deleted_at IS NULL;
 
+-- Lists active installations owned by one external tenant identifier.
 -- name: ListModelRouterInstallationsForExternalID :many
 SELECT *
 FROM router.model_router_installations
@@ -73,7 +75,7 @@ WHERE id = @id::uuid
 -- preference so the scorer reverts to its tuned defaults.
 -- name: UpdateModelRouterInstallationRoutingPreference :execrows
 UPDATE router.model_router_installations
-SET routing_quality_weight = sqlc.narg('routing_quality_weight'),
+SET routing_quality_weight = sqlc.narg('routing_quality_weight')::double precision,
     updated_at = NOW()
 WHERE id = @id::uuid
   AND external_id = @external_id::varchar
@@ -86,7 +88,7 @@ WHERE id = @id::uuid
 -- name: UpdateModelRouterInstallationUsageBypass :execrows
 UPDATE router.model_router_installations
 SET usage_bypass_enabled = @usage_bypass_enabled::boolean,
-    usage_bypass_threshold = sqlc.narg('usage_bypass_threshold'),
+    usage_bypass_threshold = sqlc.narg('usage_bypass_threshold')::double precision,
     updated_at = NOW()
 WHERE id = @id::uuid
   AND external_id = @external_id::varchar
@@ -96,7 +98,7 @@ WHERE id = @id::uuid
 -- to an external_id to prevent cross-tenant updates. NULL clears the override.
 -- name: UpdateModelRouterInstallationContentCaptureMode :execrows
 UPDATE router.model_router_installations
-SET content_capture_mode = sqlc.narg('content_capture_mode'),
+SET content_capture_mode = sqlc.narg('content_capture_mode')::text,
     updated_at = NOW()
 WHERE id = @id::uuid
   AND external_id = @external_id::varchar

--- a/db/queries/model_router_subscription_accounts.sql
+++ b/db/queries/model_router_subscription_accounts.sql
@@ -1,3 +1,4 @@
+-- Creates or re-enables one subscription account and refreshes its credential.
 -- name: UpsertModelRouterSubscriptionAccount :one
 INSERT INTO router.model_router_subscription_accounts (
   api_key_id, provider, external_account_id, refresh_token_ciphertext
@@ -19,6 +20,7 @@ FROM router.model_router_subscription_accounts
 WHERE api_key_id = @api_key_id::uuid
 ORDER BY provider, created_at;
 
+-- Updates enabled state and cooldown for an account owned by the router key.
 -- name: UpdateModelRouterSubscriptionAccountState :execrows
 UPDATE router.model_router_subscription_accounts
 SET enabled = @enabled::boolean,
@@ -36,12 +38,14 @@ WHERE id = @id::uuid
   AND api_key_id = @api_key_id::uuid
   AND enabled = TRUE;
 
+-- Replaces the encrypted refresh token for an account owned by the router key.
 -- name: UpdateModelRouterSubscriptionRefreshToken :execrows
 UPDATE router.model_router_subscription_accounts
 SET refresh_token_ciphertext = @refresh_token_ciphertext::bytea,
     updated_at = CURRENT_TIMESTAMP
 WHERE id = @id::uuid AND api_key_id = @api_key_id::uuid;
 
+-- Deletes a subscription account owned by the router key.
 -- name: DeleteModelRouterSubscriptionAccount :execrows
 DELETE FROM router.model_router_subscription_accounts
 WHERE id = @id::uuid AND api_key_id = @api_key_id::uuid;

--- a/db/queries/policy_shadow_decisions.sql
+++ b/db/queries/policy_shadow_decisions.sql
@@ -1,3 +1,4 @@
+-- Records the serving and shadow policy decisions for offline comparison.
 -- name: InsertPolicyShadowDecision :exec
 INSERT INTO router.policy_shadow_decisions (
     installation_id,

--- a/db/queries/struggle_escalation_events.sql
+++ b/db/queries/struggle_escalation_events.sql
@@ -1,3 +1,4 @@
+-- Records one routing escalation triggered by sustained struggle evidence.
 -- name: InsertStruggleEscalationEvent :exec
 INSERT INTO router.struggle_escalation_events (
     installation_id, session_key, role, struggling_model,
@@ -10,6 +11,7 @@ INSERT INTO router.struggle_escalation_events (
     @arming_mode::varchar, @evidence_reasons::varchar[]
 );
 
+-- Counts matching escalation events for a session role.
 -- name: CountStruggleEscalationEvents :one
 SELECT COUNT(*)
 FROM router.struggle_escalation_events

--- a/internal/proxy/AGENTS.md
+++ b/internal/proxy/AGENTS.md
@@ -18,7 +18,7 @@ Plus the action loop, handover adapter, cache writer, and session-key derivation
 ## Adding a method to `*proxy.Service`
 
 1. **Define method on `*proxy.Service`.** No I/O directly here — push into a provider adapter or repo. Inner-ring imports (`router`, `providers`, `translate`, `observability`, `internal/router/*`, `internal/proxy/usage`) + small utility libs are fine.
-2. **If you need new repo methods**, surface them as an interface in the inner-ring package, implement in `internal/postgres/`. Example: `sessionpin.Store` in [`../router/sessionpin/store.go`](../router/sessionpin/store.go), implemented by `postgres.SessionPinRepository`.
+2. **If you need new repo methods**, surface them as an interface in the inner-ring package, implement in `internal/postgres/`. Example: `sessionpin.Store` in [`../router/sessionpin/store.go`](../router/sessionpin/store.go), implemented by `postgres.SessionPinRepo`.
 3. **Update `service_test.go` fakes** to satisfy the expanded interface. Real assertions on return values, not "mock called with X".
 
 ## Per-action flow (cache-aware action routing)
@@ -269,9 +269,9 @@ Only the Anthropic Messages surface is wrapped today — that is where the failu
 was observed. `KeepaliveWriter` takes the frame as a parameter, so adding the
 OpenAI/Gemini surfaces is a wiring change plus their own frame.
 
-## `OnUpstreamMeta` callbacks
+## Upstream metadata
 
-Provider adapters call back into `proxy.OnUpstreamMeta` so streaming responses record usage/headers back to proxy without coupling provider packages to proxy internals. The catalog / planner stack depends on per-action token counts being recorded promptly — **don't add a provider that forgets to call the callback.**
+Provider adapters pass response headers to `providers.ObserveUpstreamHeaders`; `proxy.Service` installs the request-scoped observer with `providers.WithUpstreamHeaderObserver`. The proxy wraps each attempt sink with `otel.UsageExtractor` so token counts remain available for accounting and session-pin usage after dispatch. A new provider must preserve both paths.
 
 ## What NOT to do
 

--- a/internal/proxy/CLAUDE.md
+++ b/internal/proxy/CLAUDE.md
@@ -18,7 +18,7 @@ Plus the action loop, handover adapter, cache writer, and session-key derivation
 ## Adding a method to `*proxy.Service`
 
 1. **Define method on `*proxy.Service`.** No I/O directly here — push into a provider adapter or repo. Inner-ring imports (`router`, `providers`, `translate`, `observability`, `internal/router/*`, `internal/proxy/usage`) + small utility libs are fine.
-2. **If you need new repo methods**, surface them as an interface in the inner-ring package, implement in `internal/postgres/`. Example: `sessionpin.Store` in [`../router/sessionpin/store.go`](../router/sessionpin/store.go), implemented by `postgres.SessionPinRepository`.
+2. **If you need new repo methods**, surface them as an interface in the inner-ring package, implement in `internal/postgres/`. Example: `sessionpin.Store` in [`../router/sessionpin/store.go`](../router/sessionpin/store.go), implemented by `postgres.SessionPinRepo`.
 3. **Update `service_test.go` fakes** to satisfy the expanded interface. Real assertions on return values, not "mock called with X".
 
 ## Per-action flow (cache-aware action routing)
@@ -269,9 +269,9 @@ Only the Anthropic Messages surface is wrapped today — that is where the failu
 was observed. `KeepaliveWriter` takes the frame as a parameter, so adding the
 OpenAI/Gemini surfaces is a wiring change plus their own frame.
 
-## `OnUpstreamMeta` callbacks
+## Upstream metadata
 
-Provider adapters call back into `proxy.OnUpstreamMeta` so streaming responses record usage/headers back to proxy without coupling provider packages to proxy internals. The catalog / planner stack depends on per-action token counts being recorded promptly — **don't add a provider that forgets to call the callback.**
+Provider adapters pass response headers to `providers.ObserveUpstreamHeaders`; `proxy.Service` installs the request-scoped observer with `providers.WithUpstreamHeaderObserver`. The proxy wraps each attempt sink with `otel.UsageExtractor` so token counts remain available for accounting and session-pin usage after dispatch. A new provider must preserve both paths.
 
 ## What NOT to do
 

--- a/internal/router/cluster/AGENTS.md
+++ b/internal/router/cluster/AGENTS.md
@@ -2,7 +2,7 @@
 
 > **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
 
-AvengersPro-derived primary router (arXiv 2508.12631, DAI 2025). **P0.** Full design in [`../../../docs/plans/archive/CLUSTER_ROUTING_PLAN.md`](../../../docs/plans/archive/CLUSTER_ROUTING_PLAN.md); this file is the rules-for-AI subset. Read [root CLAUDE.md](../../../CLAUDE.md) and [internal/router/CLAUDE.md](../CLAUDE.md) first.
+AvengersPro-derived primary router (arXiv 2508.12631, DAI 2025). **P0.** This file is the focused guide for its load-bearing contracts. Read [root CLAUDE.md](../../../CLAUDE.md) and [internal/router/CLAUDE.md](../CLAUDE.md) first.
 
 ## What's load-bearing
 

--- a/internal/router/cluster/CLAUDE.md
+++ b/internal/router/cluster/CLAUDE.md
@@ -2,7 +2,7 @@
 
 > **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
 
-AvengersPro-derived primary router (arXiv 2508.12631, DAI 2025). **P0.** Full design in [`../../../docs/plans/archive/CLUSTER_ROUTING_PLAN.md`](../../../docs/plans/archive/CLUSTER_ROUTING_PLAN.md); this file is the rules-for-AI subset. Read [root CLAUDE.md](../../../CLAUDE.md) and [internal/router/CLAUDE.md](../CLAUDE.md) first.
+AvengersPro-derived primary router (arXiv 2508.12631, DAI 2025). **P0.** This file is the focused guide for its load-bearing contracts. Read [root CLAUDE.md](../../../CLAUDE.md) and [internal/router/CLAUDE.md](../CLAUDE.md) first.
 
 ## What's load-bearing
 

--- a/internal/router/cluster/artifacts/README.md
+++ b/internal/router/cluster/artifacts/README.md
@@ -34,8 +34,7 @@ artifacts/
   per-model raw axes (input/output cost per 1k, TTFT, TPS, verbosity
   tokens). Five routing knobs (α, speed_weight, output_cost_ratio,
   expected_output_tokens, per_model_verbosity) are reconstructable at
-  request time and overridable via `x-weave-routing-*` headers. See
-  [`docs/plans/ROUTER_RUNTIME_TUNABLE_KNOBS.md`](../../../../docs/plans/ROUTER_RUNTIME_TUNABLE_KNOBS.md).
+  request time and overridable via `x-weave-routing-*` headers.
 
 The loader probes for `quality_means.json` to detect v2; falls back to
 `rankings.json` for v1. A v2 directory may co-host both files during

--- a/internal/router/sessionpin/AGENTS.md
+++ b/internal/router/sessionpin/AGENTS.md
@@ -7,7 +7,7 @@
 ## Surface
 
 - `Pin` value type.
-- `Store` interface (inner-ring contract) — implemented by `postgres.SessionPinRepository` in [`../../postgres`](../../postgres).
+- `Store` interface (inner-ring contract) — implemented by `postgres.SessionPinRepo` in [`../../postgres`](../../postgres).
 - Keyed by `(api_key_id, session_key, role)` where `session_key` = 16-byte sha256 truncation derived from the inbound request (see [`../../proxy/session_key.go`](../../proxy/session_key.go)).
 
 ## Roles

--- a/internal/router/sessionpin/CLAUDE.md
+++ b/internal/router/sessionpin/CLAUDE.md
@@ -7,7 +7,7 @@
 ## Surface
 
 - `Pin` value type.
-- `Store` interface (inner-ring contract) — implemented by `postgres.SessionPinRepository` in [`../../postgres`](../../postgres).
+- `Store` interface (inner-ring contract) — implemented by `postgres.SessionPinRepo` in [`../../postgres`](../../postgres).
 - Keyed by `(api_key_id, session_key, role)` where `session_key` = 16-byte sha256 truncation derived from the inbound request (see [`../../proxy/session_key.go`](../../proxy/session_key.go)).
 
 ## Roles

--- a/internal/sqlc/flag_definitions.sql.go
+++ b/internal/sqlc/flag_definitions.sql.go
@@ -39,7 +39,7 @@ FROM router.flag_definitions
 ORDER BY key
 `
 
-// ListFlagDefinitions
+// Lists the published flag registry in stable key order.
 //
 //	SELECT key, kind, env_var, deployment_default, org_overridable, description, registry_version, updated_at
 //	FROM router.flag_definitions

--- a/internal/sqlc/model_router_api_keys.sql.go
+++ b/internal/sqlc/model_router_api_keys.sql.go
@@ -25,11 +25,11 @@ INSERT INTO router.model_router_api_keys (
 VALUES (
     $1::uuid,
     $2::varchar,
-    $3,
+    $3::varchar,
     $4::varchar,
     $5::varchar,
     $6::varchar,
-    $7,
+    $7::varchar,
     $8::varchar
 )
 RETURNING id, installation_id, external_id, name, key_prefix, key_hash, key_suffix, last_used_at, created_at, deleted_at, created_by, spend_cap_usd_micros, spent_usd_micros, scope
@@ -62,11 +62,11 @@ type CreateModelRouterAPIKeyParams struct {
 //	VALUES (
 //	    $1::uuid,
 //	    $2::varchar,
-//	    $3,
+//	    $3::varchar,
 //	    $4::varchar,
 //	    $5::varchar,
 //	    $6::varchar,
-//	    $7,
+//	    $7::varchar,
 //	    $8::varchar
 //	)
 //	RETURNING id, installation_id, external_id, name, key_prefix, key_hash, key_suffix, last_used_at, created_at, deleted_at, created_by, spend_cap_usd_micros, spent_usd_micros, scope

--- a/internal/sqlc/model_router_external_api_keys.sql.go
+++ b/internal/sqlc/model_router_external_api_keys.sql.go
@@ -40,8 +40,8 @@ VALUES (
     $5::varchar,
     $6::varchar,
     $7::varchar,
-    $8,
-    $9,
+    $8::varchar,
+    $9::text,
     $10::jsonb,
     $11::text,
     $12::text,
@@ -50,7 +50,7 @@ VALUES (
     $15::text,
     $16::text,
     $17::text,
-    $18
+    $18::varchar
 )
 RETURNING id, installation_id, external_id, provider, key_ciphertext, key_prefix, key_suffix, key_fingerprint, name, last_used_at, created_at, updated_at, deleted_at, created_by, base_url, model_aliases, identity_header_name, identity_header_format, auth_type, auth_account, auth_user, deleted_by, forwarded_client_headers, baggage_header
 `
@@ -108,8 +108,8 @@ type CreateExternalAPIKeyParams struct {
 //	    $5::varchar,
 //	    $6::varchar,
 //	    $7::varchar,
-//	    $8,
-//	    $9,
+//	    $8::varchar,
+//	    $9::text,
 //	    $10::jsonb,
 //	    $11::text,
 //	    $12::text,
@@ -118,7 +118,7 @@ type CreateExternalAPIKeyParams struct {
 //	    $15::text,
 //	    $16::text,
 //	    $17::text,
-//	    $18
+//	    $18::varchar
 //	)
 //	RETURNING id, installation_id, external_id, provider, key_ciphertext, key_prefix, key_suffix, key_fingerprint, name, last_used_at, created_at, updated_at, deleted_at, created_by, base_url, model_aliases, identity_header_name, identity_header_format, auth_type, auth_account, auth_user, deleted_by, forwarded_client_headers, baggage_header
 func (q *Queries) CreateExternalAPIKey(ctx context.Context, arg CreateExternalAPIKeyParams) (RouterModelRouterExternalAPIKey, error) {

--- a/internal/sqlc/model_router_installations.sql.go
+++ b/internal/sqlc/model_router_installations.sql.go
@@ -20,7 +20,7 @@ INSERT INTO router.model_router_installations (
 VALUES (
     $1::varchar,
     $2::varchar,
-    $3
+    $3::varchar
 )
 RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models, first_request_served_at, flag_overrides, models_when_subscription_active, models_when_subscription_inactive, fast_mode_models
 `
@@ -31,7 +31,7 @@ type CreateModelRouterInstallationParams struct {
 	CreatedBy  *string
 }
 
-// CreateModelRouterInstallation
+// Creates an installation owned by the external tenant identifier.
 //
 //	INSERT INTO router.model_router_installations (
 //	    external_id,
@@ -41,7 +41,7 @@ type CreateModelRouterInstallationParams struct {
 //	VALUES (
 //	    $1::varchar,
 //	    $2::varchar,
-//	    $3
+//	    $3::varchar
 //	)
 //	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models, first_request_served_at, flag_overrides, models_when_subscription_active, models_when_subscription_inactive, fast_mode_models
 func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateModelRouterInstallationParams) (RouterModelRouterInstallation, error) {
@@ -148,7 +148,7 @@ WHERE external_id = $1::varchar
 ORDER BY created_at DESC
 `
 
-// ListModelRouterInstallationsForExternalID
+// Lists active installations owned by one external tenant identifier.
 //
 //	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models, first_request_served_at, flag_overrides, models_when_subscription_active, models_when_subscription_inactive, fast_mode_models
 //	FROM router.model_router_installations
@@ -289,7 +289,7 @@ func (q *Queries) UpdateModelRouterInstallationAllowedModels(ctx context.Context
 
 const updateModelRouterInstallationContentCaptureMode = `-- name: UpdateModelRouterInstallationContentCaptureMode :execrows
 UPDATE router.model_router_installations
-SET content_capture_mode = $1,
+SET content_capture_mode = $1::text,
     updated_at = NOW()
 WHERE id = $2::uuid
   AND external_id = $3::varchar
@@ -306,7 +306,7 @@ type UpdateModelRouterInstallationContentCaptureModeParams struct {
 // to an external_id to prevent cross-tenant updates. NULL clears the override.
 //
 //	UPDATE router.model_router_installations
-//	SET content_capture_mode = $1,
+//	SET content_capture_mode = $1::text,
 //	    updated_at = NOW()
 //	WHERE id = $2::uuid
 //	  AND external_id = $3::varchar
@@ -490,7 +490,7 @@ func (q *Queries) UpdateModelRouterInstallationHideTerminalSurfaces(ctx context.
 
 const updateModelRouterInstallationRoutingPreference = `-- name: UpdateModelRouterInstallationRoutingPreference :execrows
 UPDATE router.model_router_installations
-SET routing_quality_weight = $1,
+SET routing_quality_weight = $1::double precision,
     updated_at = NOW()
 WHERE id = $2::uuid
   AND external_id = $3::varchar
@@ -508,7 +508,7 @@ type UpdateModelRouterInstallationRoutingPreferenceParams struct {
 // preference so the scorer reverts to its tuned defaults.
 //
 //	UPDATE router.model_router_installations
-//	SET routing_quality_weight = $1,
+//	SET routing_quality_weight = $1::double precision,
 //	    updated_at = NOW()
 //	WHERE id = $2::uuid
 //	  AND external_id = $3::varchar
@@ -559,7 +559,7 @@ func (q *Queries) UpdateModelRouterInstallationSubscriptionRoutingDisabled(ctx c
 const updateModelRouterInstallationUsageBypass = `-- name: UpdateModelRouterInstallationUsageBypass :execrows
 UPDATE router.model_router_installations
 SET usage_bypass_enabled = $1::boolean,
-    usage_bypass_threshold = $2,
+    usage_bypass_threshold = $2::double precision,
     updated_at = NOW()
 WHERE id = $3::uuid
   AND external_id = $4::varchar
@@ -580,7 +580,7 @@ type UpdateModelRouterInstallationUsageBypassParams struct {
 //
 //	UPDATE router.model_router_installations
 //	SET usage_bypass_enabled = $1::boolean,
-//	    usage_bypass_threshold = $2,
+//	    usage_bypass_threshold = $2::double precision,
 //	    updated_at = NOW()
 //	WHERE id = $3::uuid
 //	  AND external_id = $4::varchar

--- a/internal/sqlc/model_router_subscription_accounts.sql.go
+++ b/internal/sqlc/model_router_subscription_accounts.sql.go
@@ -22,7 +22,7 @@ type DeleteModelRouterSubscriptionAccountParams struct {
 	APIKeyID uuid.UUID
 }
 
-// DeleteModelRouterSubscriptionAccount
+// Deletes a subscription account owned by the router key.
 //
 //	DELETE FROM router.model_router_subscription_accounts
 //	WHERE id = $1::uuid AND api_key_id = $2::uuid
@@ -125,7 +125,7 @@ type UpdateModelRouterSubscriptionAccountStateParams struct {
 	APIKeyID      uuid.UUID
 }
 
-// UpdateModelRouterSubscriptionAccountState
+// Updates enabled state and cooldown for an account owned by the router key.
 //
 //	UPDATE router.model_router_subscription_accounts
 //	SET enabled = $1::boolean,
@@ -158,7 +158,7 @@ type UpdateModelRouterSubscriptionRefreshTokenParams struct {
 	APIKeyID               uuid.UUID
 }
 
-// UpdateModelRouterSubscriptionRefreshToken
+// Replaces the encrypted refresh token for an account owned by the router key.
 //
 //	UPDATE router.model_router_subscription_accounts
 //	SET refresh_token_ciphertext = $1::bytea,
@@ -193,7 +193,7 @@ type UpsertModelRouterSubscriptionAccountParams struct {
 	RefreshTokenCiphertext []byte
 }
 
-// UpsertModelRouterSubscriptionAccount
+// Creates or re-enables one subscription account and refreshes its credential.
 //
 //	INSERT INTO router.model_router_subscription_accounts (
 //	  api_key_id, provider, external_account_id, refresh_token_ciphertext

--- a/internal/sqlc/policy_shadow_decisions.sql.go
+++ b/internal/sqlc/policy_shadow_decisions.sql.go
@@ -86,7 +86,7 @@ type InsertPolicyShadowDecisionParams struct {
 	ModelsAgree                 bool
 }
 
-// InsertPolicyShadowDecision
+// Records the serving and shadow policy decisions for offline comparison.
 //
 //	INSERT INTO router.policy_shadow_decisions (
 //	    installation_id,

--- a/internal/sqlc/struggle_escalation_events.sql.go
+++ b/internal/sqlc/struggle_escalation_events.sql.go
@@ -23,7 +23,7 @@ type CountStruggleEscalationEventsParams struct {
 	Role       string
 }
 
-// CountStruggleEscalationEvents
+// Counts matching escalation events for a session role.
 //
 //	SELECT COUNT(*)
 //	FROM router.struggle_escalation_events
@@ -63,7 +63,7 @@ type InsertStruggleEscalationEventParams struct {
 	EvidenceReasons     []string
 }
 
-// InsertStruggleEscalationEvent
+// Records one routing escalation triggered by sustained struggle evidence.
 //
 //	INSERT INTO router.struggle_escalation_events (
 //	    installation_id, session_key, role, struggling_model,

--- a/scripts/check_docs/main.go
+++ b/scripts/check_docs/main.go
@@ -1,0 +1,346 @@
+// Command check_docs validates repository-local Markdown links and qualified
+// references to exported Go symbols in prose.
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var (
+	inlineLinkPattern = regexp.MustCompile(`!?\[[^\]]*\]\(\s*(?:<([^>]+)>|([^\s)]+))(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)`)
+	referencePattern  = regexp.MustCompile(`^\s*\[[^]]+\]:\s*(?:<([^>]+)>|(\S+))`)
+	inlineCodePattern = regexp.MustCompile("`([^`\\n]+)`")
+	symbolPattern     = regexp.MustCompile(`^([a-z][a-z0-9_]*)\.([A-Z][A-Za-z0-9_]*(?:\.[A-Z][A-Za-z0-9_]*)*)$`)
+)
+
+type exceptionKey struct{ kind, document, reference string }
+type exceptionSet map[exceptionKey]bool
+type finding struct {
+	document string
+	line     int
+	message  string
+}
+
+func main() {
+	root, err := repositoryRoot()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(2)
+	}
+	findings, err := checkRepository(root)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(2)
+	}
+	if len(findings) > 0 {
+		for _, problem := range findings {
+			fmt.Fprintf(os.Stderr, "%s:%d: %s\n", problem.document, problem.line, problem.message)
+		}
+		os.Exit(1)
+	}
+	fmt.Println("Markdown links and Go symbol references passed")
+}
+
+func repositoryRoot() (string, error) {
+	output, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", fmt.Errorf("find repository root: %w", err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func checkRepository(root string) ([]finding, error) {
+	markdownFiles, err := repositoryFiles(root, "*.md")
+	if err != nil {
+		return nil, err
+	}
+	goFiles, err := repositoryFiles(root, "*.go")
+	if err != nil {
+		return nil, err
+	}
+	exceptions, err := loadExceptions(filepath.Join(root, "scripts", "docs_check_exceptions.txt"))
+	if err != nil {
+		return nil, err
+	}
+	packages, err := collectPackageSymbols(root, goFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	var findings []finding
+	for _, document := range markdownFiles {
+		if filepath.Base(document) == "AGENTS.md" {
+			continue // Generated mirrors are checked byte-for-byte separately.
+		}
+		problems, err := checkMarkdownFile(root, document, packages, exceptions)
+		if err != nil {
+			return nil, err
+		}
+		findings = append(findings, problems...)
+	}
+	for exception, used := range exceptions {
+		if !used {
+			findings = append(findings, finding{document: exception.document, message: fmt.Sprintf("unused %s exception for %s", exception.kind, exception.reference)})
+		}
+	}
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].document != findings[j].document {
+			return findings[i].document < findings[j].document
+		}
+		if findings[i].line != findings[j].line {
+			return findings[i].line < findings[j].line
+		}
+		return findings[i].message < findings[j].message
+	})
+	return findings, nil
+}
+
+func repositoryFiles(root, pattern string) ([]string, error) {
+	command := exec.Command("git", "-C", root, "ls-files", "-z", "--cached", "--others", "--exclude-standard", "--", pattern)
+	output, err := command.Output()
+	if err != nil {
+		return nil, fmt.Errorf("list repository %s files: %w", pattern, err)
+	}
+	trimmed := strings.TrimSuffix(string(output), "\x00")
+	if trimmed == "" {
+		return nil, nil
+	}
+	return strings.Split(trimmed, "\x00"), nil
+}
+
+func loadExceptions(path string) (exceptionSet, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open documentation exceptions: %w", err)
+	}
+	defer file.Close()
+	exceptions := exceptionSet{}
+	scanner := bufio.NewScanner(file)
+	for lineNumber := 1; scanner.Scan(); lineNumber++ {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 3 || (fields[0] != "link" && fields[0] != "symbol") {
+			return nil, fmt.Errorf("%s:%d: expected '<link|symbol> <Markdown file> <reference>'", path, lineNumber)
+		}
+		key := exceptionKey{fields[0], filepath.ToSlash(fields[1]), fields[2]}
+		if _, exists := exceptions[key]; exists {
+			return nil, fmt.Errorf("%s:%d: duplicate exception", path, lineNumber)
+		}
+		exceptions[key] = false
+	}
+	return exceptions, scanner.Err()
+}
+
+func collectPackageSymbols(root string, goFiles []string) (map[string]map[string]struct{}, error) {
+	packages := map[string]map[string]struct{}{}
+	files := token.NewFileSet()
+	for _, relativePath := range goFiles {
+		if strings.HasSuffix(relativePath, "_test.go") {
+			continue
+		}
+		parsed, err := parser.ParseFile(files, filepath.Join(root, relativePath), nil, 0)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", relativePath, err)
+		}
+		symbols := packages[parsed.Name.Name]
+		if symbols == nil {
+			symbols = map[string]struct{}{}
+			packages[parsed.Name.Name] = symbols
+		}
+		for _, declaration := range parsed.Decls {
+			collectDeclarationSymbols(symbols, declaration)
+		}
+	}
+	return packages, nil
+}
+
+func collectDeclarationSymbols(symbols map[string]struct{}, declaration ast.Decl) {
+	switch declaration := declaration.(type) {
+	case *ast.FuncDecl:
+		if ast.IsExported(declaration.Name.Name) {
+			symbols[declaration.Name.Name] = struct{}{}
+		}
+	case *ast.GenDecl:
+		for _, specification := range declaration.Specs {
+			switch specification := specification.(type) {
+			case *ast.TypeSpec:
+				if ast.IsExported(specification.Name.Name) {
+					symbols[specification.Name.Name] = struct{}{}
+				}
+				collectFieldSymbols(symbols, specification.Type)
+			case *ast.ValueSpec:
+				for _, name := range specification.Names {
+					if ast.IsExported(name.Name) {
+						symbols[name.Name] = struct{}{}
+					}
+				}
+			}
+		}
+	}
+}
+
+func collectFieldSymbols(symbols map[string]struct{}, expression ast.Expr) {
+	var fields *ast.FieldList
+	switch expression := expression.(type) {
+	case *ast.StructType:
+		fields = expression.Fields
+	case *ast.InterfaceType:
+		fields = expression.Methods
+	default:
+		return
+	}
+	for _, field := range fields.List {
+		for _, name := range field.Names {
+			if ast.IsExported(name.Name) {
+				symbols[name.Name] = struct{}{}
+			}
+		}
+	}
+}
+
+func checkMarkdownFile(root, document string, packages map[string]map[string]struct{}, exceptions exceptionSet) ([]finding, error) {
+	file, err := os.Open(filepath.Join(root, filepath.FromSlash(document)))
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", document, err)
+	}
+	defer file.Close()
+	var findings []finding
+	inFence := false
+	scanner := bufio.NewScanner(file)
+	for lineNumber := 1; scanner.Scan(); lineNumber++ {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+		for _, target := range markdownTargets(line) {
+			if problem := checkRelativeTarget(root, document, target, exceptions); problem != "" {
+				findings = append(findings, finding{document, lineNumber, problem})
+			}
+		}
+		for _, match := range inlineCodePattern.FindAllStringSubmatch(line, -1) {
+			if problem := checkSymbolReference(document, match[1], packages, exceptions); problem != "" {
+				findings = append(findings, finding{document, lineNumber, problem})
+			}
+		}
+	}
+	return findings, scanner.Err()
+}
+
+func markdownTargets(line string) []string {
+	var targets []string
+	for _, match := range inlineLinkPattern.FindAllStringSubmatch(line, -1) {
+		targets = append(targets, firstNonempty(match[1], match[2]))
+	}
+	if match := referencePattern.FindStringSubmatch(line); match != nil && !strings.HasPrefix(strings.TrimSpace(line), "[^") {
+		targets = append(targets, firstNonempty(match[1], match[2]))
+	}
+	return targets
+}
+
+func firstNonempty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func checkRelativeTarget(root, document, target string, exceptions exceptionSet) string {
+	if target == "" || strings.HasPrefix(target, "#") {
+		return ""
+	}
+	parsed, err := url.Parse(target)
+	if err != nil {
+		return fmt.Sprintf("invalid link target %q: %v", target, err)
+	}
+	if parsed.Scheme != "" || parsed.Host != "" || strings.HasPrefix(parsed.Path, "/") {
+		return ""
+	}
+	decodedPath, err := url.PathUnescape(parsed.Path)
+	if err != nil {
+		return fmt.Sprintf("invalid escaped link target %q: %v", target, err)
+	}
+	if decodedPath == "" {
+		return ""
+	}
+	resolved := filepath.Join(root, filepath.Dir(filepath.FromSlash(document)), filepath.FromSlash(decodedPath))
+	_, err = os.Stat(resolved)
+	if err == nil {
+		if hasException(exceptions, "link", document, target) && isIgnoredPath(root, resolved) {
+			useException(exceptions, "link", document, target)
+		}
+		return ""
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Sprintf("cannot inspect link target %q: %v", target, err)
+	}
+	if useException(exceptions, "link", document, target) {
+		return ""
+	}
+	return fmt.Sprintf("relative link target does not exist: %s", target)
+}
+
+func isIgnoredPath(root, path string) bool {
+	relativePath, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return exec.Command("git", "-C", root, "check-ignore", "--quiet", "--", relativePath).Run() == nil
+}
+
+func checkSymbolReference(document, reference string, packages map[string]map[string]struct{}, exceptions exceptionSet) string {
+	match := symbolPattern.FindStringSubmatch(reference)
+	if match == nil {
+		useException(exceptions, "symbol", document, reference)
+		return ""
+	}
+	symbols, internalPackage := packages[match[1]]
+	if !internalPackage {
+		return ""
+	}
+	for _, symbol := range strings.Split(match[2], ".") {
+		if _, exists := symbols[symbol]; exists {
+			continue
+		}
+		if useException(exceptions, "symbol", document, reference) {
+			return ""
+		}
+		return fmt.Sprintf("qualified Go symbol does not exist: %s", reference)
+	}
+	return ""
+}
+
+func useException(exceptions exceptionSet, kind, document, reference string) bool {
+	key := exceptionKey{kind, filepath.ToSlash(document), reference}
+	if !hasException(exceptions, kind, document, reference) {
+		return false
+	}
+	exceptions[key] = true
+	return true
+}
+
+func hasException(exceptions exceptionSet, kind, document, reference string) bool {
+	_, exists := exceptions[exceptionKey{kind, filepath.ToSlash(document), reference}]
+	return exists
+}

--- a/scripts/check_docs/main_test.go
+++ b/scripts/check_docs/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarkdownTargets(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, []string{"docs/guide.md#setup", "path with spaces.md"}, markdownTargets(
+		`Read [the guide](docs/guide.md#setup) and [the notes](<path with spaces.md>).`,
+	))
+	assert.Empty(t, markdownTargets(`[^1]: A citation with prose (not-a-link).`))
+}
+
+func TestCheckRelativeTarget(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "docs"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "guide.md"), nil, 0o644))
+	assert.Empty(t, checkRelativeTarget(root, "docs/README.md", "../guide.md#intro", exceptionSet{}))
+	assert.Contains(t, checkRelativeTarget(root, "docs/README.md", "missing.md", exceptionSet{}), "does not exist")
+	assert.Empty(t, checkRelativeTarget(root, "docs/README.md", "https://example.com/missing.md", exceptionSet{}))
+}
+
+func TestCheckSymbolReference(t *testing.T) {
+	t.Parallel()
+	packages := map[string]map[string]struct{}{"proxy": {"Service": {}, "Route": {}}}
+	assert.Empty(t, checkSymbolReference("docs/guide.md", "proxy.Service.Route", packages, exceptionSet{}))
+	assert.Contains(t, checkSymbolReference("docs/guide.md", "proxy.OnUpstreamMeta", packages, exceptionSet{}), "does not exist")
+	assert.Empty(t, checkSymbolReference("docs/guide.md", "http.Client", packages, exceptionSet{}))
+}
+
+func TestCollectDeclarationSymbols(t *testing.T) {
+	t.Parallel()
+	parsed, err := parser.ParseFile(token.NewFileSet(), "sample.go", `package sample
+type Service struct { ExportedField string; hiddenField string }
+const ExportedConstant = "value"
+func (s *Service) ExportedMethod() {}
+`, 0)
+	require.NoError(t, err)
+	symbols := map[string]struct{}{}
+	for _, declaration := range parsed.Decls {
+		collectDeclarationSymbols(symbols, declaration)
+	}
+	assert.Contains(t, symbols, "Service")
+	assert.Contains(t, symbols, "ExportedField")
+	assert.Contains(t, symbols, "ExportedConstant")
+	assert.Contains(t, symbols, "ExportedMethod")
+	assert.NotContains(t, symbols, "hiddenField")
+}

--- a/scripts/check_sql_queries.sh
+++ b/scripts/check_sql_queries.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root=$(git rev-parse --show-toplevel)
+query_directory=${1:-"$repository_root/db/queries"}
+if [[ ! -d "$query_directory" ]]; then
+  echo "error: SQL query directory does not exist: $query_directory" >&2
+  exit 2
+fi
+
+findings=$(mktemp)
+trap 'rm -f "$findings"' EXIT
+perl -ne '
+  $line = $_; $line =~ s/--.*$//;
+  while ($line =~ /\$[1-9][0-9]*\b/g) { print "$ARGV:$.: numbered parameter $&\n"; }
+  while ($line =~ /(@[A-Za-z_][A-Za-z0-9_]*|sqlc\.(?:arg|narg)\(\s*\x27[^\x27]+\x27\s*\))/g) {
+    $parameter = $1; $remainder = substr($line, pos($line));
+    if ($remainder !~ /^\s*::/) { print "$ARGV:$.: parameter has no explicit type cast: $parameter\n"; }
+  }
+  close ARGV if eof;
+' "$query_directory"/*.sql >> "$findings"
+awk '
+  FNR == 1 { previous_nonblank = "" }
+  /^-- name:/ {
+    if (previous_nonblank !~ /^-- / || previous_nonblank ~ /^-- name:/) {
+      printf "%s:%d: query declaration needs an explanatory comment\n", FILENAME, FNR
+    }
+  }
+  $0 !~ /^[[:space:]]*$/ { previous_nonblank = $0 }
+' "$query_directory"/*.sql >> "$findings"
+if [[ -s "$findings" ]]; then LC_ALL=C sort "$findings" >&2; exit 1; fi
+echo "SQL query conventions passed"

--- a/scripts/docs_check_exceptions.txt
+++ b/scripts/docs_check_exceptions.txt
@@ -1,0 +1,13 @@
+# kind    Markdown file                                  relative target or qualified symbol
+# Governance documents are being added by a separate active change. Exceptions fail
+# once they no longer match a broken reference, so they cannot silently outlive it.
+link      CONTRIBUTING.md                                CODE_OF_CONDUCT.md
+link      CONTRIBUTING.md                                SECURITY.md
+
+# npm prepack creates this file beside the published README; it is absent in source.
+link      install/npm/README.md                          ./install.sh
+
+# Root/provider guide corrections overlap active guide changes. Remove after they land.
+symbol    CLAUDE.md                                      OnUpstreamMeta
+symbol    internal/providers/CLAUDE.md                   proxy.OnUpstreamMeta
+symbol    internal/providers/CLAUDE.md                   anthropic.MessageRequest

--- a/scripts/generate_agents.sh
+++ b/scripts/generate_agents.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() { echo "usage: $0 [--check] [--root <repository>]" >&2; }
+
+check_only=false
+repository_root=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check) check_only=true; shift ;;
+    --root)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      repository_root=$2
+      shift 2
+      ;;
+    *) usage; exit 2 ;;
+  esac
+done
+
+if [[ -z "$repository_root" ]]; then
+  repository_root=$(git rev-parse --show-toplevel)
+fi
+repository_root=$(cd "$repository_root" && pwd)
+
+render_mirror() {
+  local source=$1
+  awk '
+    NR == 1 {
+      if ($0 !~ / — CLAUDE$/) {
+        print "error: " FILENAME ": first line must end with \" — CLAUDE\"" > "/dev/stderr"
+        exit 2
+      }
+      sub(/ — CLAUDE$/, " — AGENTS")
+    }
+    NR == 3 {
+      if ($0 !~ /\[AGENTS\.md\]\(AGENTS\.md\)/) {
+        print "error: " FILENAME ": line 3 must link to AGENTS.md" > "/dev/stderr"
+        exit 2
+      }
+      sub(/\[AGENTS\.md\]\(AGENTS\.md\)/, "[CLAUDE.md](CLAUDE.md)")
+    }
+    { print }
+  ' "$source"
+}
+
+claude_guides=()
+while IFS= read -r guide; do
+  claude_guides+=("$guide")
+done < <(
+  find "$repository_root" -type f -name CLAUDE.md \
+    -not -path '*/.git/*' -not -path '*/node_modules/*' -print | LC_ALL=C sort
+)
+
+if [[ ${#claude_guides[@]} -eq 0 ]]; then
+  echo "error: no CLAUDE.md guides found under $repository_root" >&2
+  exit 1
+fi
+
+failures=0
+for source in "${claude_guides[@]}"; do
+  mirror="${source%CLAUDE.md}AGENTS.md"
+  temporary=$(mktemp "${mirror}.tmp.XXXXXX")
+  if ! render_mirror "$source" > "$temporary"; then
+    rm -f "$temporary"
+    exit 1
+  fi
+  if $check_only; then
+    if [[ ! -f "$mirror" ]] || ! cmp -s "$temporary" "$mirror"; then
+      echo "error: generated mirror is stale: ${mirror#"$repository_root"/}" >&2
+      if [[ -f "$mirror" ]]; then diff -u "$mirror" "$temporary" || true; else echo "error: mirror is missing" >&2; fi
+      failures=$((failures + 1))
+    fi
+    rm -f "$temporary"
+  else
+    mv "$temporary" "$mirror"
+  fi
+done
+
+while IFS= read -r mirror; do
+  source="${mirror%AGENTS.md}CLAUDE.md"
+  if [[ ! -f "$source" ]]; then
+    echo "error: AGENTS.md has no canonical CLAUDE.md: ${mirror#"$repository_root"/}" >&2
+    failures=$((failures + 1))
+  fi
+done < <(
+  find "$repository_root" -type f -name AGENTS.md \
+    -not -path '*/.git/*' -not -path '*/node_modules/*' -print | LC_ALL=C sort
+)
+
+[[ $failures -eq 0 ]] || exit 1
+action=generated
+$check_only && action=checked
+echo "$action ${#claude_guides[@]} CLAUDE.md -> AGENTS.md mirrors"


### PR DESCRIPTION
Implements P0-B from the architecture audit: deterministic gates for docs and SQL quality.

## What

- `scripts/generate_agents.sh` derives all 19 `AGENTS.md` mirrors from canonical `CLAUDE.md` guides; `--check` detects drift.
- `scripts/check_docs/` validates relative Markdown links and qualified Go symbol references, with explicit exceptions.
- `scripts/check_sql_queries.sh` rejects numbered parameters, uncast parameters, and undocumented query declarations.
- Added `make check-docs`, `check-sql`, and `check-repository-conventions`; the full `check` target includes the new gate.
- Corrected stale guide symbols and broken links.
- Added missing SQL casts/comments and regenerated sqlc output with v1.30.0.

## Validation

- `make check` passes with sqlc v1.30.0.
- Generator idempotence and drift detection verified.
- SQL checker positive/negative fixtures verified.
- Go tests, vet, build, installer/statusline checks pass.