### PR TITLE
feat: honor quality price bias in HMM routing

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -868,6 +868,9 @@ func main() {
 		var capabilityErr error
 		hmmCapabilities, capabilityErr = hmmClient.Capabilities(capabilityCtx)
 		cancelCapabilityDiscovery()
+		dynamicHMMRoster := declarativeRoster != nil && (declarativeRoster.SchemaVersion == rosterdata.SchemaVersionV7 || declarativeRoster.SchemaVersion == rosterdata.SchemaVersionV75C)
+		hmmCapabilities.HonorsQualityPriceBias = dynamicHMMRoster
+		hmmCapabilities.SupportsRoutingDistribution = dynamicHMMRoster
 		if capabilityErr != nil {
 			logger.Warn("HMM policy sidecar capabilities unavailable at boot; optional behavior remains disabled", "sidecar_url", hmmSidecarURL, "err", capabilityErr)
 		}
@@ -887,6 +890,8 @@ func main() {
 					hmmTimeout,
 					hmmCapabilityRetryInterval,
 					func(capabilities policy.Capabilities) {
+						capabilities.HonorsQualityPriceBias = dynamicHMMRoster
+						capabilities.SupportsRoutingDistribution = dynamicHMMRoster
 						hmmPolicyRouter.WithCapabilities(capabilities)
 						hmmEmbeddingPolicyRouter.WithCapabilities(capabilities)
 					},
@@ -1264,7 +1269,7 @@ func main() {
 	deployedModels, _ := rtr.(*cluster.Multiversion)
 	analyticsSvc := analytics.NewService(repo.Analytics, time.Now)
 	readinessChecker := newReadinessChecker(pool, hmmReadinessChecker)
-	server.Register(engine, authSvc, proxySvc, deployedModels, hmmRosterModels, deploymentMode, billingSvc, readinessChecker, hmmRosterSource, analyticsSvc)
+	server.Register(engine, authSvc, proxySvc, deployedModels, hmmRosterModels, deploymentMode, billingSvc, readinessChecker, hmmRosterSource, analyticsSvc, declarativeRoster)
 
 	srv := &http.Server{
 		Addr:    ":" + config.GetOr("PORT", "8080"),

--- a/docs/HMM_GO_SELECTION.md
+++ b/docs/HMM_GO_SELECTION.md
@@ -23,9 +23,9 @@ class and shrinks the sidecar's authority to what only it can do: ML inference.
 
 | Concern | Owner |
 |---|---|
-| Roster contents (`hmm_router_cluster_roster_v6` JSON) | Declarative data, loaded and fail-loud validated by Go at boot (`internal/router/hmm/rosterdata`) |
+| Roster contents (`hmm_router_cluster_roster_v7` JSON) | Declarative data, loaded and fail-loud validated by Go at boot (`internal/router/hmm/rosterdata`) |
 | Roster↔catalog validation | Go: `hmm.ValidateRosterIDs` (`internal/router/hmm/validate.go`) plus the `validate-roster` CLI for CI |
-| Within-cluster deterministic arm selection (harness-specific order, rank-1 pick, ranked cluster-fallback walk) | Go: `internal/router/hmm/selection` |
+| Within-cluster deterministic arm selection (harness policy, preference-adjusted WII/WPI ranking, ranked cluster-fallback walk) | Go: `internal/router/hmm/selection` |
 | Complexity classification (ML) | Python sidecar (`policy_router_v3` contract) |
 | Ranked cluster fallback (per-group probability, roster arms, eligible arms) | Python sidecar — the only selection input the router accepts |
 
@@ -43,6 +43,18 @@ and the sidecar's classifier label/confidence is kept. Explicit force-cluster
 and per-key cluster overrides take precedence when they actually constrain the
 pick (a ranked-group pass-through with no configured list for the winning group
 does not).
+
+The organization quality/price dial is applied only after the classifier band,
+candidate set, sidecar allowlist, and harness membership are fixed. Within that
+eligible pool, v7 rosters score each arm as `alpha*WII - (1-alpha)*WPI`.
+The user-facing neutral value (`0.70`) maps to the independently tuned alpha for
+each band; an unset or exactly neutral preference uses the generated fixed order
+and score map byte-for-byte. Manual pins and harness vendor priority remain
+stronger tiers than the dynamic score, and original roster position breaks ties.
+
+The same Go scorer produces `/v1/router/routing-distribution` and the per-arm
+scores used by effort hysteresis. WPI is a normalized evaluation-workload axis,
+not a billing rate; preview dollars always come from catalog serving prices.
 
 Selection is **fail-closed**. A `/route` response with no ranked fallback, a
 ranked fallback holding no eligible arm, or a `policy_router_v1`/`v2` schema is

--- a/internal/api/admin/routing_distribution.go
+++ b/internal/api/admin/routing_distribution.go
@@ -6,7 +6,10 @@ import (
 	"strconv"
 	"strings"
 
+	"weave-os/router/internal/router"
 	"weave-os/router/internal/router/cluster"
+	"weave-os/router/internal/router/hmm/rosterdata"
+	hmmselection "weave-os/router/internal/router/hmm/selection"
 
 	"github.com/gin-gonic/gin"
 )
@@ -41,7 +44,7 @@ type routingDistributionResponse struct {
 // the eligible pool so the preview matches what Route would do for an
 // installation with those exclusions — the control plane passes the requesting
 // org's lists, keeping the endpoint unauthed/global while still org-correct.
-func RoutingDistributionHandler(dist RoutingDistributionSource) gin.HandlerFunc {
+func RoutingDistributionHandler(dist RoutingDistributionSource, hmmRosters ...*rosterdata.Roster) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		gridN := 0 // 0 -> scorer default
 		if raw := c.Query("grid"); raw != "" {
@@ -54,7 +57,18 @@ func RoutingDistributionHandler(dist RoutingDistributionSource) gin.HandlerFunc 
 		}
 		excludedModels := parseCSVSet(c.Query("excluded_models"))
 		excludedProviders := parseCSVSet(c.Query("excluded_providers"))
-		points, err := dist.DefaultRoutingDistribution(gridN, excludedModels, excludedProviders)
+		strategy := router.Strategy(strings.ToLower(strings.TrimSpace(c.Query("strategy"))))
+		var points []cluster.DistributionPoint
+		var err error
+		if router.IsHMMStrategy(strategy) {
+			if len(hmmRosters) == 0 || hmmRosters[0] == nil {
+				c.JSON(http.StatusServiceUnavailable, gin.H{"error": "hmm routing distribution unavailable"})
+				return
+			}
+			points, err = hmmselection.RoutingDistribution(hmmRosters[0], gridN, excludedModels, excludedProviders)
+		} else {
+			points, err = dist.DefaultRoutingDistribution(gridN, excludedModels, excludedProviders)
+		}
 		if err != nil {
 			// An exclusion set that empties the eligible pool is a client
 			// configuration error (4xx), not a server outage — same sentinel

--- a/internal/api/admin/routing_distribution_test.go
+++ b/internal/api/admin/routing_distribution_test.go
@@ -9,6 +9,7 @@ import (
 
 	"weave-os/router/internal/api/admin"
 	"weave-os/router/internal/router/cluster"
+	"weave-os/router/internal/router/hmm/rosterdata"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -124,4 +125,34 @@ func TestRoutingDistributionHandler_EmptyPoolIs400(t *testing.T) {
 	rec := httptest.NewRecorder()
 	engine.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestRoutingDistributionHandler_UsesHMMRosterForHMMStrategy(t *testing.T) {
+	src := &fakeDistributionSource{err: errors.New("legacy cluster source must not run")}
+	roster := &rosterdata.Roster{
+		SchemaVersion: rosterdata.SchemaVersionV7,
+		Ranking: rosterdata.Ranking{
+			Alpha: map[string]float64{"low": 0.4}, AlphaMin: map[string]float64{"low": 0.05},
+			AlphaMax: map[string]float64{"low": 0.8}, QualityBiasNeutral: 0.7,
+		},
+		Clusters: map[string]rosterdata.Cluster{
+			"low": {
+				Arms:      []string{"openai/gpt-5.6-luna"},
+				ArmScores: map[string]float64{"openai/gpt-5.6-luna": 20},
+				ArmIndices: map[string]rosterdata.ArmIndices{
+					"openai/gpt-5.6-luna": {WII: 50, WPI: 0},
+				},
+			},
+		},
+	}
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.GET("/v1/router/routing-distribution", admin.RoutingDistributionHandler(src, roster))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/router/routing-distribution?strategy=hmm_embedding&grid=2", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Zero(t, src.lastGrid)
 }

--- a/internal/proxy/hysteresis.go
+++ b/internal/proxy/hysteresis.go
@@ -13,8 +13,8 @@ const effortHysteresisThreshold = 1.0
 const effortHysteresisReason = "effort_hysteresis"
 
 // effortHysteresisHold returns the incumbent effort to keep serving, or "" to
-// let the challenger through. Both sides are looked up in the sidecar's
-// per-arm WMI map, which is keyed by effort-qualified roster arm ID
+// let the challenger through. Both sides are looked up in the router's
+// preference-adjusted per-arm WII/WPI score map, keyed by roster arm ID
 // ("anthropic/claude-opus-5:xhigh") rather than by catalog serving identity.
 func effortHysteresisHold(fresh router.Decision, prevServedModel, chosenModel, chosenEffort string) string {
 	if fresh.Metadata == nil || len(fresh.Metadata.ArmScores) == 0 {

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -265,8 +265,8 @@ type authorityCacheShadow struct {
 	// StayModel carries ":effort" while decision_model is a bare catalog ID, so a
 	// string compare reports a false divergence on every effort-bearing pin.
 	Sticky bool
-	// StayScore/FreshScore are the sidecar's candidate scores. Nil when the sidecar
-	// reported no score; the nil rate is a measurement result in itself.
+	// StayScore/FreshScore are the router's preference-adjusted candidate scores.
+	// Nil when the active roster cannot score the arm; that nil rate is useful.
 	StayScore  *float64
 	FreshScore *float64
 }

--- a/internal/router/hmm/rosterdata/rosterdata.go
+++ b/internal/router/hmm/rosterdata/rosterdata.go
@@ -6,6 +6,7 @@ package rosterdata
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"sort"
 	"strings"
@@ -13,10 +14,17 @@ import (
 	"weave-os/router/internal/router/hmm"
 )
 
+type SchemaVersion string
+
+const (
+	SchemaVersionV7   SchemaVersion = "hmm_router_cluster_roster_v7"
+	SchemaVersionV75C SchemaVersion = "hmm_router_cluster_roster_v7_5c"
+)
+
 // Roster is the parsed generated roster document. Unknown top-level fields
 // are tolerated; the fields here are the ones the router consumes.
 type Roster struct {
-	SchemaVersion string             `json:"schema_version"`
+	SchemaVersion SchemaVersion      `json:"schema_version"`
 	Ranking       Ranking            `json:"ranking"`
 	Clusters      map[string]Cluster `json:"clusters"`
 }
@@ -24,18 +32,35 @@ type Roster struct {
 // Ranking carries the ranking metadata the roster builder used; Alpha is the
 // per-cluster WMI blend weight.
 type Ranking struct {
-	Alpha map[string]float64 `json:"alpha"`
+	Alpha                  map[string]float64 `json:"alpha"`
+	AlphaMin               map[string]float64 `json:"alpha_min"`
+	AlphaMax               map[string]float64 `json:"alpha_max"`
+	QualityBiasNeutral     float64            `json:"quality_bias_neutral"`
+	WIIScoreVersion        string             `json:"wii_score_version"`
+	WIINormalizationSHA256 string             `json:"wii_normalization_sha256"`
+	WPIScoreVersion        string             `json:"wpi_score_version"`
+	WPINormalizationSHA256 string             `json:"wpi_normalization_sha256"`
+}
+
+// ArmIndices are the immutable quality and price axes used to dynamically
+// rank an arm. Both are absolute 0-100 indices; WPI is not a serving price.
+type ArmIndices struct {
+	WII float64 `json:"wii_v1"`
+	WPI float64 `json:"wpi_v1"`
 }
 
 // Cluster is one complexity cluster's ordered arm roster and reference costs.
 type Cluster struct {
-	ComplexityLabel     string              `json:"complexity_label"`
-	Arms                []string            `json:"arms"`
-	ArmsByHarness       map[string][]string `json:"arms_by_harness"`
-	MembershipByHarness map[string][]string `json:"membership_by_harness"`
-	CostRefUSD          float64             `json:"cost_ref_usd"`
-	LatencyRefMS        float64             `json:"latency_ref_ms"`
-	ArmScores           map[string]float64  `json:"arm_scores"`
+	ComplexityLabel           string                `json:"complexity_label"`
+	Arms                      []string              `json:"arms"`
+	ArmsByHarness             map[string][]string   `json:"arms_by_harness"`
+	MembershipByHarness       map[string][]string   `json:"membership_by_harness"`
+	CostRefUSD                float64               `json:"cost_ref_usd"`
+	LatencyRefMS              float64               `json:"latency_ref_ms"`
+	ArmScores                 map[string]float64    `json:"arm_scores"`
+	ArmIndices                map[string]ArmIndices `json:"arm_indices"`
+	ManualPinsByHarness       map[string][]string   `json:"manual_pins_by_harness"`
+	PreferredVendorsByHarness map[string][]string   `json:"preferred_vendors_by_harness"`
 }
 
 // AllArms returns every distinct arm ID referenced by the roster — cluster
@@ -124,6 +149,57 @@ func validateSchema(r *Roster) error {
 		if _, ok := r.Ranking.Alpha[label]; !ok {
 			return fmt.Errorf("cluster %q has no ranking.alpha entry", label)
 		}
+		if r.SchemaVersion == SchemaVersionV7 || r.SchemaVersion == SchemaVersionV75C {
+			if err := validateDynamicCluster(r, label, cluster); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
+}
+
+func validateDynamicCluster(r *Roster, label string, cluster Cluster) error {
+	if r.Ranking.WIIScoreVersion == "" || r.Ranking.WIINormalizationSHA256 == "" ||
+		r.Ranking.WPIScoreVersion == "" || r.Ranking.WPINormalizationSHA256 == "" {
+		return fmt.Errorf("v7 roster has incomplete WII/WPI provenance")
+	}
+	neutral := r.Ranking.QualityBiasNeutral
+	defaultAlpha := r.Ranking.Alpha[label]
+	minAlpha, hasMin := r.Ranking.AlphaMin[label]
+	maxAlpha, hasMax := r.Ranking.AlphaMax[label]
+	if !finiteUnit(neutral) || neutral <= 0 || neutral >= 1 {
+		return fmt.Errorf("ranking.quality_bias_neutral must be inside (0,1)")
+	}
+	if !hasMin || !hasMax || !finiteUnit(minAlpha) || !finiteUnit(defaultAlpha) || !finiteUnit(maxAlpha) || minAlpha > defaultAlpha || defaultAlpha > maxAlpha {
+		return fmt.Errorf("cluster %q has invalid alpha calibration", label)
+	}
+	pins := make(map[string]struct{})
+	for _, arms := range cluster.ManualPinsByHarness {
+		for _, arm := range arms {
+			pins[arm] = struct{}{}
+		}
+	}
+	allOrderedArms := append([]string(nil), cluster.Arms...)
+	for _, arms := range cluster.ArmsByHarness {
+		allOrderedArms = append(allOrderedArms, arms...)
+	}
+	for _, arm := range allOrderedArms {
+		indices, ok := cluster.ArmIndices[arm]
+		if !ok {
+			if _, explicitlyPinned := pins[arm]; explicitlyPinned {
+				continue
+			}
+			return fmt.Errorf("cluster %q arm %q has no arm_indices entry", label, arm)
+		}
+		if !finiteRange(indices.WII, 0, 100) || !finiteRange(indices.WPI, 0, 100) {
+			return fmt.Errorf("cluster %q arm %q has invalid WII/WPI indices", label, arm)
+		}
+	}
+	return nil
+}
+
+func finiteUnit(value float64) bool { return finiteRange(value, 0, 1) }
+
+func finiteRange(value, minimum, maximum float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0) && value >= minimum && value <= maximum
 }

--- a/internal/router/hmm/rosterdata/rosterdata.go
+++ b/internal/router/hmm/rosterdata/rosterdata.go
@@ -17,6 +17,7 @@ import (
 type SchemaVersion string
 
 const (
+	SchemaVersionV6   SchemaVersion = "hmm_router_cluster_roster_v6"
 	SchemaVersionV7   SchemaVersion = "hmm_router_cluster_roster_v7"
 	SchemaVersionV75C SchemaVersion = "hmm_router_cluster_roster_v7_5c"
 )
@@ -173,20 +174,11 @@ func validateDynamicCluster(r *Roster, label string, cluster Cluster) error {
 	if !hasMin || !hasMax || !finiteUnit(minAlpha) || !finiteUnit(defaultAlpha) || !finiteUnit(maxAlpha) || minAlpha > defaultAlpha || defaultAlpha > maxAlpha {
 		return fmt.Errorf("cluster %q has invalid alpha calibration", label)
 	}
-	pins := make(map[string]struct{})
-	for _, arms := range cluster.ManualPinsByHarness {
-		for _, arm := range arms {
-			pins[arm] = struct{}{}
-		}
-	}
-	allOrderedArms := append([]string(nil), cluster.Arms...)
-	for _, arms := range cluster.ArmsByHarness {
-		allOrderedArms = append(allOrderedArms, arms...)
-	}
-	for _, arm := range allOrderedArms {
+	globalPins := armSet(cluster.ManualPinsByHarness["*"])
+	for _, arm := range cluster.Arms {
 		indices, ok := cluster.ArmIndices[arm]
 		if !ok {
-			if _, explicitlyPinned := pins[arm]; explicitlyPinned {
+			if _, globallyPinned := globalPins[arm]; globallyPinned {
 				continue
 			}
 			return fmt.Errorf("cluster %q arm %q has no arm_indices entry", label, arm)
@@ -195,7 +187,32 @@ func validateDynamicCluster(r *Roster, label string, cluster Cluster) error {
 			return fmt.Errorf("cluster %q arm %q has invalid WII/WPI indices", label, arm)
 		}
 	}
+	for harness, arms := range cluster.ArmsByHarness {
+		harnessPins := armSet(cluster.ManualPinsByHarness[harness])
+		for _, arm := range arms {
+			indices, ok := cluster.ArmIndices[arm]
+			if !ok {
+				_, globallyPinned := globalPins[arm]
+				_, pinnedForHarness := harnessPins[arm]
+				if globallyPinned || pinnedForHarness {
+					continue
+				}
+				return fmt.Errorf("cluster %q harness %q arm %q has no arm_indices entry", label, harness, arm)
+			}
+			if !finiteRange(indices.WII, 0, 100) || !finiteRange(indices.WPI, 0, 100) {
+				return fmt.Errorf("cluster %q harness %q arm %q has invalid WII/WPI indices", label, harness, arm)
+			}
+		}
+	}
 	return nil
+}
+
+func armSet(arms []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(arms))
+	for _, arm := range arms {
+		set[arm] = struct{}{}
+	}
+	return set
 }
 
 func finiteUnit(value float64) bool { return finiteRange(value, 0, 1) }

--- a/internal/router/hmm/rosterdata/rosterdata_test.go
+++ b/internal/router/hmm/rosterdata/rosterdata_test.go
@@ -138,6 +138,59 @@ func TestParseSchemaErrors(t *testing.T) {
 	}
 }
 
+func TestParseDynamicRoster(t *testing.T) {
+	roster, err := rosterdata.Parse([]byte(`{
+  "schema_version": "hmm_router_cluster_roster_v7",
+  "ranking": {
+    "alpha": {"low": 0.4},
+    "alpha_min": {"low": 0.05},
+    "alpha_max": {"low": 0.8},
+    "quality_bias_neutral": 0.7,
+    "wii_score_version": "wii-v1",
+    "wii_normalization_sha256": "wii-sha",
+    "wpi_score_version": "wpi-v1",
+    "wpi_normalization_sha256": "wpi-sha"
+  },
+  "clusters": {
+    "low": {
+      "complexity_label": "low",
+      "arms": ["provider/scored", "provider/manual"],
+      "arms_by_harness": {"pi": ["provider/manual"]},
+      "cost_ref_usd": 0.02,
+      "latency_ref_ms": 8000,
+      "arm_scores": {"provider/scored": 10, "provider/manual": 20},
+      "arm_indices": {"provider/scored": {"wii_v1": 50, "wpi_v1": 10}},
+      "manual_pins_by_harness": {"pi": ["provider/manual"]},
+      "preferred_vendors_by_harness": {"codex": ["provider"]}
+    }
+  }
+}`))
+	require.NoError(t, err)
+	assert.Equal(t, 50.0, roster.Clusters["low"].ArmIndices["provider/scored"].WII)
+	assert.Equal(t, []string{"provider/manual"}, roster.Clusters["low"].ManualPinsByHarness["pi"])
+}
+
+func TestParseDynamicRosterRejectsMissingIndices(t *testing.T) {
+	_, err := rosterdata.Parse([]byte(`{
+  "schema_version": "hmm_router_cluster_roster_v7",
+  "ranking": {
+    "alpha": {"low": 0.4}, "alpha_min": {"low": 0.05}, "alpha_max": {"low": 0.8},
+    "quality_bias_neutral": 0.7,
+    "wii_score_version": "wii-v1", "wii_normalization_sha256": "wii-sha",
+    "wpi_score_version": "wpi-v1", "wpi_normalization_sha256": "wpi-sha"
+  },
+  "clusters": {
+    "low": {
+      "complexity_label": "low", "arms": ["provider/unscored"],
+      "cost_ref_usd": 0.02, "latency_ref_ms": 8000,
+      "arm_scores": {"provider/unscored": 10}, "arm_indices": {}
+    }
+  }
+}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no arm_indices entry")
+}
+
 // replaceJSON returns a mutator that swaps one occurrence of old for new in
 // the fixture document, failing the test if old is absent.
 func replaceJSON(old, new string) func(t *testing.T, doc []byte) []byte {

--- a/internal/router/hmm/rosterdata/rosterdata_test.go
+++ b/internal/router/hmm/rosterdata/rosterdata_test.go
@@ -16,7 +16,7 @@ func TestLoadValidRoster(t *testing.T) {
 	roster, err := rosterdata.Load(filepath.Join("testdata", "roster_valid.json"))
 	require.NoError(t, err)
 
-	assert.Equal(t, "hmm_router_cluster_roster_v6", roster.SchemaVersion)
+	assert.Equal(t, rosterdata.SchemaVersionV6, roster.SchemaVersion)
 	require.Len(t, roster.Clusters, 2)
 
 	low := roster.Clusters["low"]
@@ -66,7 +66,7 @@ func TestParseUnknownFieldsTolerated(t *testing.T) {
 
 	roster, parseErr := rosterdata.Parse(data)
 	require.NoError(t, parseErr)
-	assert.Equal(t, "hmm_router_cluster_roster_v6", roster.SchemaVersion)
+	assert.Equal(t, rosterdata.SchemaVersionV6, roster.SchemaVersion)
 }
 
 func TestParseSchemaErrors(t *testing.T) {
@@ -154,7 +154,7 @@ func TestParseDynamicRoster(t *testing.T) {
   "clusters": {
     "low": {
       "complexity_label": "low",
-      "arms": ["provider/scored", "provider/manual"],
+      "arms": ["provider/scored"],
       "arms_by_harness": {"pi": ["provider/manual"]},
       "cost_ref_usd": 0.02,
       "latency_ref_ms": 8000,
@@ -189,6 +189,30 @@ func TestParseDynamicRosterRejectsMissingIndices(t *testing.T) {
 }`))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no arm_indices entry")
+}
+
+func TestParseDynamicRosterRejectsHarnessPinWithoutGlobalCoverage(t *testing.T) {
+	_, err := rosterdata.Parse([]byte(`{
+  "schema_version": "hmm_router_cluster_roster_v7",
+  "ranking": {
+    "alpha": {"low": 0.4}, "alpha_min": {"low": 0.05}, "alpha_max": {"low": 0.8},
+    "quality_bias_neutral": 0.7,
+    "wii_score_version": "wii-v1", "wii_normalization_sha256": "wii-sha",
+    "wpi_score_version": "wpi-v1", "wpi_normalization_sha256": "wpi-sha"
+  },
+  "clusters": {
+    "low": {
+      "complexity_label": "low", "arms": ["provider/scored", "provider/manual"],
+      "arms_by_harness": {"pi": ["provider/manual"]},
+      "cost_ref_usd": 0.02, "latency_ref_ms": 8000,
+      "arm_scores": {"provider/scored": 10, "provider/manual": 20},
+      "arm_indices": {"provider/scored": {"wii_v1": 50, "wpi_v1": 10}},
+      "manual_pins_by_harness": {"pi": ["provider/manual"]}
+    }
+  }
+}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `arm "provider/manual" has no arm_indices entry`)
 }
 
 // replaceJSON returns a mutator that swaps one occurrence of old for new in

--- a/internal/router/hmm/selection/distribution.go
+++ b/internal/router/hmm/selection/distribution.go
@@ -1,0 +1,94 @@
+package selection
+
+import (
+	"fmt"
+	"sort"
+
+	"weave-os/router/internal/router/catalog"
+	"weave-os/router/internal/router/cluster"
+	"weave-os/router/internal/router/hmm"
+	"weave-os/router/internal/router/hmm/rosterdata"
+)
+
+const defaultDistributionGrid = 21
+
+// RoutingDistribution projects the HMM roster's within-band model mix across
+// the quality/price dial. Each classifier band contributes equal weight; live
+// traffic weights remain request-dependent and are intentionally not guessed.
+func RoutingDistribution(roster *rosterdata.Roster, gridN int, excludedModels, excludedProviders map[string]struct{}) ([]cluster.DistributionPoint, error) {
+	if roster == nil || (roster.SchemaVersion != rosterdata.SchemaVersionV7 && roster.SchemaVersion != rosterdata.SchemaVersionV75C) {
+		return nil, fmt.Errorf("HMM routing distribution requires a dynamic v7 roster")
+	}
+	if gridN < 2 {
+		gridN = defaultDistributionGrid
+	}
+	labels := make([]string, 0, len(roster.Clusters))
+	for label := range roster.Clusters {
+		labels = append(labels, label)
+	}
+	sort.Strings(labels)
+	points := make([]cluster.DistributionPoint, 0, gridN)
+	for gridIndex := 0; gridIndex < gridN; gridIndex++ {
+		qualityBias := float64(gridIndex) / float64(gridN-1)
+		counts := make(map[string]int)
+		prices := make(map[string]float64)
+		selectedGroups := 0
+		for _, label := range labels {
+			clusterRoster := roster.Clusters[label]
+			candidates := make(map[string]struct{}, len(clusterRoster.Arms))
+			for _, arm := range clusterRoster.Arms {
+				baseRosterID, _ := hmm.SplitEffort(arm)
+				catalogID := hmm.CatalogIDForRoster(baseRosterID)
+				model, ok := catalog.ByID(catalogID)
+				if !ok {
+					continue
+				}
+				provider := model.PrimaryProvider()
+				if _, excluded := excludedModels[catalogID]; excluded {
+					continue
+				}
+				if _, excluded := excludedProviders[provider]; excluded {
+					continue
+				}
+				candidates[baseRosterID] = struct{}{}
+				if len(model.Providers) > 0 {
+					prices[catalogID] = model.Providers[0].Price.InputUSDPer1M / 1000
+				}
+			}
+			pick, _, ok := SelectGroupsWithPreference(
+				roster,
+				[]Group{{Label: label}},
+				"",
+				candidates,
+				&qualityBias,
+			)
+			if !ok {
+				continue
+			}
+			selectedGroups++
+			counts[hmm.CatalogIDForRoster(pick.Arm)]++
+		}
+		if len(counts) == 0 {
+			return nil, fmt.Errorf("exclusions leave no eligible candidates: %w", cluster.ErrNoEligibleProvider)
+		}
+		modelShares := make([]cluster.ModelShare, 0, len(counts))
+		projectedCost := 0.0
+		for model, count := range counts {
+			share := float64(count) / float64(selectedGroups)
+			modelShares = append(modelShares, cluster.ModelShare{Model: model, Share: share})
+			projectedCost += share * prices[model]
+		}
+		sort.Slice(modelShares, func(i, j int) bool {
+			if modelShares[i].Share != modelShares[j].Share {
+				return modelShares[i].Share > modelShares[j].Share
+			}
+			return modelShares[i].Model < modelShares[j].Model
+		})
+		points = append(points, cluster.DistributionPoint{
+			QualityBias:                qualityBias,
+			Models:                     modelShares,
+			ProjectedCostPer1KInputUSD: projectedCost,
+		})
+	}
+	return points, nil
+}

--- a/internal/router/hmm/selection/distribution_test.go
+++ b/internal/router/hmm/selection/distribution_test.go
@@ -1,0 +1,70 @@
+package selection_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"weave-os/router/internal/router/hmm/rosterdata"
+	"weave-os/router/internal/router/hmm/selection"
+)
+
+func TestRoutingDistributionUsesLivePreferenceScorer(t *testing.T) {
+	roster := &rosterdata.Roster{
+		SchemaVersion: rosterdata.SchemaVersionV7,
+		Ranking: rosterdata.Ranking{
+			Alpha:              map[string]float64{"low": 0.4},
+			AlphaMin:           map[string]float64{"low": 0.05},
+			AlphaMax:           map[string]float64{"low": 0.8},
+			QualityBiasNeutral: 0.7,
+		},
+		Clusters: map[string]rosterdata.Cluster{
+			"low": {
+				Arms: []string{"openai/gpt-5.6-luna", "x-ai/grok-4.6"},
+				ArmScores: map[string]float64{
+					"openai/gpt-5.6-luna": 30,
+					"x-ai/grok-4.6":       25,
+				},
+				ArmIndices: map[string]rosterdata.ArmIndices{
+					"openai/gpt-5.6-luna": {WII: 90, WPI: 10},
+					"x-ai/grok-4.6":       {WII: 55, WPI: 0},
+				},
+			},
+		},
+	}
+
+	points, err := selection.RoutingDistribution(roster, 3, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, points, 3)
+	require.Len(t, points[0].Models, 1)
+	require.Len(t, points[2].Models, 1)
+	assert.NotEqual(t, points[0].Models[0].Model, points[2].Models[0].Model)
+	assert.Equal(t, 1.0, points[0].Models[0].Share)
+	assert.Positive(t, points[0].ProjectedCostPer1KInputUSD)
+}
+
+func TestRoutingDistributionHonorsExclusions(t *testing.T) {
+	roster := dynamicRoster()
+	// Replace test-only IDs with catalog-backed IDs so distribution can resolve them.
+	cluster := roster.Clusters["low"]
+	cluster.Arms = []string{"openai/gpt-5.6-luna", "x-ai/grok-4.6"}
+	cluster.ArmScores = map[string]float64{"openai/gpt-5.6-luna": 30, "x-ai/grok-4.6": 25}
+	cluster.ArmIndices = map[string]rosterdata.ArmIndices{
+		"openai/gpt-5.6-luna": {WII: 90, WPI: 10},
+		"x-ai/grok-4.6":       {WII: 55, WPI: 0},
+	}
+	roster.Clusters["low"] = cluster
+
+	points, err := selection.RoutingDistribution(
+		roster,
+		2,
+		map[string]struct{}{"gpt-5.6-luna": {}},
+		nil,
+	)
+	require.NoError(t, err)
+	for _, point := range points {
+		require.Len(t, point.Models, 1)
+		assert.NotEqual(t, "gpt-5.6-luna", point.Models[0].Model)
+	}
+}

--- a/internal/router/hmm/selection/selection.go
+++ b/internal/router/hmm/selection/selection.go
@@ -4,6 +4,8 @@
 package selection
 
 import (
+	"math"
+	"sort"
 	"strings"
 
 	"weave-os/router/internal/router/hmm"
@@ -59,6 +61,21 @@ func Select(roster *rosterdata.Roster, rankedGroups []string, harness string, ca
 // SelectGroups is Select with each group's sidecar arm allowlist applied on top
 // of the router's candidate set.
 func SelectGroups(roster *rosterdata.Roster, groups []Group, harness string, candidates map[string]struct{}) (Pick, bool) {
+	pick, _, ok := SelectGroupsWithPreference(roster, groups, harness, candidates, nil)
+	return pick, ok
+}
+
+// SelectGroupsWithPreference applies quality/price ranking inside each
+// classifier group after all hard eligibility filters. The classifier's group
+// order is never changed. Returned score maps are grouped because a later
+// force-cluster or key override may change the final group.
+func SelectGroupsWithPreference(roster *rosterdata.Roster, groups []Group, harness string, candidates map[string]struct{}, qualityBias *float64) (Pick, map[string]map[string]float32, bool) {
+	scoresByGroup := make(map[string]map[string]float32, len(groups))
+	for _, group := range groups {
+		if cluster, ok := roster.Clusters[group.Label]; ok {
+			scoresByGroup[group.Label] = Scores(roster, group.Label, cluster, qualityBias)
+		}
+	}
 	depth := 0
 	for _, group := range groups {
 		cluster, ok := roster.Clusters[group.Label]
@@ -81,6 +98,7 @@ func SelectGroups(roster *rosterdata.Roster, groups []Group, harness string, can
 		}
 		restricted := len(allowedArms)+len(allowedBases) > 0
 		order, harnessSpecific := ArmOrder(cluster, harness)
+		order = preferenceOrder(roster, group.Label, cluster, harness, order, qualityBias)
 		for _, arm := range order {
 			// Candidates carry base roster IDs, so effort-suffixed arms
 			// (model:high) match on their base ID.
@@ -95,9 +113,106 @@ func SelectGroups(roster *rosterdata.Roster, groups []Group, harness string, can
 					continue
 				}
 			}
-			return Pick{Group: group.Label, Arm: arm, FallbackDepth: depth, HarnessOrder: harnessSpecific}, true
+			return Pick{Group: group.Label, Arm: arm, FallbackDepth: depth, HarnessOrder: harnessSpecific}, scoresByGroup, true
 		}
 		depth++
 	}
-	return Pick{}, false
+	return Pick{}, scoresByGroup, false
+}
+
+// Scores returns the fixed neutral scores or preference-adjusted WII/WPI score
+// for every indexed arm in a cluster.
+func Scores(roster *rosterdata.Roster, label string, cluster rosterdata.Cluster, qualityBias *float64) map[string]float32 {
+	neutral := roster.Ranking.QualityBiasNeutral
+	if qualityBias == nil || *qualityBias == neutral || !isDynamicRoster(roster) {
+		scores := make(map[string]float32, len(cluster.ArmScores))
+		for arm, score := range cluster.ArmScores {
+			scores[arm] = float32(score)
+		}
+		return scores
+	}
+	alpha := EffectiveAlpha(roster, label, *qualityBias)
+	scores := make(map[string]float32, len(cluster.ArmIndices))
+	for arm, indices := range cluster.ArmIndices {
+		scores[arm] = float32(alpha*indices.WII - (1-alpha)*indices.WPI)
+	}
+	return scores
+}
+
+// EffectiveAlpha maps the user dial piecewise around the neutral point so the
+// neutral UI setting reproduces each cluster's independently tuned alpha.
+func EffectiveAlpha(roster *rosterdata.Roster, label string, qualityBias float64) float64 {
+	qualityBias = math.Max(0, math.Min(1, qualityBias))
+	neutral := roster.Ranking.QualityBiasNeutral
+	defaultAlpha := roster.Ranking.Alpha[label]
+	if qualityBias <= neutral {
+		return roster.Ranking.AlphaMin[label] + (defaultAlpha-roster.Ranking.AlphaMin[label])*(qualityBias/neutral)
+	}
+	return defaultAlpha + (roster.Ranking.AlphaMax[label]-defaultAlpha)*((qualityBias-neutral)/(1-neutral))
+}
+
+func preferenceOrder(roster *rosterdata.Roster, label string, cluster rosterdata.Cluster, harness string, order []string, qualityBias *float64) []string {
+	if qualityBias == nil || *qualityBias == roster.Ranking.QualityBiasNeutral || !isDynamicRoster(roster) {
+		return order
+	}
+	scores := Scores(roster, label, cluster, qualityBias)
+	pins := append([]string(nil), cluster.ManualPinsByHarness["*"]...)
+	pins = append(pins, harnessList(cluster.ManualPinsByHarness, harness)...)
+	preferredVendors := harnessList(cluster.PreferredVendorsByHarness, harness)
+	pinPosition := make(map[string]int, len(pins))
+	for index, arm := range pins {
+		pinPosition[arm] = index
+	}
+	positions := make(map[string]int, len(order))
+	for index, arm := range order {
+		positions[arm] = index
+	}
+	ranked := append([]string(nil), order...)
+	sort.SliceStable(ranked, func(i, j int) bool {
+		left, right := ranked[i], ranked[j]
+		leftPin, leftPinned := pinPosition[left]
+		rightPin, rightPinned := pinPosition[right]
+		if leftPinned != rightPinned {
+			return leftPinned
+		}
+		if leftPinned && leftPin != rightPin {
+			return leftPin < rightPin
+		}
+		leftVendor := vendorRank(left, preferredVendors)
+		rightVendor := vendorRank(right, preferredVendors)
+		if leftVendor != rightVendor {
+			return leftVendor < rightVendor
+		}
+		leftScore, leftScored := scores[left]
+		rightScore, rightScored := scores[right]
+		if leftScored != rightScored {
+			return leftScored
+		}
+		if leftScore != rightScore {
+			return leftScore > rightScore
+		}
+		return positions[left] < positions[right]
+	})
+	return ranked
+}
+
+func harnessList(values map[string][]string, harness string) []string {
+	if list := values[harness]; len(list) > 0 {
+		return list
+	}
+	return values[strings.ReplaceAll(harness, "-", "_")]
+}
+
+func vendorRank(arm string, preferred []string) int {
+	vendor := strings.SplitN(arm, "/", 2)[0]
+	for index, candidate := range preferred {
+		if vendor == candidate {
+			return index
+		}
+	}
+	return len(preferred)
+}
+
+func isDynamicRoster(roster *rosterdata.Roster) bool {
+	return roster.SchemaVersion == rosterdata.SchemaVersionV7 || roster.SchemaVersion == rosterdata.SchemaVersionV75C
 }

--- a/internal/router/hmm/selection/selection_test.go
+++ b/internal/router/hmm/selection/selection_test.go
@@ -47,6 +47,94 @@ func testRoster() *rosterdata.Roster {
 	}
 }
 
+func dynamicRoster() *rosterdata.Roster {
+	return &rosterdata.Roster{
+		SchemaVersion: rosterdata.SchemaVersionV7,
+		Ranking: rosterdata.Ranking{
+			Alpha:              map[string]float64{"low": 0.4},
+			AlphaMin:           map[string]float64{"low": 0.05},
+			AlphaMax:           map[string]float64{"low": 0.8},
+			QualityBiasNeutral: 0.7,
+		},
+		Clusters: map[string]rosterdata.Cluster{
+			"low": {
+				Arms: []string{"vendor-a/quality", "vendor-b/cheap"},
+				ArmScores: map[string]float64{
+					"vendor-a/quality": 30,
+					"vendor-b/cheap":   25,
+				},
+				ArmIndices: map[string]rosterdata.ArmIndices{
+					"vendor-a/quality": {WII: 90, WPI: 10},
+					"vendor-b/cheap":   {WII: 55, WPI: 0},
+				},
+			},
+		},
+	}
+}
+
+func TestSelectGroupsWithPreferenceReweightsWithinClassifierBand(t *testing.T) {
+	roster := dynamicRoster()
+	candidates := candidateSet("vendor-a/quality", "vendor-b/cheap")
+	groups := []selection.Group{{Label: "low"}}
+
+	neutral := 0.7
+	pick, scores, ok := selection.SelectGroupsWithPreference(roster, groups, "", candidates, &neutral)
+	require.True(t, ok)
+	assert.Equal(t, "vendor-a/quality", pick.Arm)
+	assert.Equal(t, float32(30), scores["low"]["vendor-a/quality"])
+
+	priceHeavy := 0.0
+	pick, _, ok = selection.SelectGroupsWithPreference(roster, groups, "", candidates, &priceHeavy)
+	require.True(t, ok)
+	assert.Equal(t, "vendor-b/cheap", pick.Arm)
+
+	qualityHeavy := 1.0
+	pick, _, ok = selection.SelectGroupsWithPreference(roster, groups, "", candidates, &qualityHeavy)
+	require.True(t, ok)
+	assert.Equal(t, "vendor-a/quality", pick.Arm)
+}
+
+func TestSelectGroupsWithPreferencePreservesPolicyTiers(t *testing.T) {
+	roster := dynamicRoster()
+	cluster := roster.Clusters["low"]
+	cluster.ManualPinsByHarness = map[string][]string{"pi": {"vendor-b/cheap"}}
+	cluster.PreferredVendorsByHarness = map[string][]string{"codex": {"vendor-b"}}
+	roster.Clusters["low"] = cluster
+	qualityHeavy := 1.0
+	candidates := candidateSet("vendor-a/quality", "vendor-b/cheap")
+
+	pick, _, ok := selection.SelectGroupsWithPreference(roster, []selection.Group{{Label: "low"}}, "pi", candidates, &qualityHeavy)
+	require.True(t, ok)
+	assert.Equal(t, "vendor-b/cheap", pick.Arm, "manual pin must outrank the dynamic score")
+
+	pick, _, ok = selection.SelectGroupsWithPreference(roster, []selection.Group{{Label: "low"}}, "codex", candidates, &qualityHeavy)
+	require.True(t, ok)
+	assert.Equal(t, "vendor-b/cheap", pick.Arm, "vendor affinity must outrank the dynamic score")
+}
+
+func TestSelectGroupsWithPreferenceKeepsFallbackOrder(t *testing.T) {
+	roster := dynamicRoster()
+	high := roster.Clusters["low"]
+	high.Arms = []string{"vendor-c/high"}
+	high.ArmScores = map[string]float64{"vendor-c/high": 80}
+	high.ArmIndices = map[string]rosterdata.ArmIndices{"vendor-c/high": {WII: 100, WPI: 100}}
+	roster.Clusters["high"] = high
+	roster.Ranking.Alpha["high"] = 0.85
+	roster.Ranking.AlphaMin["high"] = 0.6
+	roster.Ranking.AlphaMax["high"] = 0.98
+	qualityHeavy := 1.0
+
+	pick, _, ok := selection.SelectGroupsWithPreference(
+		roster,
+		[]selection.Group{{Label: "low"}, {Label: "high"}},
+		"",
+		candidateSet("vendor-a/quality", "vendor-c/high"),
+		&qualityHeavy,
+	)
+	require.True(t, ok)
+	assert.Equal(t, "low", pick.Group)
+}
+
 func TestArmOrder(t *testing.T) {
 	roster := testRoster()
 

--- a/internal/router/hmm/selection/selection_test.go
+++ b/internal/router/hmm/selection/selection_test.go
@@ -22,7 +22,7 @@ func candidateSet(ids ...string) map[string]struct{} {
 
 func testRoster() *rosterdata.Roster {
 	return &rosterdata.Roster{
-		SchemaVersion: "hmm_router_cluster_roster_v6",
+		SchemaVersion: rosterdata.SchemaVersionV6,
 		Clusters: map[string]rosterdata.Cluster{
 			"low": {
 				Arms: []string{"vendor-a/cheap", "vendor-b/cheap"},

--- a/internal/router/hmm/selection/selector.go
+++ b/internal/router/hmm/selection/selector.go
@@ -30,7 +30,7 @@ func Selector(roster *rosterdata.Roster) policy.ArmSelector {
 		for _, rosterID := range input.CandidateRosterIDs {
 			candidates[rosterID] = struct{}{}
 		}
-		pick, ok := SelectGroups(roster, groups, input.Harness, candidates)
+		pick, scoresByGroup, ok := SelectGroupsWithPreference(roster, groups, input.Harness, candidates, input.QualityBias)
 		if !ok {
 			log.Warn("HMM selection found no eligible arm in any ranked group",
 				"strategy", input.Strategy,
@@ -43,6 +43,14 @@ func Selector(roster *rosterdata.Roster) policy.ArmSelector {
 			)
 			return policy.SelectionPick{}, ErrNoEligibleArm
 		}
-		return policy.SelectionPick{Group: pick.Group, Arm: pick.Arm}, nil
+		logFields := []any{"strategy", input.Strategy, "group", pick.Group, "arm", pick.Arm}
+		if input.QualityBias != nil {
+			logFields = append(logFields,
+				"quality_bias", *input.QualityBias,
+				"effective_alpha", EffectiveAlpha(roster, pick.Group, *input.QualityBias),
+			)
+		}
+		log.Debug("HMM preference-aware arm selected", logFields...)
+		return policy.SelectionPick{Group: pick.Group, Arm: pick.Arm, ArmScoresByGroup: scoresByGroup}, nil
 	}
 }

--- a/internal/router/hmm/selection/selector.go
+++ b/internal/router/hmm/selection/selector.go
@@ -2,7 +2,6 @@ package selection
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"weave-os/router/internal/observability"
@@ -11,7 +10,7 @@ import (
 )
 
 // ErrNoEligibleArm is returned when no ranked group holds an eligible arm.
-var ErrNoEligibleArm = errors.New("no eligible arm in any ranked group")
+var ErrNoEligibleArm = policy.ErrNoEligibleArm
 
 // Selector returns the deterministic arm selector backed by roster.
 func Selector(roster *rosterdata.Roster) policy.ArmSelector {

--- a/internal/router/policy/arm_selector.go
+++ b/internal/router/policy/arm_selector.go
@@ -2,9 +2,14 @@ package policy
 
 import (
 	"context"
+	"errors"
 
 	"weave-os/router/internal/router"
 )
+
+// ErrNoEligibleArm is returned when deterministic selection exhausts every
+// eligible arm reported by the policy sidecar.
+var ErrNoEligibleArm = errors.New("no eligible arm in any ranked group")
 
 // SelectionInput is the content-free classification the router selects an arm from.
 type SelectionInput struct {

--- a/internal/router/policy/arm_selector.go
+++ b/internal/router/policy/arm_selector.go
@@ -48,5 +48,16 @@ func selectionInputFor(strategy router.Strategy, executionMode string, req route
 		qualityBias := *req.RoutingKnobs.QualityBias
 		input.QualityBias = &qualityBias
 	}
+	if req.ForceCluster != "" {
+		if _, hasOverride := req.ClusterArmOverrides[req.ForceCluster]; !hasOverride {
+			for _, group := range res.RankedFallback {
+				if group.Group == req.ForceCluster && len(group.EligibleArms) > 0 {
+					input.ClassifierGroup = req.ForceCluster
+					input.RankedFallback = []PreviewGroup{group}
+					break
+				}
+			}
+		}
+	}
 	return input
 }

--- a/internal/router/policy/arm_selector.go
+++ b/internal/router/policy/arm_selector.go
@@ -15,12 +15,14 @@ type SelectionInput struct {
 	ClassifierGroup    string
 	RankedFallback     []PreviewGroup
 	CandidateRosterIDs []string
+	QualityBias        *float64
 }
 
 // SelectionPick is the router's selected arm.
 type SelectionPick struct {
-	Group string
-	Arm   string
+	Group            string
+	Arm              string
+	ArmScoresByGroup map[string]map[string]float32
 }
 
 // ArmSelector picks the served arm from a sidecar classification. An error
@@ -33,7 +35,7 @@ func selectionInputFor(strategy router.Strategy, executionMode string, req route
 	for _, candidate := range resolved.Candidates {
 		candidateRosterIDs = append(candidateRosterIDs, candidate.RosterID)
 	}
-	return SelectionInput{
+	input := SelectionInput{
 		Strategy:           strategy,
 		ExecutionMode:      executionMode,
 		RouteID:            res.RouteID,
@@ -42,4 +44,9 @@ func selectionInputFor(strategy router.Strategy, executionMode string, req route
 		RankedFallback:     res.RankedFallback,
 		CandidateRosterIDs: candidateRosterIDs,
 	}
+	if req.RoutingKnobs != nil && req.RoutingKnobs.QualityBias != nil {
+		qualityBias := *req.RoutingKnobs.QualityBias
+		input.QualityBias = &qualityBias
+	}
+	return input
 }

--- a/internal/router/policy/arm_selector_test.go
+++ b/internal/router/policy/arm_selector_test.go
@@ -86,6 +86,27 @@ func TestArmSelectorErrorFailsTheTurn(t *testing.T) {
 		"a failed selection must surface as the strategy's unavailable sentinel, not a sidecar-picked arm")
 }
 
+func TestArmSelectorForceClusterExhaustionIsCallerError(t *testing.T) {
+	result := classifierOnlyResult()
+	result.RankedFallback = append(result.RankedFallback, policy.PreviewGroup{
+		Group:        "low",
+		Probability:  0.2,
+		EligibleArms: []string{"anthropic/claude-sonnet-5"},
+	})
+	adapter := newSelectorAdapter(result)
+	adapter.WithArmSelector(func(_ context.Context, input policy.SelectionInput) (policy.SelectionPick, error) {
+		require.Len(t, input.RankedFallback, 1)
+		assert.Equal(t, "low", input.RankedFallback[0].Group)
+		return policy.SelectionPick{}, policy.ErrNoEligibleArm
+	})
+
+	_, err := adapter.Route(context.Background(), router.Request{ForceCluster: "low"})
+
+	require.ErrorIs(t, err, policy.ErrForcedClusterUnservable)
+	assert.NotContains(t, err.Error(), "selection unavailable")
+	assert.Contains(t, err.Error(), "low")
+}
+
 func TestArmSelectorRejectsLegacySchema(t *testing.T) {
 	result := classifierOnlyResult()
 	result.SchemaVersion = policy.SchemaVersionV1

--- a/internal/router/policy/arm_selector_test.go
+++ b/internal/router/policy/arm_selector_test.go
@@ -44,13 +44,24 @@ func classifierOnlyResult() policy.Result {
 
 func TestArmSelectorPickIsServed(t *testing.T) {
 	adapter := newSelectorAdapter(classifierOnlyResult())
+	qualityBias := 0.2
 	adapter.WithArmSelector(func(_ context.Context, input policy.SelectionInput) (policy.SelectionPick, error) {
 		assert.Equal(t, "maximum", input.ClassifierGroup)
 		assert.ElementsMatch(t, []string{"anthropic/claude-opus-4-8", "anthropic/claude-sonnet-5"}, input.CandidateRosterIDs)
-		return policy.SelectionPick{Group: "maximum", Arm: "anthropic/claude-sonnet-5"}, nil
+		require.NotNil(t, input.QualityBias)
+		assert.Equal(t, qualityBias, *input.QualityBias)
+		return policy.SelectionPick{
+			Group: "maximum",
+			Arm:   "anthropic/claude-sonnet-5",
+			ArmScoresByGroup: map[string]map[string]float32{
+				"maximum": {"anthropic/claude-sonnet-5": 42},
+			},
+		}, nil
 	})
 
-	decision, err := adapter.Route(context.Background(), router.Request{})
+	decision, err := adapter.Route(context.Background(), router.Request{
+		RoutingKnobs: &router.Overrides{QualityBias: &qualityBias},
+	})
 
 	require.NoError(t, err)
 	assert.Equal(t, "claude-sonnet-5", decision.Model)
@@ -59,6 +70,7 @@ func TestArmSelectorPickIsServed(t *testing.T) {
 	require.NotNil(t, decision.Metadata)
 	assert.Equal(t, "anthropic/claude-sonnet-5", decision.Metadata.SelectedRosterArmID)
 	assert.Equal(t, "maximum", decision.Metadata.PolicyGroup)
+	assert.Equal(t, float32(42), decision.Metadata.ArmScores["anthropic/claude-sonnet-5"])
 }
 
 func TestArmSelectorErrorFailsTheTurn(t *testing.T) {
@@ -146,4 +158,37 @@ func TestArmSelectorSurvivesOverridesOmittingWinningGroup(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "claude-sonnet-5", decision.Model)
 	assert.Contains(t, decision.Reason, ":go_selection")
+}
+
+func TestArmSelectorForceClusterUsesFinalGroupScores(t *testing.T) {
+	result := classifierOnlyResult()
+	result.RankedFallback = append(result.RankedFallback, policy.PreviewGroup{
+		Group:        "low",
+		Probability:  0.2,
+		RosterArms:   []string{"anthropic/claude-sonnet-5"},
+		EligibleArms: []string{"anthropic/claude-sonnet-5"},
+	})
+	adapter := newSelectorAdapter(result)
+	adapter.WithArmSelector(func(_ context.Context, _ policy.SelectionInput) (policy.SelectionPick, error) {
+		return policy.SelectionPick{
+			Group: "maximum",
+			Arm:   "anthropic/claude-opus-4-8",
+			ArmScoresByGroup: map[string]map[string]float32{
+				"maximum": {"anthropic/claude-opus-4-8": 90},
+				"low":     {"anthropic/claude-sonnet-5": 20},
+			},
+		}, nil
+	})
+
+	decision, err := adapter.Route(context.Background(), router.Request{
+		ForceCluster: "low",
+		ClusterArmOverrides: map[string][]string{
+			"low": {"claude-sonnet-5"},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, decision.Metadata)
+	assert.Equal(t, "low", decision.Metadata.PolicyGroup)
+	assert.Equal(t, map[string]float32{"anthropic/claude-sonnet-5": 20}, decision.Metadata.ArmScores)
 }

--- a/internal/router/policy/arm_selector_test.go
+++ b/internal/router/policy/arm_selector_test.go
@@ -192,3 +192,38 @@ func TestArmSelectorForceClusterUsesFinalGroupScores(t *testing.T) {
 	assert.Equal(t, "low", decision.Metadata.PolicyGroup)
 	assert.Equal(t, map[string]float32{"anthropic/claude-sonnet-5": 20}, decision.Metadata.ArmScores)
 }
+
+func TestArmSelectorForceClusterPreservesPreferenceRanking(t *testing.T) {
+	result := classifierOnlyResult()
+	result.RankedFallback = append(result.RankedFallback, policy.PreviewGroup{
+		Group:        "low",
+		Probability:  0.2,
+		RosterArms:   []string{"anthropic/claude-opus-4-8", "anthropic/claude-sonnet-5"},
+		EligibleArms: []string{"anthropic/claude-opus-4-8", "anthropic/claude-sonnet-5"},
+	})
+	adapter := newSelectorAdapter(result)
+	adapter.WithArmSelector(func(_ context.Context, input policy.SelectionInput) (policy.SelectionPick, error) {
+		require.Len(t, input.RankedFallback, 1)
+		assert.Equal(t, "low", input.ClassifierGroup)
+		assert.Equal(t, "low", input.RankedFallback[0].Group)
+		return policy.SelectionPick{
+			Group: "low",
+			Arm:   "anthropic/claude-sonnet-5",
+			ArmScoresByGroup: map[string]map[string]float32{
+				"low": {"anthropic/claude-opus-4-8": 10, "anthropic/claude-sonnet-5": 20},
+			},
+		}, nil
+	})
+
+	decision, err := adapter.Route(context.Background(), router.Request{ForceCluster: "low"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "claude-sonnet-5", decision.Model)
+	assert.Contains(t, decision.Reason, ":force_cluster")
+	require.NotNil(t, decision.Metadata)
+	assert.Equal(t, "low", decision.Metadata.PolicyGroup)
+	assert.Equal(t, map[string]float32{
+		"anthropic/claude-opus-4-8": 10,
+		"anthropic/claude-sonnet-5": 20,
+	}, decision.Metadata.ArmScores)
+}

--- a/internal/router/policy/contract.go
+++ b/internal/router/policy/contract.go
@@ -32,7 +32,10 @@ type Capabilities struct {
 	HonorsQualityPriceBias   bool   `json:"honors_quality_price_bias"`
 	SupportsDebugRouteDetail bool   `json:"supports_debug_route_detail"`
 	SupportsPreview          bool   `json:"supports_preview"`
-	SupportsShadow           bool   `json:"supports_shadow"`
+	// SupportsRoutingDistribution means the Go router can project the same
+	// quality/price scorer used by live serving across the dashboard dial.
+	SupportsRoutingDistribution bool `json:"supports_routing_distribution"`
+	SupportsShadow              bool `json:"supports_shadow"`
 	// ReportsRankedFallback declares that the sidecar returns ranked_fallback on
 	// the serving /route response. When false, cluster arm overrides fail open.
 	ReportsRankedFallback bool `json:"reports_ranked_fallback"`

--- a/internal/router/policy/sidecar_router.go
+++ b/internal/router/policy/sidecar_router.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"slices"
@@ -338,8 +339,17 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 		if res.SchemaVersion != SchemaVersionV3 {
 			return router.Decision{}, fmt.Errorf("%s: sidecar reported schema %q, expected %s: %w", strategy, res.SchemaVersion, SchemaVersionV3, r.config.Unavailable)
 		}
-		pick, selectErr := r.armSelector(ctx, selectionInputFor(strategy, executionMode, req, res, resolved))
+		selectionInput := selectionInputFor(strategy, executionMode, req, res, resolved)
+		pick, selectErr := r.armSelector(ctx, selectionInput)
 		if selectErr != nil {
+			if errors.Is(selectErr, ErrNoEligibleArm) &&
+				req.ForceCluster != "" && len(selectionInput.RankedFallback) == 1 &&
+				selectionInput.RankedFallback[0].Group == req.ForceCluster {
+				return router.Decision{}, &ForcedClusterUnservableError{
+					Cluster: req.ForceCluster,
+					Reason:  fmt.Sprintf("no model in cluster %q can serve this request", req.ForceCluster),
+				}
+			}
 			return router.Decision{}, fmt.Errorf("%s: arm selection: %w: %w", strategy, selectErr, r.config.Unavailable)
 		}
 		overrideArmID = indexCandidates(resolved).rosterToArm[pick.Arm]

--- a/internal/router/policy/sidecar_router.go
+++ b/internal/router/policy/sidecar_router.go
@@ -333,6 +333,7 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 	// sidecar's, which is the only case where res.Provider legitimately names a
 	// different provider than the resolved binding.
 	reselected := false
+	var routerArmScoresByGroup map[string]map[string]float32
 	if r.armSelector != nil {
 		if res.SchemaVersion != SchemaVersionV3 {
 			return router.Decision{}, fmt.Errorf("%s: sidecar reported schema %q, expected %s: %w", strategy, res.SchemaVersion, SchemaVersionV3, r.config.Unavailable)
@@ -346,6 +347,7 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 		overrideReasonSuffix = ":go_selection"
 		reselected = true
 		res.PolicyGroup = pick.Group
+		routerArmScoresByGroup = pick.ArmScoresByGroup
 	}
 
 	// Per-key cluster allowlist enforcement. ranked_fallback presence in the /route
@@ -373,6 +375,7 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 			"previous_arm", previousRosterID,
 			"forced_arm", outcome.RosterID,
 		)
+		res.PolicyGroup = outcome.Group
 	case len(req.ClusterArmOverrides) > 0 && len(res.RankedFallback) > 0:
 		outcome := ApplyClusterArmOverrides(req.ClusterArmOverrides, res.RankedFallback, resolved, overrideRosterID)
 		// Only a configured allowlist supersedes the router's own selection; an
@@ -383,6 +386,7 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 			// be ambiguous (shared across providers) and absent from ByRosterID.
 			overrideArmID = outcome.ArmID
 			overrideRosterID = outcome.RosterID
+			res.PolicyGroup = outcome.Group
 			if outcome.Changed {
 				overrideReasonSuffix = ":cluster_override"
 				reselected = true
@@ -399,6 +403,9 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 	selectedRosterArmID := overrideArmID
 	if selectedRosterArmID == "" {
 		selectedRosterArmID = overrideRosterID
+	}
+	if routerArmScoresByGroup != nil {
+		res.ArmScores = routerArmScoresByGroup[res.PolicyGroup]
 	}
 
 	binding, ok := resolved.BindingForSelection(overrideArmID, overrideRosterID)

--- a/internal/router/policy/sidecar_router.go
+++ b/internal/router/policy/sidecar_router.go
@@ -363,17 +363,21 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 			return router.Decision{}, err
 		}
 		previousRosterID := overrideRosterID
-		overrideArmID = outcome.ArmID
-		overrideRosterID = outcome.RosterID
+		_, hasExplicitOverride := req.ClusterArmOverrides[req.ForceCluster]
+		selectedForcedGroupWithPreference := r.armSelector != nil && !hasExplicitOverride && res.PolicyGroup == outcome.Group
+		if !selectedForcedGroupWithPreference {
+			overrideArmID = outcome.ArmID
+			overrideRosterID = outcome.RosterID
+		}
 		// Annotated even when the forced cluster is the one already selected,
 		// so telemetry can tell a constrained turn from a free one.
 		overrideReasonSuffix = ":force_cluster"
-		reselected = reselected || outcome.Changed
+		reselected = reselected || outcome.Changed || selectedForcedGroupWithPreference
 		observability.FromContext(ctx).Info("Forced cluster applied",
 			"strategy", strategy,
 			"group", outcome.Group,
 			"previous_arm", previousRosterID,
-			"forced_arm", outcome.RosterID,
+			"forced_arm", overrideRosterID,
 		)
 		res.PolicyGroup = outcome.Group
 	case len(req.ClusterArmOverrides) > 0 && len(res.RankedFallback) > 0:

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -355,8 +355,8 @@ type RoutingMetadata struct {
 	PairedModel    string
 	PairedProvider string
 	PairedScore    float32
-	// ArmScores is per-arm WMI scores for the cluster this decision was drawn
-	// from. Populated from a B1+ sidecar; absent on older sidecars.
+	// ArmScores is the router-selected preference-adjusted score map for the
+	// cluster this decision was drawn from. Absent on fixed/legacy rosters.
 	ArmScores map[string]float32
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -21,6 +21,7 @@ import (
 	"weave-os/router/internal/policyclient"
 	"weave-os/router/internal/proxy"
 	"weave-os/router/internal/router"
+	"weave-os/router/internal/router/hmm/rosterdata"
 	"weave-os/router/internal/router/policy"
 	"weave-os/router/internal/server/middleware"
 
@@ -81,7 +82,7 @@ const (
 //
 // analyticsSvc, when non-nil, mounts the /v1/analytics/* export surface;
 // nil leaves it unmounted (tests, deployments without telemetry storage).
-func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service, deployedModels admin.DeployedModelsSource, hmmModels admin.HMMRosterSource, mode DeploymentMode, billingSvc *billing.Service, readinessChecker admin.HealthChecker, hmmRosterSource policy.RosterSource, analyticsSvc *analytics.Service) {
+func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service, deployedModels admin.DeployedModelsSource, hmmModels admin.HMMRosterSource, mode DeploymentMode, billingSvc *billing.Service, readinessChecker admin.HealthChecker, hmmRosterSource policy.RosterSource, analyticsSvc *analytics.Service, hmmDistributionRosters ...*rosterdata.Roster) {
 	// Browser clients need an explicit expose list before fetch can read the
 	// router's routing and cost metadata from a cross-origin response.
 	engine.Use(func(c *gin.Context) {
@@ -136,7 +137,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		// for the dashboard's distribution preview. Same unauthed rationale as
 		// /v1/router/models; the assertion skips sources that can't project one.
 		if dist, ok := deployedModels.(admin.RoutingDistributionSource); ok {
-			engine.GET("/v1/router/routing-distribution", middleware.WithTimeout(healthTimeout), admin.RoutingDistributionHandler(dist))
+			engine.GET("/v1/router/routing-distribution", middleware.WithTimeout(healthTimeout), admin.RoutingDistributionHandler(dist, hmmDistributionRosters...))
 		}
 	}
 


### PR DESCRIPTION
## Why

Production uses the `hmm_embedding` strategy, but the organization-level Quality / Price preference was previously dropped before deterministic HMM arm selection. The setting saved successfully yet did not affect the model chosen for normal production traffic.

This PR makes the Go router honor that preference **inside the complexity band chosen by HMM**, without changing classification, weakening eligibility rules, or moving selection authority back into Python.

Companion roster/package release: https://github.com/weave-os/weave/pull/13067

## Runtime flow

```text
request
  → HMM sidecar classifies low / medium / high / maximum
  → router validates the returned band and candidate roster
  → hard eligibility and harness policy narrow the candidates
  → preference scorer ranks candidates inside the selected band
  → effort hysteresis consumes the same adjusted scores
  → router serves the selected model
```

The classifier's confidence behavior and fallback order are unchanged.

## Preference scoring

For v7 rosters, each dynamically ranked model carries raw **WII** and **WPI** values. The router computes:

```text
effective score = alpha × WII − (1 − alpha) × WPI
```

The saved quality preference is mapped piecewise around the UI's neutral 70/30 position:

| Band | Alpha range | Alpha at neutral 70/30 |
| --- | ---: | ---: |
| Low | 0.05–0.80 | 0.40 |
| Medium | 0.25–0.92 | 0.65 |
| High | 0.60–0.98 | 0.85 |
| Maximum | 0.85–0.995 | 0.95 |

Nil preference and exact neutral preference take the compatibility path and preserve the roster's original ordering and scores byte-for-byte. Stable roster position remains the final tie-breaker.

WPI is not used as a dollar estimate. Distribution-preview cost projections use the model catalog's actual input/output prices.

## Eligibility and precedence

Preference ranking only runs after the router has applied availability, allowlist, request subset, model capability, harness membership, and other hard filters.

Within an eligible group, precedence is:

1. Manual pins
2. Harness-specific vendor priority
3. Preference-adjusted score
4. Original roster order

Explicit force-model and operational overrides remain above this selection pipeline.

The implementation also preserves important edge behavior:

- harness-only unscored pins cannot leak into shared ranking;
- force-cluster overrides retain preference ranking rather than resetting to the first arm;
- an exhausted forced cluster returns `ForcedClusterUnservableError` instead of being misreported as a general outage;
- score maps are rebuilt for the final selected group, so routing metadata and hysteresis never consume stale scores from a pre-override group.

## Roster validation

The Go loader supports the new v7 four- and five-class schemas and fail-loud validates:

- WII/WPI presence and finite `[0,100]` bounds;
- per-band default/minimum/maximum alpha;
- neutral preference and score provenance;
- normalization and index-version identities;
- manual-pin and harness-specific policy metadata;
- dynamic-score coverage for every rankable candidate.

Older roster schemas retain their fixed-order behavior. Explicit unscored manual pins remain valid only where the pin policy makes them authoritative.

## Hysteresis and observability

The preference-adjusted score is carried through selection metadata and into effort hysteresis. Upgrade/downgrade decisions therefore compare the same scores that produced the current route.

Structured decision diagnostics expose the selected band, preference-derived alpha, and scoring outcome without logging prompt content.

## Distribution preview

The admin routing-distribution endpoint now dispatches by the effective routing strategy. For HMM it:

- loads the same validated roster used by live routing;
- reuses the same preference scorer and precedence behavior;
- calculates model shares for the requested quality bias;
- uses catalog prices for dollar projections;
- reports capabilities truthfully only when HMM preference scoring and preview are available.

This keeps the dashboard preview aligned with what the live selector would serve.

## Main implementation areas

- `internal/router/hmm/rosterdata`: typed v7 parsing and validation
- `internal/router/hmm/selection`: alpha mapping, scoring, ranking, and distribution projection
- `internal/router/policy`: quality-bias plumbing and final score metadata
- `internal/proxy`: preference-aware hysteresis handoff
- `internal/api/admin`: HMM distribution preview
- `cmd/router` / `internal/server`: validated roster wiring and capability reporting

## Validation

- `go test ./...`
- `go vet ./...`
- repository router typecheck and full test commands
- generated v7 four- and five-class roster validation
- focused tests for endpoint flips, neutral parity, ties, allowlists, manual pins, vendor priority, harness membership, force-cluster behavior, per-group score maps, hysteresis, and preview/live-scorer equivalence

Final GitHub state: 16 active checks passed, one conditional check skipped, no unresolved review threads, and a clean merge state.
