### PR TITLE
Propagate OTel trace headers

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -1254,9 +1254,9 @@ func main() {
 	engine.UnescapePathValues = true
 	engine.UseRawPath = true
 	engine.Use(
+		apm.Middleware(),
 		observability.Middleware(),
 		observability.AccessLog(),
-		apm.Middleware(),
 		gin.Recovery(),
 	)
 

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -70,6 +70,9 @@ import (
 
 func main() {
 	logger := observability.Get()
+	// Initialize propagation and APM before constructing HTTP clients so their
+	// OpenTelemetry transports capture the configured providers and propagator.
+	apm.Init()
 	if err := router.ValidateCatalogReasoningCapabilities(); err != nil {
 		logger.Error("Refusing to boot with invalid model reasoning capabilities", "err", err)
 		panic(err)
@@ -1245,10 +1248,6 @@ func main() {
 	}
 	logger.Info("Subscription plan-aware routing configured",
 		"enabled", config.GetOr("ROUTER_SUBSCRIPTION_PLAN_AWARE_ROUTING", "false") == "true")
-
-	// No-op when WV_APM_OTLP_ENDPOINT is unset. Flushed explicitly in the
-	// shutdown path below since a defer would run after SIGKILL.
-	apm.Init()
 
 	engine := gin.New()
 	engine.UnescapePathValues = true

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/tink-crypto/tink-go/v2 v2.2.0
 	github.com/vlad-tokarev/sloggcp v0.0.0-20230820053939-1b7dbb8c7b58
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.61.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.61.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0
@@ -96,7 +97,6 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	golang.org/x/arch v0.17.0 // indirect
 	golang.org/x/crypto v0.52.0 // indirect

--- a/internal/entra/client_credentials.go
+++ b/internal/entra/client_credentials.go
@@ -49,6 +49,7 @@ func NewClientCredentialsSource(httpClient *http.Client, now auth.Clock) *Client
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
+	httpClient = observability.WrapHTTPClient(httpClient)
 	if now == nil {
 		now = time.Now
 	}
@@ -131,7 +132,6 @@ func (s *ClientCredentialsSource) mint(ctx context.Context, key *auth.ExternalAP
 	if err != nil {
 		return nil, fmt.Errorf("%w: build token request: %v", auth.ErrEntraUnavailable, err)
 	}
-	observability.InjectTraceContext(ctx, request)
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	response, err := s.httpClient.Do(request)
 	if err != nil {

--- a/internal/entra/client_credentials.go
+++ b/internal/entra/client_credentials.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/sync/singleflight"
 
 	"weave-os/router/internal/auth"
+	"weave-os/router/internal/observability"
 )
 
 const (
@@ -130,6 +131,7 @@ func (s *ClientCredentialsSource) mint(ctx context.Context, key *auth.ExternalAP
 	if err != nil {
 		return nil, fmt.Errorf("%w: build token request: %v", auth.ErrEntraUnavailable, err)
 	}
+	observability.InjectTraceContext(ctx, request)
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	response, err := s.httpClient.Do(request)
 	if err != nil {

--- a/internal/observability/apm/apm.go
+++ b/internal/observability/apm/apm.go
@@ -41,7 +41,9 @@ var (
 )
 
 // Init wires the OTel SDK against the SigNoz collector using
-// WV_APM_OTLP_ENDPOINT (host:port for OTLP/gRPC). Empty = no-op. Idempotent.
+// WV_APM_OTLP_ENDPOINT (host:port for OTLP/gRPC). With an empty endpoint it
+// still enables W3C trace-context propagation but does not export telemetry.
+// Idempotent.
 // Mirrors backend/internal/app/telemetry/otel.go's init() so the router
 // reports the same resource attribute shape as the rest of Weave.
 func Init() {
@@ -54,10 +56,7 @@ func initLocked() {
 	// Configure extraction/injection even when exporting is disabled. This
 	// keeps distributed trace headers flowing through the router in no-op APM
 	// deployments, and lets request logs retain an inbound parent trace.
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
-		propagation.TraceContext{},
-		propagation.Baggage{},
-	))
+	otel.SetTextMapPropagator(propagation.TraceContext{})
 
 	endpoint := config.GetOr("WV_APM_OTLP_ENDPOINT", "")
 	if endpoint == "" {

--- a/internal/observability/apm/apm.go
+++ b/internal/observability/apm/apm.go
@@ -51,6 +51,14 @@ func Init() {
 func initLocked() {
 	log := observability.Get()
 
+	// Configure extraction/injection even when exporting is disabled. This
+	// keeps distributed trace headers flowing through the router in no-op APM
+	// deployments, and lets request logs retain an inbound parent trace.
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
 	endpoint := config.GetOr("WV_APM_OTLP_ENDPOINT", "")
 	if endpoint == "" {
 		log.Info("APM disabled: WV_APM_OTLP_ENDPOINT unset")
@@ -91,11 +99,6 @@ func initLocked() {
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 	)
 	otel.SetTracerProvider(tracerProvider)
-
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
-		propagation.TraceContext{},
-		propagation.Baggage{},
-	))
 
 	metricExporter, err := otlpmetricgrpc.New(ctx, metricGRPCOpts(endpoint, insecure)...)
 	if err != nil {

--- a/internal/observability/logger.go
+++ b/internal/observability/logger.go
@@ -265,6 +265,7 @@ func Middleware() gin.HandlerFunc {
 			"method", c.Request.Method,
 			"path", c.Request.URL.Path,
 		)
+		logger = LoggerWithTraceContext(c.Request.Context(), logger)
 		if upstream := sanitizeLogValue(c.Request.Header.Get("X-Request-Id")); upstream != "" {
 			logger = logger.With("upstream_request_id", upstream)
 		}

--- a/internal/observability/trace.go
+++ b/internal/observability/trace.go
@@ -1,0 +1,56 @@
+package observability
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+const (
+	gcpTraceField = "logging.googleapis.com/trace"
+	gcpSpanField  = "logging.googleapis.com/spanId"
+)
+
+// LoggerWithTraceContext adds the active OpenTelemetry trace and span IDs to a
+// logger using the field names Cloud Logging recognizes for trace correlation.
+// When GCP_PROJECT_ID is set, the trace field is the fully-qualified resource
+// name expected by Logs Explorer.
+func LoggerWithTraceContext(ctx context.Context, log *slog.Logger) *slog.Logger {
+	if log == nil {
+		return nil
+	}
+	if ctx == nil {
+		return log
+	}
+	spanCtx := oteltrace.SpanContextFromContext(ctx)
+	if !spanCtx.IsValid() {
+		return log
+	}
+
+	traceID := spanCtx.TraceID().String()
+	if projectID := strings.TrimSpace(os.Getenv("GCP_PROJECT_ID")); projectID != "" {
+		traceID = fmt.Sprintf("projects/%s/traces/%s", projectID, traceID)
+	}
+	log = log.With(gcpTraceField, traceID)
+	if spanCtx.HasSpanID() {
+		log = log.With(gcpSpanField, spanCtx.SpanID().String())
+	}
+	return log
+}
+
+// InjectTraceContext propagates the active OpenTelemetry context into an
+// outbound HTTP request. It emits the globally configured W3C Trace Context
+// and Baggage headers (typically traceparent, tracestate, and baggage).
+func InjectTraceContext(ctx context.Context, req *http.Request) {
+	if req == nil || ctx == nil {
+		return
+	}
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
+}

--- a/internal/observability/trace.go
+++ b/internal/observability/trace.go
@@ -4,12 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"os"
 	"strings"
 
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/propagation"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
@@ -43,14 +40,4 @@ func LoggerWithTraceContext(ctx context.Context, log *slog.Logger) *slog.Logger 
 		log = log.With(gcpSpanField, spanCtx.SpanID().String())
 	}
 	return log
-}
-
-// InjectTraceContext propagates the active OpenTelemetry context into an
-// outbound HTTP request. It emits the globally configured W3C Trace Context
-// and Baggage headers (typically traceparent, tracestate, and baggage).
-func InjectTraceContext(ctx context.Context, req *http.Request) {
-	if req == nil || ctx == nil {
-		return
-	}
-	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
 }

--- a/internal/observability/trace_test.go
+++ b/internal/observability/trace_test.go
@@ -1,0 +1,96 @@
+package observability_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"weave-os/router/internal/observability"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+func TestLoggerWithTraceContextUsesCloudLoggingFields(t *testing.T) {
+	t.Setenv("GCP_PROJECT_ID", "router-project")
+	var buf strings.Builder
+	log := slog.New(slog.NewJSONHandler(&buf, nil))
+	traceID, err := oteltrace.TraceIDFromHex("0123456789abcdef0123456789abcdef")
+	require.NoError(t, err)
+	spanID, err := oteltrace.SpanIDFromHex("0123456789abcdef")
+	require.NoError(t, err)
+	ctx := oteltrace.ContextWithRemoteSpanContext(context.Background(), oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: oteltrace.FlagsSampled,
+		Remote:     true,
+	}))
+
+	observability.LoggerWithTraceContext(ctx, log).Info("trace-linked")
+	var record map[string]any
+	require.NoError(t, json.Unmarshal([]byte(buf.String()), &record))
+	assert.Equal(t, "projects/router-project/traces/0123456789abcdef0123456789abcdef", record["logging.googleapis.com/trace"])
+	assert.Equal(t, "0123456789abcdef", record["logging.googleapis.com/spanId"])
+}
+
+func TestInjectTraceContextAddsW3CHeaders(t *testing.T) {
+	previous := otel.GetTextMapPropagator()
+	t.Cleanup(func() { otel.SetTextMapPropagator(previous) })
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
+
+	traceID, err := oteltrace.TraceIDFromHex("0123456789abcdef0123456789abcdef")
+	require.NoError(t, err)
+	spanID, err := oteltrace.SpanIDFromHex("0123456789abcdef")
+	require.NoError(t, err)
+	ctx := oteltrace.ContextWithRemoteSpanContext(context.Background(), oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: oteltrace.FlagsSampled,
+		Remote:     true,
+	}))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+
+	observability.InjectTraceContext(ctx, req)
+	assert.Equal(t, "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01", req.Header.Get("traceparent"))
+}
+
+func TestMiddlewareIncludesTraceContextInRequestLogs(t *testing.T) {
+	t.Setenv("GCP_PROJECT_ID", "router-project")
+	var buf strings.Builder
+	restore := swapDefaultLogger(t, &buf)
+	defer restore()
+
+	traceID, err := oteltrace.TraceIDFromHex("0123456789abcdef0123456789abcdef")
+	require.NoError(t, err)
+	spanID, err := oteltrace.SpanIDFromHex("0123456789abcdef")
+	require.NoError(t, err)
+	ctx := oteltrace.ContextWithRemoteSpanContext(context.Background(), oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: oteltrace.FlagsSampled,
+		Remote:     true,
+	}))
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.Use(observability.Middleware())
+	engine.GET("/x", func(c *gin.Context) {
+		observability.FromGin(c).Info("handler ran")
+		c.Status(http.StatusOK)
+	})
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/x", nil)
+	engine.ServeHTTP(httptest.NewRecorder(), req)
+
+	line := findLogLine(t, buf.String(), "handler ran")
+	assert.Equal(t, "projects/router-project/traces/0123456789abcdef0123456789abcdef", line["logging.googleapis.com/trace"])
+	assert.Equal(t, "0123456789abcdef", line["logging.googleapis.com/spanId"])
+}

--- a/internal/observability/trace_test.go
+++ b/internal/observability/trace_test.go
@@ -10,11 +10,13 @@ import (
 	"testing"
 
 	"weave-os/router/internal/observability"
+	"weave-os/router/internal/observability/apm"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/propagation"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
@@ -41,10 +43,10 @@ func TestLoggerWithTraceContextUsesCloudLoggingFields(t *testing.T) {
 	assert.Equal(t, "0123456789abcdef", record["logging.googleapis.com/spanId"])
 }
 
-func TestInjectTraceContextAddsW3CHeaders(t *testing.T) {
+func TestWrapHTTPClientPropagatesTraceContextWithoutBaggage(t *testing.T) {
 	previous := otel.GetTextMapPropagator()
 	t.Cleanup(func() { otel.SetTextMapPropagator(previous) })
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
+	otel.SetTextMapPropagator(propagation.TraceContext{})
 
 	traceID, err := oteltrace.TraceIDFromHex("0123456789abcdef0123456789abcdef")
 	require.NoError(t, err)
@@ -56,12 +58,30 @@ func TestInjectTraceContextAddsW3CHeaders(t *testing.T) {
 		TraceFlags: oteltrace.FlagsSampled,
 		Remote:     true,
 	}))
+	member, err := baggage.NewMember("tenant", "internal")
+	require.NoError(t, err)
+	bag, err := baggage.New(member)
+	require.NoError(t, err)
+	ctx = baggage.ContextWithBaggage(ctx, bag)
+
+	var got http.Header
+	client := observability.WrapHTTPClient(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		got = req.Header.Clone()
+		return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody, Header: make(http.Header)}, nil
+	})})
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.com", nil)
 	require.NoError(t, err)
 
-	observability.InjectTraceContext(ctx, req)
-	assert.Equal(t, "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01", req.Header.Get("traceparent"))
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01", got.Get("traceparent"))
+	assert.Empty(t, got.Get("baggage"))
 }
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
 
 func TestMiddlewareIncludesTraceContextInRequestLogs(t *testing.T) {
 	t.Setenv("GCP_PROJECT_ID", "router-project")
@@ -69,25 +89,18 @@ func TestMiddlewareIncludesTraceContextInRequestLogs(t *testing.T) {
 	restore := swapDefaultLogger(t, &buf)
 	defer restore()
 
-	traceID, err := oteltrace.TraceIDFromHex("0123456789abcdef0123456789abcdef")
-	require.NoError(t, err)
-	spanID, err := oteltrace.SpanIDFromHex("0123456789abcdef")
-	require.NoError(t, err)
-	ctx := oteltrace.ContextWithRemoteSpanContext(context.Background(), oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
-		TraceID:    traceID,
-		SpanID:     spanID,
-		TraceFlags: oteltrace.FlagsSampled,
-		Remote:     true,
-	}))
-
 	gin.SetMode(gin.TestMode)
 	engine := gin.New()
-	engine.Use(observability.Middleware())
+	previous := otel.GetTextMapPropagator()
+	t.Cleanup(func() { otel.SetTextMapPropagator(previous) })
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	engine.Use(apm.Middleware(), observability.Middleware())
 	engine.GET("/x", func(c *gin.Context) {
 		observability.FromGin(c).Info("handler ran")
 		c.Status(http.StatusOK)
 	})
-	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/x", nil)
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set("traceparent", "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01")
 	engine.ServeHTTP(httptest.NewRecorder(), req)
 
 	line := findLogLine(t, buf.String(), "handler ran")

--- a/internal/observability/transport.go
+++ b/internal/observability/transport.go
@@ -1,0 +1,25 @@
+package observability
+
+import (
+	"net/http"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+// NewTracingTransport wraps base with OpenTelemetry HTTP client tracing and
+// W3C trace-context propagation. A nil base uses http.DefaultTransport.
+func NewTracingTransport(base http.RoundTripper) http.RoundTripper {
+	return otelhttp.NewTransport(base)
+}
+
+// WrapHTTPClient returns a copy of client whose transport emits OpenTelemetry
+// client spans and propagates W3C trace context. The original client and its
+// redirect, cookie, and timeout settings are unchanged.
+func WrapHTTPClient(client *http.Client) *http.Client {
+	if client == nil {
+		client = &http.Client{}
+	}
+	wrapped := *client
+	wrapped.Transport = NewTracingTransport(client.Transport)
+	return &wrapped
+}

--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -105,6 +105,7 @@ func New(baseURL string, client *http.Client, timeout time.Duration, opts ...Opt
 			},
 		}
 	}
+	client = observability.WrapHTTPClient(client)
 	sidecar := &Client{
 		baseURL:        strings.TrimRight(baseURL, "/"),
 		client:         client,
@@ -123,7 +124,6 @@ func (c *Client) CheckHealth(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("build policy readiness request: %w", err)
 	}
-	observability.InjectTraceContext(ctx, req)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("call policy readiness endpoint: %w", err)
@@ -152,7 +152,6 @@ func (c *Client) Capabilities(ctx context.Context) (policy.Capabilities, error) 
 	if err != nil {
 		return policy.Capabilities{}, fmt.Errorf("build policy capabilities request: %w", err)
 	}
-	observability.InjectTraceContext(ctx, req)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return policy.Capabilities{}, fmt.Errorf("call policy capabilities endpoint: %w", err)
@@ -207,7 +206,6 @@ func (c *Client) fetchRoster(ctx context.Context) (rosterResponse, error) {
 	if err != nil {
 		return rosterResponse{}, fmt.Errorf("build policy roster request: %w", err)
 	}
-	observability.InjectTraceContext(ctx, req)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return rosterResponse{}, fmt.Errorf("call policy roster endpoint: %w", err)
@@ -239,7 +237,6 @@ func (c *Client) post(ctx context.Context, path string, payload map[string]inter
 	if err != nil {
 		return fmt.Errorf("build policy %s request: %w", label, err)
 	}
-	observability.InjectTraceContext(ctx, req)
 	req.Header.Set("content-type", "application/json")
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -850,7 +847,6 @@ func (c *Client) doPolicyAttempt(
 	if err != nil {
 		return nil, nil, true, fmt.Errorf("build policy route request: %w", err)
 	}
-	observability.InjectTraceContext(attemptCtx, req)
 	req.Header.Set("content-type", "application/json")
 
 	resp, err := c.client.Do(req)

--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -14,6 +14,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"weave-os/router/internal/observability"
 	"weave-os/router/internal/router"
 	"weave-os/router/internal/router/policy"
 )
@@ -122,6 +123,7 @@ func (c *Client) CheckHealth(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("build policy readiness request: %w", err)
 	}
+	observability.InjectTraceContext(ctx, req)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("call policy readiness endpoint: %w", err)
@@ -150,6 +152,7 @@ func (c *Client) Capabilities(ctx context.Context) (policy.Capabilities, error) 
 	if err != nil {
 		return policy.Capabilities{}, fmt.Errorf("build policy capabilities request: %w", err)
 	}
+	observability.InjectTraceContext(ctx, req)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return policy.Capabilities{}, fmt.Errorf("call policy capabilities endpoint: %w", err)
@@ -204,6 +207,7 @@ func (c *Client) fetchRoster(ctx context.Context) (rosterResponse, error) {
 	if err != nil {
 		return rosterResponse{}, fmt.Errorf("build policy roster request: %w", err)
 	}
+	observability.InjectTraceContext(ctx, req)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return rosterResponse{}, fmt.Errorf("call policy roster endpoint: %w", err)
@@ -235,6 +239,7 @@ func (c *Client) post(ctx context.Context, path string, payload map[string]inter
 	if err != nil {
 		return fmt.Errorf("build policy %s request: %w", label, err)
 	}
+	observability.InjectTraceContext(ctx, req)
 	req.Header.Set("content-type", "application/json")
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -845,6 +850,7 @@ func (c *Client) doPolicyAttempt(
 	if err != nil {
 		return nil, nil, true, fmt.Errorf("build policy route request: %w", err)
 	}
+	observability.InjectTraceContext(attemptCtx, req)
 	req.Header.Set("content-type", "application/json")
 
 	resp, err := c.client.Do(req)

--- a/internal/providers/httputil/client_test.go
+++ b/internal/providers/httputil/client_test.go
@@ -1,6 +1,7 @@
 package httputil
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -9,7 +10,42 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestNewClientPropagatesTraceContext(t *testing.T) {
+	previous := otel.GetTextMapPropagator()
+	t.Cleanup(func() { otel.SetTextMapPropagator(previous) })
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	traceID, err := oteltrace.TraceIDFromHex("0123456789abcdef0123456789abcdef")
+	require.NoError(t, err)
+	spanID, err := oteltrace.SpanIDFromHex("0123456789abcdef")
+	require.NoError(t, err)
+	ctx := oteltrace.ContextWithRemoteSpanContext(context.Background(), oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: oteltrace.FlagsSampled,
+		Remote:     true,
+	}))
+
+	var got string
+	client := NewClient(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		got = req.Header.Get("traceparent")
+		return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody, Header: make(http.Header)}, nil
+	}))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+	_, err = client.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01", got)
+}
 
 func TestNewClientFailsTheCallOnARedirect(t *testing.T) {
 	// atomic: written on the httptest handler goroutine, read here.

--- a/internal/providers/httputil/client_test.go
+++ b/internal/providers/httputil/client_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/propagation"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
@@ -34,17 +35,25 @@ func TestNewClientPropagatesTraceContext(t *testing.T) {
 		TraceFlags: oteltrace.FlagsSampled,
 		Remote:     true,
 	}))
+	member, err := baggage.NewMember("tenant", "internal")
+	require.NoError(t, err)
+	bag, err := baggage.New(member)
+	require.NoError(t, err)
+	ctx = baggage.ContextWithBaggage(ctx, bag)
 
-	var got string
+	var got, gotBaggage string
 	client := NewClient(roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		got = req.Header.Get("traceparent")
+		gotBaggage = req.Header.Get("baggage")
 		return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody, Header: make(http.Header)}, nil
 	}))
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.com", nil)
 	require.NoError(t, err)
-	_, err = client.Do(req)
+	resp, err := client.Do(req)
 	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
 	assert.Equal(t, "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01", got)
+	assert.Empty(t, gotBaggage)
 }
 
 func TestNewClientFailsTheCallOnARedirect(t *testing.T) {

--- a/internal/providers/httputil/httputil.go
+++ b/internal/providers/httputil/httputil.go
@@ -263,31 +263,15 @@ func newTransport(dialTimeout, tlsTimeout, responseHeaderTimeout time.Duration, 
 // host the deployment never configured, so the call is failed rather than relayed.
 var ErrRefusedRedirect = errors.New("upstream returned a redirect, which is not followed")
 
-// NewClient returns an http.Client on transport that refuses redirects.
-// Failing the call keeps a 3xx off every relay path — returning it would let
-// each adapter treat the redirect status as success.
+// NewClient returns an http.Client that records OpenTelemetry client spans,
+// propagates W3C trace context, and refuses redirects. Failing the call keeps
+// a 3xx off every relay path — returning it would let each adapter treat the
+// redirect status as success.
 func NewClient(transport http.RoundTripper) *http.Client {
 	if transport == nil {
 		transport = http.DefaultTransport
 	}
-	return &http.Client{Transport: tracePropagatingTransport{next: transport}, CheckRedirect: refuseRedirect}
-}
-
-// tracePropagatingTransport injects the current OTel context at the last
-// possible point before an outbound request is sent. Doing this in the shared
-// client keeps provider adapters (including model discovery and passthrough)
-// from accidentally dropping traceparent/tracestate headers.
-type tracePropagatingTransport struct {
-	next http.RoundTripper
-}
-
-func (t tracePropagatingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if req == nil {
-		return t.next.RoundTrip(req)
-	}
-	out := req.Clone(req.Context())
-	observability.InjectTraceContext(out.Context(), out)
-	return t.next.RoundTrip(out)
+	return &http.Client{Transport: observability.NewTracingTransport(transport), CheckRedirect: refuseRedirect}
 }
 
 func refuseRedirect(*http.Request, []*http.Request) error {

--- a/internal/providers/httputil/httputil.go
+++ b/internal/providers/httputil/httputil.go
@@ -267,7 +267,27 @@ var ErrRefusedRedirect = errors.New("upstream returned a redirect, which is not 
 // Failing the call keeps a 3xx off every relay path — returning it would let
 // each adapter treat the redirect status as success.
 func NewClient(transport http.RoundTripper) *http.Client {
-	return &http.Client{Transport: transport, CheckRedirect: refuseRedirect}
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	return &http.Client{Transport: tracePropagatingTransport{next: transport}, CheckRedirect: refuseRedirect}
+}
+
+// tracePropagatingTransport injects the current OTel context at the last
+// possible point before an outbound request is sent. Doing this in the shared
+// client keeps provider adapters (including model discovery and passthrough)
+// from accidentally dropping traceparent/tracestate headers.
+type tracePropagatingTransport struct {
+	next http.RoundTripper
+}
+
+func (t tracePropagatingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req == nil {
+		return t.next.RoundTrip(req)
+	}
+	out := req.Clone(req.Context())
+	observability.InjectTraceContext(out.Context(), out)
+	return t.next.RoundTrip(out)
 }
 
 func refuseRedirect(*http.Request, []*http.Request) error {

--- a/internal/router/rl/client.go
+++ b/internal/router/rl/client.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"weave-os/router/internal/observability"
 )
 
 // DefaultTimeout bounds a single policy decision. The sidecar embeds the
@@ -101,6 +103,7 @@ func (d *HTTPDecider) Decide(ctx context.Context, q Query) (Result, error) {
 	for k, v := range d.headers {
 		req.Header.Set(k, v)
 	}
+	observability.InjectTraceContext(ctx, req)
 
 	resp, err := d.client.Do(req)
 	if err != nil {

--- a/internal/router/rl/client.go
+++ b/internal/router/rl/client.go
@@ -47,6 +47,7 @@ func NewHTTPDeciderWithHeaders(baseURL string, client *http.Client, timeout time
 			},
 		}
 	}
+	client = observability.WrapHTTPClient(client)
 	copied := map[string]string{}
 	for k, v := range headers {
 		if strings.TrimSpace(k) == "" || v == "" {
@@ -103,7 +104,6 @@ func (d *HTTPDecider) Decide(ctx context.Context, q Query) (Result, error) {
 	for k, v := range d.headers {
 		req.Header.Set(k, v)
 	}
-	observability.InjectTraceContext(ctx, req)
 
 	resp, err := d.client.Do(req)
 	if err != nil {

--- a/internal/subscriptions/oauth.go
+++ b/internal/subscriptions/oauth.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"weave-os/router/internal/observability"
 )
 
 const (
@@ -103,6 +105,7 @@ func (c *OAuthClient) refreshCodex(ctx context.Context, refreshToken string) (Re
 	if err != nil {
 		return RefreshedToken{}, err
 	}
+	observability.InjectTraceContext(ctx, req)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("User-Agent", tokenUserAgent)
 	var response struct {
@@ -137,6 +140,7 @@ func (c *OAuthClient) refreshClaude(ctx context.Context, refreshToken string) (R
 	if err != nil {
 		return RefreshedToken{}, err
 	}
+	observability.InjectTraceContext(ctx, req)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", tokenUserAgent)
 	var response struct {

--- a/internal/subscriptions/oauth.go
+++ b/internal/subscriptions/oauth.go
@@ -56,6 +56,7 @@ func NewOAuthClient(httpClient *http.Client, codexTokenURL, claudeTokenURL strin
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
+	httpClient = observability.WrapHTTPClient(httpClient)
 	if codexTokenURL == "" {
 		codexTokenURL = DefaultCodexTokenURL
 	}
@@ -105,7 +106,6 @@ func (c *OAuthClient) refreshCodex(ctx context.Context, refreshToken string) (Re
 	if err != nil {
 		return RefreshedToken{}, err
 	}
-	observability.InjectTraceContext(ctx, req)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("User-Agent", tokenUserAgent)
 	var response struct {
@@ -140,7 +140,6 @@ func (c *OAuthClient) refreshClaude(ctx context.Context, refreshToken string) (R
 	if err != nil {
 		return RefreshedToken{}, err
 	}
-	observability.InjectTraceContext(ctx, req)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", tokenUserAgent)
 	var response struct {


### PR DESCRIPTION
## Summary
- propagate W3C OTel trace context on outbound HTTP requests
- include GCP Cloud Logging trace/span fields in request logs
- initialize propagation even when APM exporting is disabled

## Validation
- go test ./...