### PR TITLE
fix(translate): sanitize invalid tool names for OpenAI

### DIFF
--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -631,7 +631,7 @@ func buildOpenAIToolCall(block gjson.Result) string {
 	inner.Key("function")
 	inner.Obj()
 	inner.Key("name")
-	inner.Str(block.Get("name").String())
+	inner.Str(sanitizeResponsesToolAlias(block.Get("name").String()))
 	// input is a JSON object; encode it as a JSON string (arguments field).
 	inputRaw := block.Get("input").Raw
 	if inputRaw == "" {
@@ -821,7 +821,7 @@ func writeOpenAIToolsFromAnthropic(jw *jsonWriter, body []byte) {
 		jw.Key("function")
 		jw.Obj()
 		jw.Key("name")
-		jw.Str(tool.Get("name").String())
+		jw.Str(sanitizeResponsesToolAlias(tool.Get("name").String()))
 		if desc := tool.Get("description"); desc.Exists() {
 			jw.Key("description")
 			jw.Raw(desc.Raw)
@@ -858,7 +858,7 @@ func writeOpenAIToolChoiceFromAnthropic(jw *jsonWriter, body []byte) {
 		inner.Key("function")
 		inner.Obj()
 		inner.Key("name")
-		inner.Str(name)
+		inner.Str(sanitizeResponsesToolAlias(name))
 		inner.EndObj()
 		inner.EndObj()
 		jw.Key("tool_choice")

--- a/internal/translate/emit_openai_responses.go
+++ b/internal/translate/emit_openai_responses.go
@@ -410,7 +410,7 @@ func writeResponsesInputFromAnthropic(jw *jsonWriter, body []byte) {
 				jw.Key("call_id")
 				jw.Str(clampOpenAIToolCallID(callID))
 				jw.Key("name")
-				jw.Str(block.Get("name").String())
+				jw.Str(sanitizeResponsesToolAlias(block.Get("name").String()))
 				inputRaw := block.Get("input").Raw
 				if inputRaw == "" {
 					inputRaw = "{}"
@@ -630,7 +630,7 @@ func writeResponsesFunctionTools(jw *jsonWriter, tools []responsesFunctionTool) 
 		jw.Key("type")
 		jw.Str("function")
 		jw.Key("name")
-		jw.Str(tool.name)
+		jw.Str(sanitizeResponsesToolAlias(tool.name))
 		if tool.description.Exists() {
 			jw.Key("description")
 			jw.Raw(tool.description.Raw)
@@ -665,7 +665,7 @@ func writeResponsesToolChoiceFromAnthropic(jw *jsonWriter, body []byte) {
 		jw.Key("type")
 		jw.Str("function")
 		jw.Key("name")
-		jw.Str(name)
+		jw.Str(sanitizeResponsesToolAlias(name))
 		jw.EndObj()
 	}
 }

--- a/internal/translate/emit_openai_responses_from_openai.go
+++ b/internal/translate/emit_openai_responses_from_openai.go
@@ -156,7 +156,7 @@ func writeResponsesInputFromOpenAI(jw *jsonWriter, messages gjson.Result, skip i
 				jw.Key("call_id")
 				jw.Str(clampOpenAIToolCallID(call.Get("id").String()))
 				jw.Key("name")
-				jw.Str(call.Get("function.name").String())
+				jw.Str(sanitizeResponsesToolAlias(call.Get("function.name").String()))
 				args := call.Get("function.arguments").String()
 				if args == "" {
 					args = "{}"
@@ -316,7 +316,7 @@ func writeResponsesToolChoiceFromOpenAI(jw *jsonWriter, body []byte) {
 		jw.Key("type")
 		jw.Str("function")
 		jw.Key("name")
-		jw.Str(name)
+		jw.Str(sanitizeResponsesToolAlias(name))
 		jw.EndObj()
 	}
 }

--- a/internal/translate/responses_outbound_test.go
+++ b/internal/translate/responses_outbound_test.go
@@ -127,6 +127,33 @@ func TestPrepareOpenAIResponses_RequestShape(t *testing.T) {
 	assert.Equal(t, providers.EndpointResponses, prep.Endpoint)
 }
 
+// Unknown tool calls stay in Anthropic history for the client's feedback loop,
+// but OpenAI Responses only accepts the restricted function-name alphabet.
+func TestPrepareOpenAIResponses_SanitizesHistoricalToolName(t *testing.T) {
+	body := []byte(`{
+      "model":"claude-opus-5",
+      "messages":[
+        {"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"dots schema search --scope all","input":{}}]},
+        {"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"done"}]}
+      ]
+    }`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareOpenAIResponses(http.Header{}, translate.EmitOptions{
+		TargetModel:  "gpt-5.6-luna",
+		Capabilities: router.Lookup("gpt-5.6-luna"),
+	})
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &out))
+	input, _ := out["input"].([]any)
+	require.Len(t, input, 2)
+	call, _ := input[0].(map[string]any)
+	assert.Equal(t, "dots_schema_search_--scope_all", call["name"])
+	assert.Regexp(t, `^[a-zA-Z0-9_-]+$`, call["name"])
+}
+
 func topLevelResponsesFields(t *testing.T, body []byte) []string {
 	t.Helper()
 	decoder := json.NewDecoder(bytes.NewReader(body))


### PR DESCRIPTION
## Summary
- sanitize Anthropic/OpenAI tool names before emitting OpenAI chat and Responses requests
- prevent malformed historical tool calls from causing OpenAI 400s
- add regression coverage for names containing spaces

Observed in production: an unknown tool call named `dots schema search --scope all organization_members --db prod --json` was preserved in Claude Code history and rejected by OpenAI Responses at `input[26].name`.
