### PR TITLE
fix(translate): omit invalid top-level Anthropic effort

### DIFF
--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -556,15 +556,17 @@ func applyOverrides(body []byte, ov EmitOverrides) ([]byte, error) {
 	}
 
 	// ForceOutputConfigEffort wins over any request-derived or inbound
-	// effort; write both sibling fields so either form is overridden.
+	// output_config.effort. Anthropic Messages only accepts the nested form;
+	// a top-level `effort` field is rejected as an unknown input. Delete any
+	// client-supplied top-level value rather than forwarding it upstream.
 	if ov.ForceOutputConfigEffort != "" {
 		out, err = sjson.SetBytes(out, "output_config.effort", ov.ForceOutputConfigEffort)
 		if err != nil {
 			return nil, fmt.Errorf("set output_config.effort (forced): %w", err)
 		}
-		out, err = sjson.SetBytes(out, "effort", ov.ForceOutputConfigEffort)
+		out, err = sjson.DeleteBytes(out, "effort")
 		if err != nil {
-			return nil, fmt.Errorf("set effort (forced): %w", err)
+			return nil, fmt.Errorf("delete effort (forced): %w", err)
 		}
 	}
 

--- a/internal/translate/force_effort_anthropic_test.go
+++ b/internal/translate/force_effort_anthropic_test.go
@@ -69,8 +69,27 @@ func TestForceEffort_AnthropicOverrides(t *testing.T) {
 			oc, ok := out["output_config"].(map[string]any)
 			require.True(t, ok, "output_config must survive the rewrite")
 			assert.Equal(t, tc.wantEff, oc["effort"])
+			assert.NotContains(t, out, "effort", "forced Anthropic effort must not be sent at top level")
 		})
 	}
+}
+
+func TestForceEffort_AnthropicRemovesInboundTopLevelEffort(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-5","max_tokens":1024,"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"effort":"high"}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareAnthropic(http.Header{}, translate.EmitOptions{
+		TargetModel:  "claude-opus-5",
+		Capabilities: router.Lookup("claude-opus-5"),
+		ForceEffort:  "low",
+	})
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &out))
+	assert.NotContains(t, out, "effort", "top-level effort is not valid in Anthropic Messages")
+	outputConfig, ok := out["output_config"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "low", outputConfig["effort"])
 }
 
 // TestForceEffort_AnthropicPassesThroughAlias verifies alias forms (e.g. ultra)


### PR DESCRIPTION
Anthropic Messages accepts effort only under output_config.effort. When the router forced an effort level, it also emitted a top-level effort sibling, causing 400 responses: `effort: Extra inputs are not permitted`.

This removes any inbound/generated top-level effort whenever ForceOutputConfigEffort is applied and adds regression coverage for forced and inbound values.

Tests: go test ./internal/translate ./internal/proxy ./internal/providers/...