### PR TITLE
feat: control plan-aware subscription routing per organization

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -1050,28 +1050,29 @@ func main() {
 	// effort: the table is never read on the request path, so a failure here
 	// degrades that UI and nothing else.
 	publishFlagRegistry(logger, repo.FlagDefinitions, map[flags.Key]string{
-		flags.KeyStruggleShadowEnabled:     boolDefault(struggleShadowEnabled),
-		flags.KeyStruggleEscalationEnabled: boolDefault(struggleEscalationEnabled),
-		flags.KeyStruggleEscalationHoldout: strconv.Itoa(struggleEscalationHoldoutPct),
-		flags.KeyStruggleEvidenceArming:    boolDefault(struggleEvidenceArming),
-		flags.KeySpiralShadowEnabled:       boolDefault(spiralShadowEnabled),
-		flags.KeyTurnSignalCapture:         boolDefault(turnSignalCaptureEnabled),
-		flags.KeyLoopEscalationEnabled:     boolDefault(loopEscalationEnabled),
-		flags.KeyLoopEscalationHoldoutPct:  strconv.Itoa(loopEscalationHoldoutPct),
-		flags.KeyTextRepetitionBreak:       boolDefault(textRepetitionBreakEnabled),
-		flags.KeyPlannerEnabled:            boolDefault(plannerEnabled),
-		flags.KeyScoreToolResultTurns:      boolDefault(scoreToolResultTurns),
-		flags.KeyPrefixTrimFreeSwitch:      boolDefault(prefixTrimFreeSwitch),
-		flags.KeyAuthoritativeUpgradeGate:  boolDefault(authoritativeUpgradeGate),
-		flags.KeyAuthorityCacheShadow:      boolDefault(authorityCacheShadow),
-		flags.KeySiblingFailover:           boolDefault(siblingFailover),
-		flags.KeyOpenAIResponsesBroad:      boolDefault(openAIResponsesBroad),
-		flags.KeyAllowedModelsHeader:       boolDefault(allowedModelsHeader),
-		flags.KeyEffortEscalation:          boolDefault(effortEscalation),
-		flags.KeyCyberRefusalRepin:         boolDefault(cyberRefusalRepin),
-		flags.KeyCyberRefusalFallback:      cyberRefusalFallbackModel,
-		flags.KeyAnthropicServerFallback:   boolDefault(anthropicServerSideFallback),
-		flags.KeyEmbedOnlyUserMessage:      boolDefault(embedOnlyUser),
+		flags.KeySubscriptionPlanAwareRouting: boolDefault(false),
+		flags.KeyStruggleShadowEnabled:        boolDefault(struggleShadowEnabled),
+		flags.KeyStruggleEscalationEnabled:    boolDefault(struggleEscalationEnabled),
+		flags.KeyStruggleEscalationHoldout:    strconv.Itoa(struggleEscalationHoldoutPct),
+		flags.KeyStruggleEvidenceArming:       boolDefault(struggleEvidenceArming),
+		flags.KeySpiralShadowEnabled:          boolDefault(spiralShadowEnabled),
+		flags.KeyTurnSignalCapture:            boolDefault(turnSignalCaptureEnabled),
+		flags.KeyLoopEscalationEnabled:        boolDefault(loopEscalationEnabled),
+		flags.KeyLoopEscalationHoldoutPct:     strconv.Itoa(loopEscalationHoldoutPct),
+		flags.KeyTextRepetitionBreak:          boolDefault(textRepetitionBreakEnabled),
+		flags.KeyPlannerEnabled:               boolDefault(plannerEnabled),
+		flags.KeyScoreToolResultTurns:         boolDefault(scoreToolResultTurns),
+		flags.KeyPrefixTrimFreeSwitch:         boolDefault(prefixTrimFreeSwitch),
+		flags.KeyAuthoritativeUpgradeGate:     boolDefault(authoritativeUpgradeGate),
+		flags.KeyAuthorityCacheShadow:         boolDefault(authorityCacheShadow),
+		flags.KeySiblingFailover:              boolDefault(siblingFailover),
+		flags.KeyOpenAIResponsesBroad:         boolDefault(openAIResponsesBroad),
+		flags.KeyAllowedModelsHeader:          boolDefault(allowedModelsHeader),
+		flags.KeyEffortEscalation:             boolDefault(effortEscalation),
+		flags.KeyCyberRefusalRepin:            boolDefault(cyberRefusalRepin),
+		flags.KeyCyberRefusalFallback:         cyberRefusalFallbackModel,
+		flags.KeyAnthropicServerFallback:      boolDefault(anthropicServerSideFallback),
+		flags.KeyEmbedOnlyUserMessage:         boolDefault(embedOnlyUser),
 	})
 
 	// Always wire even when beta is unavailable: existing beta sessions fail
@@ -1145,8 +1146,7 @@ func main() {
 		WithCompactionHardPin(config.GetOr("ROUTER_HARD_PIN_MODEL", "") == "").
 		WithAvailableModels(proxyRoutableModels(routingTargets, availableProviders, hmmRouter != nil)).
 		WithDefaultBaselineModel(resolveDefaultBaselineModel()).
-		WithBillingService(billingSvc).
-		WithPlanAwareSubscriptionRouting(config.GetOr("ROUTER_SUBSCRIPTION_PLAN_AWARE_ROUTING", "false") == "true")
+		WithBillingService(billingSvc)
 	if subscriptionRuntime != nil {
 		proxySvc.WithManagedSubscriptions(subscriptionRuntime)
 	}
@@ -1246,9 +1246,6 @@ func main() {
 	} else {
 		logger.Info("Usage observer wired; subscription-aware cost discount disabled", "observation_ttl", subscriptionTTL)
 	}
-	logger.Info("Subscription plan-aware routing configured",
-		"enabled", config.GetOr("ROUTER_SUBSCRIPTION_PLAN_AWARE_ROUTING", "false") == "true")
-
 	engine := gin.New()
 	engine.UnescapePathValues = true
 	engine.UseRawPath = true

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,6 +1,7 @@
 # Configuration reference
 
-All router configuration is via environment variables ([12-factor](https://12factor.net/config)).
+Deployment configuration uses environment variables ([12-factor](https://12factor.net/config));
+organization settings are stored in Postgres.
 This page is the exhaustive reference; the [README](../README.md) has the
 60-second quickstart.
 
@@ -12,6 +13,7 @@ This page is the exhaustive reference; the [README](../README.md) has the
 - [Postgres](#postgres)
 - [Server](#server)
 - [Routing](#routing)
+- [Plan-aware subscription routing](#plan-aware-subscription-routing)
 - [Provider and model exclusions](#provider-and-model-exclusions)
 - [Policy sidecars](#policy-sidecars)
 - [BYOK encryption](#byok-encryption)
@@ -35,7 +37,6 @@ Claude Code keep using the user's logged-in plan.
 | `OPENAI_BASE_URL`     | `https://api.openai.com`                                  | Override for OpenAI (e.g. Azure OpenAI). |
 | `ROUTER_CODEX_BASE_URL` | `https://chatgpt.com/backend-api/codex`                  | Local-testing override for the ChatGPT subscription Responses backend; leave unset in production. |
 | `ROUTER_SUBSCRIPTION_POOLS_ENABLED` | `false`                                         | Enables encrypted server-side subscription enrollment and account-management endpoints. Set `false` as the emergency pool-disable switch. |
-| `ROUTER_SUBSCRIPTION_PLAN_AWARE_ROUTING` | `false`                                | Removes models covered only by exhausted Claude/Codex plans from automatic routing per user; restores the normal roster when every linked plan is exhausted. |
 | `WEAVE_CODEX_OAUTH_ISSUER` | `https://auth.openai.com` | Optional Codex OAuth issuer override for self-hosted testing. |
 | `WEAVE_ANTHROPIC_OAUTH_AUTHORIZE` | `https://claude.ai/oauth/authorize` | Optional Claude OAuth authorization endpoint override used by the enrollment CLI. |
 | `WEAVE_ANTHROPIC_OAUTH_TOKEN` | `https://console.anthropic.com/v1/oauth/token` | Optional Claude OAuth token endpoint override used by enrollment and server-side refresh. |
@@ -420,6 +421,25 @@ Set `DATABASE_URL` directly, or compose it from the individual vars:
 If the cluster scorer can't run (missing model, embed timeout, etc.), the
 router returns HTTP 503 — it does *not* silently fall back to a default
 model. Failures are loud by design.
+
+## Plan-aware subscription routing
+
+`subscription_plan_aware_routing_enabled` is an organization-only boolean in
+`router.model_router_installations.flag_overrides`. It defaults to `false`;
+clearing the override also turns it off. The former
+`ROUTER_SUBSCRIPTION_PLAN_AWARE_ROUTING` environment variable is no longer read.
+
+In the managed control plane, open **Admin → Router → Flags**, select the
+organization, and use **On**, **Off**, or **Clear** for this flag. This is the
+internal-admin UI, not a customer-facing settings control. The router publishes
+the definition at startup; saving uses the existing installation-cache
+invalidation path, so a setting change does not require a redeploy.
+
+When enabled, models covered only by an exhausted Claude/Codex plan are excluded
+while another linked plan has headroom. Unknown or all-exhausted states restore
+normal eligibility. `subscription_routing_disabled` suppresses this feature even
+when the org flag is on. This setting does not enable subscription-account
+enrollment or change how quota is observed.
 
 ## Provider and model exclusions
 

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -1,8 +1,8 @@
 // Package flags resolves per-organization overrides for the router's behavioral
 // feature flags.
 //
-// Every behavioral flag has a deployment-wide default read once at boot from an
-// env var in cmd/router/main.go and held as a *proxy.Service field. This package
+// Behavioral flags have deployment-wide defaults resolved at boot, or fixed
+// defaults for settings that require explicit organization opt-in. This package
 // layers a sparse per-organization override on top of that default, so a flag can
 // be piloted (or disabled) for one installation without a global rollout.
 //
@@ -44,35 +44,37 @@ const (
 
 // Registered flag keys. Each corresponds to exactly one entry in Registry.
 const (
-	KeyStruggleShadowEnabled     Key = "struggle_shadow_enabled"
-	KeyStruggleEscalationEnabled Key = "struggle_escalation_enabled"
-	KeyStruggleEscalationHoldout Key = "struggle_escalation_holdout_pct"
-	KeyStruggleEvidenceArming    Key = "struggle_evidence_arming"
-	KeySpiralShadowEnabled       Key = "spiral_shadow_enabled"
-	KeyTurnSignalCapture         Key = "turn_signal_capture_enabled"
-	KeyLoopEscalationEnabled     Key = "loop_escalation_enabled"
-	KeyLoopEscalationHoldoutPct  Key = "loop_escalation_holdout_pct"
-	KeyTextRepetitionBreak       Key = "text_repetition_break_enabled"
-	KeyPlannerEnabled            Key = "planner_enabled"
-	KeyScoreToolResultTurns      Key = "score_tool_result_turns"
-	KeyPrefixTrimFreeSwitch      Key = "prefix_trim_free_switch"
-	KeyAuthoritativeUpgradeGate  Key = "authoritative_upgrade_gate"
-	KeyAuthorityCacheShadow      Key = "authority_cache_shadow"
-	KeySiblingFailover           Key = "sibling_failover"
-	KeyEffortEscalation          Key = "effort_escalation"
-	KeyCyberRefusalRepin         Key = "cyber_refusal_repin"
-	KeyCyberRefusalFallback      Key = "cyber_refusal_fallback_model"
-	KeyAnthropicServerFallback   Key = "anthropic_server_side_fallback"
-	KeyEmbedOnlyUserMessage      Key = "embed_only_user_message"
-	KeyOpenAIResponsesBroad      Key = "openai_responses_broad"
-	KeyAllowedModelsHeader       Key = "allowed_models_header"
+	KeyStruggleShadowEnabled        Key = "struggle_shadow_enabled"
+	KeyStruggleEscalationEnabled    Key = "struggle_escalation_enabled"
+	KeyStruggleEscalationHoldout    Key = "struggle_escalation_holdout_pct"
+	KeyStruggleEvidenceArming       Key = "struggle_evidence_arming"
+	KeySpiralShadowEnabled          Key = "spiral_shadow_enabled"
+	KeyTurnSignalCapture            Key = "turn_signal_capture_enabled"
+	KeyLoopEscalationEnabled        Key = "loop_escalation_enabled"
+	KeyLoopEscalationHoldoutPct     Key = "loop_escalation_holdout_pct"
+	KeyTextRepetitionBreak          Key = "text_repetition_break_enabled"
+	KeyPlannerEnabled               Key = "planner_enabled"
+	KeyScoreToolResultTurns         Key = "score_tool_result_turns"
+	KeyPrefixTrimFreeSwitch         Key = "prefix_trim_free_switch"
+	KeyAuthoritativeUpgradeGate     Key = "authoritative_upgrade_gate"
+	KeyAuthorityCacheShadow         Key = "authority_cache_shadow"
+	KeySiblingFailover              Key = "sibling_failover"
+	KeyEffortEscalation             Key = "effort_escalation"
+	KeyCyberRefusalRepin            Key = "cyber_refusal_repin"
+	KeyCyberRefusalFallback         Key = "cyber_refusal_fallback_model"
+	KeyAnthropicServerFallback      Key = "anthropic_server_side_fallback"
+	KeyEmbedOnlyUserMessage         Key = "embed_only_user_message"
+	KeyOpenAIResponsesBroad         Key = "openai_responses_broad"
+	KeyAllowedModelsHeader          Key = "allowed_models_header"
+	KeySubscriptionPlanAwareRouting Key = "subscription_plan_aware_routing_enabled"
 )
 
 // Definition describes one overridable flag. DeploymentDefault is not stored
-// here: it lives in the env var and is resolved at boot, then published to
+// here: it is resolved at boot, then published to
 // router.flag_definitions for the admin UI to display.
 type Definition struct {
-	Key         Key
+	Key Key
+	// EnvVar is empty for settings controlled only by organization overrides.
 	EnvVar      string
 	Kind        Kind
 	Description string
@@ -85,7 +87,7 @@ type Definition struct {
 // RegistryVersion changes whenever Registry's membership changes. Publish uses
 // it to make pruning safe during rolling deploys: a revision with an older
 // registry version may not delete definitions published by a newer revision.
-const RegistryVersion = 6
+const RegistryVersion = 7
 
 // Registry is the curated allowlist of flags that may carry a per-organization
 // override. It is deliberately explicit rather than derived from the env var
@@ -93,6 +95,12 @@ const RegistryVersion = 6
 // are already per-installation columns on model_router_installations, or are
 // consumed at construction time and have no per-request read site to override.
 var Registry = []Definition{
+	{
+		Key:            KeySubscriptionPlanAwareRouting,
+		Kind:           KindBool,
+		Description:    "Avoid models covered only by exhausted Claude/Codex plans while another plan has headroom. Off by default; ignored when subscription routing is disabled.",
+		OrgOverridable: true,
+	},
 	{
 		Key:            KeyStruggleShadowEnabled,
 		EnvVar:         "ROUTER_STRUGGLE_SHADOW_ENABLED",

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -154,7 +154,6 @@ func TestRegistryIsWellFormed(t *testing.T) {
 	seenEnv := map[string]struct{}{}
 	for _, def := range flags.Registry {
 		assert.NotEmpty(t, def.Key, "every definition needs a key")
-		assert.NotEmpty(t, def.EnvVar, "flag %q needs an env var", def.Key)
 		assert.NotEmpty(t, def.Description, "flag %q needs a description for the admin UI", def.Key)
 		assert.Contains(t,
 			[]flags.Kind{flags.KindBool, flags.KindInt, flags.KindFloat, flags.KindString},
@@ -166,9 +165,11 @@ func TestRegistryIsWellFormed(t *testing.T) {
 
 		// Two flags sharing an env var would make the published deployment
 		// default ambiguous in the admin UI.
-		_, dupEnv := seenEnv[def.EnvVar]
-		assert.False(t, dupEnv, "duplicate env var %q", def.EnvVar)
-		seenEnv[def.EnvVar] = struct{}{}
+		if def.EnvVar != "" {
+			_, dupEnv := seenEnv[def.EnvVar]
+			assert.False(t, dupEnv, "duplicate env var %q", def.EnvVar)
+			seenEnv[def.EnvVar] = struct{}{}
+		}
 
 		def, ok := flags.Lookup(def.Key)
 		require.True(t, ok, "flag %q must be resolvable via Lookup", def.Key)
@@ -178,6 +179,23 @@ func TestRegistryIsWellFormed(t *testing.T) {
 func TestLookupUnknownKey(t *testing.T) {
 	_, ok := flags.Lookup(flags.Key("not_a_flag"))
 	assert.False(t, ok)
+}
+
+func TestSubscriptionPlanAwareRoutingIsAnOrganizationOnlyBoolean(t *testing.T) {
+	def, ok := flags.Lookup(flags.KeySubscriptionPlanAwareRouting)
+	require.True(t, ok)
+	assert.Equal(t, flags.KindBool, def.Kind)
+	assert.True(t, def.OrgOverridable)
+	assert.Empty(t, def.EnvVar)
+	for _, enabled := range []bool{false, true} {
+		overrides := flags.Overrides{Bools: map[flags.Key]bool{flags.KeySubscriptionPlanAwareRouting: enabled}}
+		require.NoError(t, flags.ValidateOverrides(overrides))
+		stored, err := json.Marshal(overrides)
+		require.NoError(t, err)
+		loaded, err := flags.ParseOverrides(stored)
+		require.NoError(t, err)
+		assert.Equal(t, overrides, loaded)
+	}
 }
 
 func TestKeysIsSortedAcrossKinds(t *testing.T) {

--- a/internal/postgres/flag_definitions_test.go
+++ b/internal/postgres/flag_definitions_test.go
@@ -85,7 +85,7 @@ func TestInstallationFlagOverridesRoundTrip(t *testing.T) {
 	assert.True(t, created.FlagOverrides.IsEmpty(), "new installation should carry no overrides")
 
 	want := flags.Overrides{
-		Bools:   map[flags.Key]bool{flags.KeyStruggleShadowEnabled: false},
+		Bools:   map[flags.Key]bool{flags.KeyStruggleShadowEnabled: false, flags.KeySubscriptionPlanAwareRouting: true},
 		Ints:    map[flags.Key]int{flags.KeyLoopEscalationHoldoutPct: 42},
 		Strings: map[flags.Key]string{flags.KeyCyberRefusalFallback: "claude-opus-5"},
 	}

--- a/internal/proxy/managed_subscriptions.go
+++ b/internal/proxy/managed_subscriptions.go
@@ -102,7 +102,7 @@ func (s *Service) leaseManagedSubscription(ctx context.Context, provider, model 
 	if !managedSubscriptionEnrolled(ctx, poolProvider) || (currentCredentials != nil && currentCredentials.OAuth) {
 		return ctx, subscriptions.Lease{}, false, nil
 	}
-	if s.planAwareSubscriptionRouting && managedSubscriptionPlansAllExhausted(ctx) {
+	if subscriptionPlanAwareRoutingEnabled(ctx) && managedSubscriptionPlansAllExhausted(ctx) {
 		if billing.SubscriptionOnlyFromContext(ctx) {
 			return ctx, subscriptions.Lease{}, true, ErrSubscriptionPoolExhausted
 		}

--- a/internal/proxy/managed_subscriptions_test.go
+++ b/internal/proxy/managed_subscriptions_test.go
@@ -12,6 +12,7 @@ import (
 
 	"weave-os/router/internal/auth"
 	"weave-os/router/internal/billing"
+	"weave-os/router/internal/flags"
 	"weave-os/router/internal/providers"
 	"weave-os/router/internal/router"
 	"weave-os/router/internal/router/catalog"
@@ -132,9 +133,9 @@ func TestManagedSubscriptionEnrollmentFailureFailsClosedAtLease(t *testing.T) {
 func TestManagedSubscriptionAllPlansExhaustedFallsThroughToNormalRouting(t *testing.T) {
 	leaser := &scriptedSubscriptionLeaser{}
 	svc := newServiceWithProviders(t, nil).
-		WithManagedSubscriptions(leaser).
-		WithPlanAwareSubscriptionRouting(true)
+		WithManagedSubscriptions(leaser)
 	ctx := managedSubscriptionTestContext()
+	ctx = flags.WithOverrides(ctx, flags.Overrides{Bools: map[flags.Key]bool{flags.KeySubscriptionPlanAwareRouting: true}})
 	ctx = context.WithValue(ctx, ManagedSubscriptionPlanStatesContextKey{}, map[subscriptions.Provider]SubscriptionPlanState{
 		subscriptions.ProviderClaude: SubscriptionPlanStateExhausted,
 	})
@@ -154,9 +155,9 @@ func TestManagedSubscriptionAllPlansExhaustedFallsThroughToNormalRouting(t *test
 func TestManagedSubscriptionAllPlansExhaustedPreservesSubscriptionOnly(t *testing.T) {
 	leaser := &scriptedSubscriptionLeaser{}
 	svc := newServiceWithProviders(t, nil).
-		WithManagedSubscriptions(leaser).
-		WithPlanAwareSubscriptionRouting(true)
+		WithManagedSubscriptions(leaser)
 	ctx := billing.WithSubscriptionOnly(managedSubscriptionTestContext())
+	ctx = flags.WithOverrides(ctx, flags.Overrides{Bools: map[flags.Key]bool{flags.KeySubscriptionPlanAwareRouting: true}})
 	ctx = context.WithValue(ctx, ManagedSubscriptionPlanStatesContextKey{}, map[subscriptions.Provider]SubscriptionPlanState{
 		subscriptions.ProviderClaude: SubscriptionPlanStateExhausted,
 	})
@@ -171,6 +172,27 @@ func TestManagedSubscriptionAllPlansExhaustedPreservesSubscriptionOnly(t *testin
 	require.True(t, managed)
 	require.Same(t, ctx, out)
 	require.Empty(t, leaser.providers)
+}
+
+func TestManagedSubscriptionAllPlansExhaustedRequiresOrgOptInForPaidFallback(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		leaser := &scriptedSubscriptionLeaser{}
+		svc := newServiceWithProviders(t, nil).WithManagedSubscriptions(leaser)
+		ctx := flags.WithOverrides(managedSubscriptionTestContext(), flags.Overrides{
+			Bools: map[flags.Key]bool{flags.KeySubscriptionPlanAwareRouting: enabled},
+		})
+		ctx = context.WithValue(ctx, ManagedSubscriptionPlanStatesContextKey{}, map[subscriptions.Provider]SubscriptionPlanState{
+			subscriptions.ProviderClaude: SubscriptionPlanStateExhausted,
+		})
+		_, _, managed, err := svc.leaseManagedSubscription(ctx, providers.ProviderAnthropic, "claude-opus-4-8")
+		if enabled {
+			require.NoError(t, err)
+			require.False(t, managed)
+		} else {
+			require.ErrorIs(t, err, ErrSubscriptionPoolExhausted)
+			require.True(t, managed)
+		}
+	}
 }
 
 func TestInferenceFailsClosedWhenSubscriptionEnrollmentIsUnknown(t *testing.T) {

--- a/internal/proxy/plan_aware_routing.go
+++ b/internal/proxy/plan_aware_routing.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"weave-os/router/internal/auth"
+	"weave-os/router/internal/flags"
 	"weave-os/router/internal/providers"
 	"weave-os/router/internal/router/catalog"
 	"weave-os/router/internal/subscriptions"
@@ -200,8 +201,12 @@ func managedSubscriptionPlansAllExhausted(ctx context.Context) bool {
 	return allSubscriptionPlansExhausted(managedSubscriptionPlanStatesFromContext(ctx))
 }
 
+func subscriptionPlanAwareRoutingEnabled(ctx context.Context) bool {
+	return !subscriptionRoutingDisabledForRequest(ctx) && flags.BoolOr(ctx, flags.KeySubscriptionPlanAwareRouting, false)
+}
+
 func (s *Service) withPlanAwareSubscriptionModels(ctx context.Context, headers http.Header) context.Context {
-	if !s.planAwareSubscriptionRouting {
+	if !subscriptionPlanAwareRoutingEnabled(ctx) {
 		return ctx
 	}
 	states := subscriptionPlanStatesForRequest(s, ctx, headers)

--- a/internal/proxy/plan_aware_routing_internal_test.go
+++ b/internal/proxy/plan_aware_routing_internal_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"net/http"
 	"testing"
 	"time"
 
@@ -9,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"weave-os/router/internal/auth"
+	"weave-os/router/internal/flags"
+	"weave-os/router/internal/proxy/usage"
 	"weave-os/router/internal/subscriptions"
 )
 
@@ -22,7 +25,10 @@ func planAwareUniverse() map[string]struct{} {
 }
 
 func planAwareStates(states map[subscriptions.Provider]SubscriptionPlanState) context.Context {
-	return context.WithValue(context.Background(), ManagedSubscriptionPlanStatesContextKey{}, states)
+	ctx := flags.WithOverrides(context.Background(), flags.Overrides{
+		Bools: map[flags.Key]bool{flags.KeySubscriptionPlanAwareRouting: true},
+	})
+	return context.WithValue(ctx, ManagedSubscriptionPlanStatesContextKey{}, states)
 }
 
 func TestManagedSubscriptionPlanStatesAggregatesAccountCooldowns(t *testing.T) {
@@ -47,8 +53,7 @@ func TestManagedSubscriptionPlanStatesAggregatesAccountCooldowns(t *testing.T) {
 
 func TestPlanAwareRoutingLeavesRosterUnchangedWhenPlansAreActive(t *testing.T) {
 	svc := &Service{
-		availableModels:              planAwareUniverse(),
-		planAwareSubscriptionRouting: true,
+		availableModels: planAwareUniverse(),
 	}
 	ctx := svc.withPlanAwareSubscriptionModels(planAwareStates(map[subscriptions.Provider]SubscriptionPlanState{
 		subscriptions.ProviderClaude: SubscriptionPlanStateActive,
@@ -61,8 +66,7 @@ func TestPlanAwareRoutingLeavesRosterUnchangedWhenPlansAreActive(t *testing.T) {
 
 func TestPlanAwareRoutingExcludesOnlyExhaustedPlanModels(t *testing.T) {
 	svc := &Service{
-		availableModels:              planAwareUniverse(),
-		planAwareSubscriptionRouting: true,
+		availableModels: planAwareUniverse(),
 	}
 	ctx := svc.withPlanAwareSubscriptionModels(planAwareStates(map[subscriptions.Provider]SubscriptionPlanState{
 		subscriptions.ProviderClaude: SubscriptionPlanStateExhausted,
@@ -79,8 +83,7 @@ func TestPlanAwareRoutingExcludesOnlyExhaustedPlanModels(t *testing.T) {
 
 func TestPlanAwareRoutingRestoresNormalRosterWhenAllPlansAreExhausted(t *testing.T) {
 	svc := &Service{
-		availableModels:              planAwareUniverse(),
-		planAwareSubscriptionRouting: true,
+		availableModels: planAwareUniverse(),
 	}
 	ctx := svc.withPlanAwareSubscriptionModels(planAwareStates(map[subscriptions.Provider]SubscriptionPlanState{
 		subscriptions.ProviderClaude: SubscriptionPlanStateExhausted,
@@ -93,8 +96,7 @@ func TestPlanAwareRoutingRestoresNormalRosterWhenAllPlansAreExhausted(t *testing
 
 func TestPlanAwareRoutingDoesNotFilterOnUnknownPlanState(t *testing.T) {
 	svc := &Service{
-		availableModels:              planAwareUniverse(),
-		planAwareSubscriptionRouting: true,
+		availableModels: planAwareUniverse(),
 	}
 	ctx := svc.withPlanAwareSubscriptionModels(planAwareStates(map[subscriptions.Provider]SubscriptionPlanState{
 		subscriptions.ProviderClaude: SubscriptionPlanStateUnknown,
@@ -107,8 +109,7 @@ func TestPlanAwareRoutingDoesNotFilterOnUnknownPlanState(t *testing.T) {
 
 func TestPlanAwareRoutingComposesWithExplicitExclusions(t *testing.T) {
 	svc := &Service{
-		availableModels:              planAwareUniverse(),
-		planAwareSubscriptionRouting: true,
+		availableModels: planAwareUniverse(),
 	}
 	ctx := svc.withPlanAwareSubscriptionModels(planAwareStates(map[subscriptions.Provider]SubscriptionPlanState{
 		subscriptions.ProviderClaude: SubscriptionPlanStateExhausted,
@@ -121,4 +122,66 @@ func TestPlanAwareRoutingComposesWithExplicitExclusions(t *testing.T) {
 	assert.Contains(t, excluded, "claude-sonnet-5")
 	assert.Contains(t, excluded, "gpt-5.6-sol")
 	assert.NotContains(t, excluded, "gemini-3.8-flash")
+}
+
+func TestPlanAwareRoutingRequiresOrganizationOptIn(t *testing.T) {
+	// The retired deployment setting must not opt untouched organizations in.
+	t.Setenv("ROUTER_SUBSCRIPTION_PLAN_AWARE_ROUTING", "true")
+	svc := &Service{availableModels: planAwareUniverse()}
+	for _, tc := range []struct {
+		name         string
+		stored       string
+		disabled     bool
+		wantExcluded bool
+	}{
+		{name: "absent", stored: `{}`},
+		{name: "org A enabled", stored: `{"subscription_plan_aware_routing_enabled":true}`, wantExcluded: true},
+		{name: "org B untouched", stored: `{}`},
+		{name: "org A disabled", stored: `{"subscription_plan_aware_routing_enabled":false}`},
+		{name: "org A re-enabled", stored: `{"subscription_plan_aware_routing_enabled":true}`, wantExcluded: true},
+		{name: "org A cleared", stored: `{}`},
+		{name: "subscription routing disabled", stored: `{"subscription_plan_aware_routing_enabled":true}`, disabled: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			overrides, err := flags.ParseOverrides([]byte(tc.stored))
+			require.NoError(t, err)
+			ctx := flags.WithOverrides(context.Background(), overrides)
+			ctx = context.WithValue(ctx, InstallationSubscriptionRoutingDisabledContextKey{}, tc.disabled)
+			ctx = context.WithValue(ctx, ManagedSubscriptionPlanStatesContextKey{}, map[subscriptions.Provider]SubscriptionPlanState{
+				subscriptions.ProviderClaude: SubscriptionPlanStateExhausted,
+				subscriptions.ProviderCodex:  SubscriptionPlanStateActive,
+			})
+			ctx = svc.withPlanAwareSubscriptionModels(ctx, nil)
+			excluded := svc.excludedModelsForRequest(ctx)
+			if tc.wantExcluded {
+				assert.Contains(t, excluded, "claude-sonnet-5")
+			} else {
+				assert.Empty(t, excluded)
+			}
+			assert.NotContains(t, excluded, "gpt-5.6-sol")
+		})
+	}
+}
+
+func TestPlanAwareRoutingOrgFlagAppliesToDirectSubscription(t *testing.T) {
+	const token = "eyJhbGciOi.codex.jwt"
+	observer := usage.NewObserver([]byte("test-salt"), time.Minute, time.Now)
+	observer.Record(observer.Key([]byte(token)), usage.Snapshot{
+		Primary: usage.Window{UsedPercent: 1, WindowMinutes: 300},
+	})
+	svc := (&Service{availableModels: planAwareUniverse()}).WithUsageObserver(observer)
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer "+token)
+	headers.Set("ChatGPT-Account-ID", "test-account")
+	ctx := planAwareStates(map[subscriptions.Provider]SubscriptionPlanState{
+		subscriptions.ProviderClaude: SubscriptionPlanStateActive,
+	})
+
+	enabled := svc.withPlanAwareSubscriptionModels(ctx, headers)
+	assert.Contains(t, svc.excludedModelsForRequest(enabled), "gpt-5.6-sol")
+	assert.NotContains(t, svc.excludedModelsForRequest(enabled), "claude-sonnet-5")
+
+	disabled := flags.WithOverrides(ctx, flags.Overrides{Bools: map[flags.Key]bool{flags.KeySubscriptionPlanAwareRouting: false}})
+	disabled = svc.withPlanAwareSubscriptionModels(disabled, headers)
+	assert.Empty(t, svc.excludedModelsForRequest(disabled))
 }

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -360,10 +360,6 @@ type Service struct {
 	// factor near epsilon until the window nears its cap.
 	subsidyEpsilon float64
 	subsidyGamma   float64
-	// planAwareSubscriptionRouting removes models whose only linked
-	// subscription plan is exhausted. It is request-scoped and never mutates
-	// the deployment roster.
-	planAwareSubscriptionRouting bool
 	// managedSubscriptions leases encrypted, owner-scoped Claude/Codex
 	// subscription credentials. Nil leaves the legacy credential path unchanged.
 	managedSubscriptions subscriptions.Leaser
@@ -2137,13 +2133,6 @@ func (s *Service) WithBillingService(b *billing.Service) *Service {
 // WithManagedSubscriptions enables server-side owner/provider account pools.
 func (s *Service) WithManagedSubscriptions(pool subscriptions.Leaser) *Service {
 	s.managedSubscriptions = pool
-	return s
-}
-
-// WithPlanAwareSubscriptionRouting enables per-user model eligibility based on
-// the aggregate state of linked Claude and Codex subscription plans.
-func (s *Service) WithPlanAwareSubscriptionRouting(enabled bool) *Service {
-	s.planAwareSubscriptionRouting = enabled
 	return s
 }
 

--- a/internal/proxy/service_cache_test.go
+++ b/internal/proxy/service_cache_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"weave-os/router/internal/feedback"
+	"weave-os/router/internal/flags"
 	"weave-os/router/internal/providers"
 	"weave-os/router/internal/proxy"
 	"weave-os/router/internal/router"
@@ -169,10 +170,10 @@ func TestService_Cache_PlanAwareRoutingBypasses(t *testing.T) {
 	}
 	fr := &fakeRouter{decision: decisionWithEmbedding(emb, []int{0, 1})}
 	c := cache.New(cache.DefaultConfig())
-	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderAnthropic: provider}, nil, false, c, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil).
-		WithPlanAwareSubscriptionRouting(true)
+	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderAnthropic: provider}, nil, false, c, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil)
 
 	ctx := proxyContextWithExternalID(t, "tenant-plan-aware")
+	ctx = flags.WithOverrides(ctx, flags.Overrides{Bools: map[flags.Key]bool{flags.KeySubscriptionPlanAwareRouting: true}})
 	ctx = context.WithValue(ctx, proxy.ManagedSubscriptionPlanStatesContextKey{}, map[subscriptions.Provider]proxy.SubscriptionPlanState{
 		subscriptions.ProviderClaude: proxy.SubscriptionPlanStateExhausted,
 		subscriptions.ProviderCodex:  proxy.SubscriptionPlanStateActive,

--- a/internal/server/middleware/plan_aware_routing_test.go
+++ b/internal/server/middleware/plan_aware_routing_test.go
@@ -1,0 +1,57 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"weave-os/router/internal/auth"
+	"weave-os/router/internal/flags"
+	"weave-os/router/internal/server/middleware"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithAuthPropagatesPlanAwareOrganizationFlag(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const routerToken = "rk_plan_aware_test"
+	hash, prefix, suffix := auth.APITokenFingerprint(routerToken)
+	installation := &auth.Installation{ID: "test-installation", ExternalID: "test-organization"}
+	repo := &fakeAPIKeyRepository{byHash: map[string]fakeKeyRow{
+		hash: {
+			apiKey:       &auth.APIKey{ID: "test-key", KeyHash: hash, KeyPrefix: prefix, KeySuffix: suffix},
+			installation: installation,
+		},
+	}}
+	svc := auth.NewService(fakeInstallationRepository{}, repo, nil, nil, auth.NoOpAPIKeyCache{}, nil, time.Now)
+	engine := gin.New()
+	engine.Use(middleware.WithAuth(svc, false))
+	var enabled bool
+	engine.GET("/probe", func(c *gin.Context) {
+		enabled = flags.BoolOr(c.Request.Context(), flags.KeySubscriptionPlanAwareRouting, false)
+		c.Status(http.StatusOK)
+	})
+
+	for _, tc := range []struct {
+		stored string
+		want   bool
+	}{
+		{stored: `{}`},
+		{stored: `{"subscription_plan_aware_routing_enabled":true}`, want: true},
+		{stored: `{"subscription_plan_aware_routing_enabled":false}`},
+		{stored: `{}`},
+	} {
+		overrides, err := flags.ParseOverrides([]byte(tc.stored))
+		require.NoError(t, err)
+		installation.FlagOverrides = overrides
+		req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+		req.Header.Set(middleware.RouterKeyHeader, routerToken)
+		recorder := httptest.NewRecorder()
+		engine.ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, tc.want, enabled, "stored override: %s", tc.stored)
+	}
+}


### PR DESCRIPTION
Store subscription_plan_aware_routing_enabled in the existing organization flag overrides and publish a fixed false default for the admin Flags UI. Remove the deployment-wide environment switch. Apply the org setting to both model eligibility and managed-pool exhaustion fallback, respecting subscription routing opt-out.

Validation: full router tests/build/vet; targeted race tests; auth propagation; isolated Postgres flag round-trip tests; docs and agent-guide checks. Existing control-plane flag API tests also pass. No schema migration is needed.