### PR TITLE
chore(install): bump router npm package to 0.2.15

### DIFF
--- a/install/npm/package.json
+++ b/install/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weave-os/router",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "One-command installer that points Claude Code, Codex, opencode, or pi at the Weave Router. For pi it also ships the routing extension, loaded via pi.extensions.",
   "bin": {
     "weave-router": "bin.js",


### PR DESCRIPTION
## Summary
- bump the npm package version from 0.2.14 to 0.2.15
- prepare the @weave-os/router and @workweave/router publish workflow for the next release

## Validation
- bash install/tests/packaging_test.sh (22 passed)