### PR TITLE
fix(billing): price Anthropic 1-hour cache writes separately

### DIFF
--- a/internal/billing/service.go
+++ b/internal/billing/service.go
@@ -205,6 +205,10 @@ type DebitInferenceParams struct {
 	InputTokens     int
 	OutputTokens    int
 	CacheCreation   int
+	// CacheCreation1h is the portion of CacheCreation written on Anthropic's
+	// 1-hour TTL tier. Zero prices every write at the 5-minute rate — the
+	// aggregate-only payloads some providers emit.
+	CacheCreation1h int
 	CacheRead       int
 	Pricing         catalog.Pricing
 	HasOverride     bool
@@ -323,7 +327,7 @@ func warnOnUnknownPricing(p DebitInferenceParams) {
 // computeNotionalMicros returns the would-be charge in USD micros,
 // regardless of override status, for the shadow billing trail.
 func computeNotionalMicros(p DebitInferenceParams) int64 {
-	inUSD := catalog.EffectiveInputCost(p.InputTokens, p.CacheCreation, p.CacheRead, p.Pricing, p.Provider)
+	inUSD := catalog.EffectiveInputCost(p.InputTokens, p.CacheCreation, p.CacheCreation1h, p.CacheRead, p.Pricing, p.Provider)
 	outUSD := catalog.EffectiveOutputCost(p.InputTokens, p.OutputTokens, p.Pricing)
 	return catalog.USDToMicros(inUSD + outUSD)
 }

--- a/internal/observability/otel/usage.go
+++ b/internal/observability/otel/usage.go
@@ -15,6 +15,7 @@ import (
 type UsageSink interface {
 	RecordUsage(inputTokens, outputTokens int)
 	RecordCacheUsage(cacheCreationTokens, cacheReadTokens int)
+	RecordCacheCreation1hTokens(tokens int)
 }
 
 var (
@@ -29,10 +30,11 @@ type UsageExtractor struct {
 	inner    http.ResponseWriter
 	provider string
 
-	input         int
-	output        int
-	cacheCreation int
-	cacheRead     int
+	input           int
+	output          int
+	cacheCreation   int
+	cacheCreation1h int
+	cacheRead       int
 
 	leftover []byte
 }
@@ -116,6 +118,14 @@ func (u *UsageExtractor) RecordCacheUsage(cacheCreationTokens, cacheReadTokens i
 	}
 }
 
+// RecordCacheCreation1hTokens sets the 1-hour-tier portion of the
+// cache-creation aggregate (Anthropic's usage.cache_creation breakdown).
+func (u *UsageExtractor) RecordCacheCreation1hTokens(tokens int) {
+	if tokens > 0 {
+		u.cacheCreation1h = tokens
+	}
+}
+
 // Tokens returns the extracted input and output token counts.
 func (u *UsageExtractor) Tokens() (input, output int) {
 	if u == nil {
@@ -131,6 +141,16 @@ func (u *UsageExtractor) CacheTokens() (creation, read int) {
 		return 0, 0
 	}
 	return u.cacheCreation, u.cacheRead
+}
+
+// CacheCreation1hTokens returns the extracted 1-hour-tier portion of the
+// cache-creation aggregate. Zero means no TTL breakdown was seen (aggregate-
+// only payloads) — every write prices at the 5-minute rate.
+func (u *UsageExtractor) CacheCreation1hTokens() int {
+	if u == nil {
+		return 0
+	}
+	return u.cacheCreation1h
 }
 
 // scanBuffer splits buffered data on SSE event boundaries and extracts token
@@ -170,13 +190,15 @@ func (u *UsageExtractor) extractFromSSEEvent(eventType []byte, data []byte) {
 	}
 }
 
-// message_start carries input_tokens + cache tokens; message_delta carries output_tokens.
+// message_start carries input_tokens + cache tokens (and, when the upstream
+// reports it, the cache_creation TTL breakdown); message_delta carries
+// output_tokens and cumulative aggregates only.
 func (u *UsageExtractor) extractAnthropicSSE(eventType []byte, data []byte) {
 	if !bytes.Equal(eventType, []byte("message_start")) && !bytes.Equal(eventType, []byte("message_delta")) {
 		return
 	}
 
-	input, output, cacheCreation, cacheRead, found := extractUsageGJSON(data, providers.ProviderAnthropic)
+	input, output, cacheCreation, cacheCreation1h, cacheRead, found := extractUsageGJSON(data, providers.ProviderAnthropic)
 	if !found {
 		return
 	}
@@ -187,6 +209,9 @@ func (u *UsageExtractor) extractAnthropicSSE(eventType []byte, data []byte) {
 		}
 		if cacheCreation > 0 {
 			u.cacheCreation = cacheCreation
+		}
+		if cacheCreation1h > 0 {
+			u.cacheCreation1h = cacheCreation1h
 		}
 		if cacheRead > 0 {
 			u.cacheRead = cacheRead
@@ -204,7 +229,7 @@ func (u *UsageExtractor) extractOpenAISSE(data []byte) {
 		return
 	}
 
-	input, output, cacheCreation, cacheRead, found := extractUsageGJSON(trimmed, u.provider)
+	input, output, cacheCreation, _, cacheRead, found := extractUsageGJSON(trimmed, u.provider)
 	if !found {
 		return
 	}
@@ -228,7 +253,7 @@ func (u *UsageExtractor) tryExtractFromJSON() {
 		return
 	}
 
-	input, output, cacheCreation, cacheRead, found := extractUsageGJSON(u.leftover, u.provider)
+	input, output, cacheCreation, cacheCreation1h, cacheRead, found := extractUsageGJSON(u.leftover, u.provider)
 	if !found {
 		return
 	}
@@ -242,6 +267,9 @@ func (u *UsageExtractor) tryExtractFromJSON() {
 	if cacheCreation > 0 {
 		u.cacheCreation = cacheCreation
 	}
+	if cacheCreation1h > 0 {
+		u.cacheCreation1h = cacheCreation1h
+	}
 	if cacheRead > 0 {
 		u.cacheRead = cacheRead
 	}
@@ -250,8 +278,11 @@ func (u *UsageExtractor) tryExtractFromJSON() {
 // extractUsageGJSON probes usage fields via gjson (no json.Unmarshal/map allocs).
 // OpenAI cache-read maps from cached_tokens; GPT-5.6+ cache-write maps from cache_write_tokens.
 // Google's native :generateContent uses usageMetadata; its OpenAI-compat surface
-// uses the OpenAI shape instead.
-func extractUsageGJSON(data []byte, provider string) (input, output, cacheCreation, cacheRead int, found bool) {
+// uses the OpenAI shape instead. cacheCreation1h is Anthropic-only: the
+// 1-hour-tier portion of the cache-creation aggregate from
+// usage.cache_creation.ephemeral_1h_input_tokens; zero when the upstream
+// reports no TTL breakdown.
+func extractUsageGJSON(data []byte, provider string) (input, output, cacheCreation, cacheCreation1h, cacheRead int, found bool) {
 	family := providers.FamilyFor(provider)
 
 	if family == providers.FamilyGemini {
@@ -259,7 +290,7 @@ func extractUsageGJSON(data []byte, provider string) (input, output, cacheCreati
 			input = int(meta.Get("promptTokenCount").Int())
 			output = int(meta.Get("candidatesTokenCount").Int())
 			cacheRead = int(meta.Get("cachedContentTokenCount").Int())
-			return input, output, 0, cacheRead, true
+			return input, output, 0, 0, cacheRead, true
 		}
 	}
 
@@ -273,7 +304,7 @@ func extractUsageGJSON(data []byte, provider string) (input, output, cacheCreati
 		usage = gjson.GetBytes(data, "response.usage")
 	}
 	if !usage.Exists() {
-		return 0, 0, 0, 0, false
+		return 0, 0, 0, 0, 0, false
 	}
 
 	switch family {
@@ -281,6 +312,7 @@ func extractUsageGJSON(data []byte, provider string) (input, output, cacheCreati
 		input = int(usage.Get("input_tokens").Int())
 		output = int(usage.Get("output_tokens").Int())
 		cacheCreation = int(usage.Get("cache_creation_input_tokens").Int())
+		cacheCreation1h = int(usage.Get("cache_creation.ephemeral_1h_input_tokens").Int())
 		cacheRead = int(usage.Get("cache_read_input_tokens").Int())
 	case providers.FamilyOpenAICompat, providers.FamilyGemini:
 		// Chat Completions uses prompt_tokens/completion_tokens; Responses API
@@ -294,10 +326,10 @@ func extractUsageGJSON(data []byte, provider string) (input, output, cacheCreati
 		}
 		cacheCreation, cacheRead = openaiCacheTokens(usage)
 	default:
-		return 0, 0, 0, 0, false
+		return 0, 0, 0, 0, 0, false
 	}
 
-	return input, output, cacheCreation, cacheRead, true
+	return input, output, cacheCreation, cacheCreation1h, cacheRead, true
 }
 
 // openaiCacheTokens mirrors translate.OpenAICacheTokens. Duplicated here so

--- a/internal/observability/otel/usage_test.go
+++ b/internal/observability/otel/usage_test.go
@@ -173,7 +173,7 @@ func TestUsageExtractor_AnthropicCacheTokens_NonStreaming(t *testing.T) {
 	rec := httptest.NewRecorder()
 	ext := otel.NewUsageExtractor(rec, "anthropic")
 
-	body := `{"id":"msg_456","type":"message","role":"assistant","content":[{"type":"text","text":"OK"}],"model":"claude-sonnet-4-5","stop_reason":"end_turn","usage":{"input_tokens":42,"output_tokens":17,"cache_creation_input_tokens":256,"cache_read_input_tokens":1024}}`
+	body := `{"id":"msg_456","type":"message","role":"assistant","content":[{"type":"text","text":"OK"}],"model":"claude-sonnet-4-5","stop_reason":"end_turn","usage":{"input_tokens":42,"output_tokens":17,"cache_creation_input_tokens":256,"cache_read_input_tokens":1024,"cache_creation":{"ephemeral_5m_input_tokens":156,"ephemeral_1h_input_tokens":100}}}`
 	_, err := ext.Write([]byte(body))
 	require.NoError(t, err)
 
@@ -184,6 +184,7 @@ func TestUsageExtractor_AnthropicCacheTokens_NonStreaming(t *testing.T) {
 	cacheCreation, cacheRead := ext.CacheTokens()
 	assert.Equal(t, 256, cacheCreation)
 	assert.Equal(t, 1024, cacheRead)
+	assert.Equal(t, 100, ext.CacheCreation1hTokens())
 }
 
 func TestUsageExtractor_AnthropicCacheTokens_Streaming(t *testing.T) {
@@ -193,9 +194,12 @@ func TestUsageExtractor_AnthropicCacheTokens_Streaming(t *testing.T) {
 	// cache tokens arrive in message_start; subsequent message_delta carries
 	// only output_tokens and must not clobber the cache values.
 	events := []string{
-		"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-4-5\",\"usage\":{\"input_tokens\":100,\"output_tokens\":0,\"cache_creation_input_tokens\":300,\"cache_read_input_tokens\":900}}}\n\n",
+		"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-4-5\",\"usage\":{\"input_tokens\":100,\"output_tokens\":0,\"cache_creation_input_tokens\":300,\"cache_read_input_tokens\":900,\"cache_creation\":{\"ephemeral_5m_input_tokens\":250,\"ephemeral_1h_input_tokens\":50}}}}\n\n",
 		"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hi\"}}\n\n",
-		"event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":25}}\n\n",
+		// message_delta repeats the cumulative aggregate without the TTL
+		// breakdown (Anthropic documents the split on message_start only) —
+		// the 1h split captured at message_start must survive it.
+		"event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":25,\"cache_creation_input_tokens\":300}}\n\n",
 	}
 
 	for _, e := range events {
@@ -210,6 +214,7 @@ func TestUsageExtractor_AnthropicCacheTokens_Streaming(t *testing.T) {
 	cacheCreation, cacheRead := ext.CacheTokens()
 	assert.Equal(t, 300, cacheCreation)
 	assert.Equal(t, 900, cacheRead)
+	assert.Equal(t, 50, ext.CacheCreation1hTokens())
 }
 
 func TestUsageExtractor_OpenAICacheTokens_NonStreaming(t *testing.T) {

--- a/internal/proxy/auxiliary_inference.go
+++ b/internal/proxy/auxiliary_inference.go
@@ -67,6 +67,7 @@ func (s *Service) billAuxiliaryInference(ctx context.Context, requestID, request
 		InputTokens:     usage.InputTokens,
 		OutputTokens:    usage.OutputTokens,
 		CacheCreation:   usage.CacheCreation,
+		CacheCreation1h: usage.CacheCreation1h,
 		CacheRead:       usage.CacheRead,
 		Pricing:         pricing,
 		HasOverride:     billing.HasOverrideFromContext(ctx),
@@ -80,7 +81,7 @@ func (s *Service) billAuxiliaryInference(ctx context.Context, requestID, request
 		return
 	}
 	clientID := ClientIdentityFrom(ctx)
-	inputCost := catalog.EffectiveInputCost(usage.InputTokens, usage.CacheCreation, usage.CacheRead, pricing, usage.Provider)
+	inputCost := catalog.EffectiveInputCost(usage.InputTokens, usage.CacheCreation, usage.CacheCreation1h, usage.CacheRead, pricing, usage.Provider)
 	outputCost := catalog.EffectiveOutputCost(usage.InputTokens, usage.OutputTokens, pricing)
 
 	s.fireTelemetry(InsertTelemetryParams{

--- a/internal/proxy/auxiliary_inference_internal_test.go
+++ b/internal/proxy/auxiliary_inference_internal_test.go
@@ -211,7 +211,7 @@ func TestBillAuxiliaryInferenceTagsSessionAndCost(t *testing.T) {
 
 	pricing, ok := catalog.PrimaryPriceFor(auxTestModel)
 	require.True(t, ok, "the test model must be priced in the catalog")
-	wantInput := catalog.EffectiveInputCost(usage.InputTokens, usage.CacheCreation, usage.CacheRead, pricing, usage.Provider)
+	wantInput := catalog.EffectiveInputCost(usage.InputTokens, usage.CacheCreation, usage.CacheCreation1h, usage.CacheRead, pricing, usage.Provider)
 	wantOutput := catalog.EffectiveOutputCost(usage.InputTokens, usage.OutputTokens, pricing)
 	assert.Greater(t, wantInput+wantOutput, 0.0, "the fixture must produce a non-zero cost")
 	assert.InDelta(t, wantInput, row.ActualInputCostUSD, 1e-12)

--- a/internal/proxy/cost_response.go
+++ b/internal/proxy/cost_response.go
@@ -72,20 +72,20 @@ type routerResponseCost struct {
 	CacheCreationTokens int     `json:"cache_creation_tokens"`
 }
 
-type routerCostCalculator func(inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens int) routerResponseCost
+type routerCostCalculator func(inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens, cacheCreation1hTokens int) routerResponseCost
 
 func routerCostCalculatorFor(model, provider string, fast bool) routerCostCalculator {
 	pricing, ok := servedPricing(provider, model, fast)
 	if !ok {
 		return nil
 	}
-	return func(inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens int) routerResponseCost {
-		return routerResponseCostFromPricing(pricing, provider, inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens)
+	return func(inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens, cacheCreation1hTokens int) routerResponseCost {
+		return routerResponseCostFromPricing(pricing, provider, inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens, cacheCreation1hTokens)
 	}
 }
 
-func routerResponseCostFromPricing(pricing catalog.Pricing, provider string, inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens int) routerResponseCost {
-	inputUSD := catalog.EffectiveInputCost(inputTokens, cacheCreationTokens, cacheReadTokens, pricing, provider)
+func routerResponseCostFromPricing(pricing catalog.Pricing, provider string, inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens, cacheCreation1hTokens int) routerResponseCost {
+	inputUSD := catalog.EffectiveInputCost(inputTokens, cacheCreationTokens, cacheCreation1hTokens, cacheReadTokens, pricing, provider)
 	outputUSD := catalog.EffectiveOutputCost(inputTokens, outputTokens, pricing)
 	return routerResponseCost{
 		TotalUSD:            roundUSD(inputUSD + outputUSD),
@@ -118,10 +118,13 @@ type streamCostWriter struct {
 	calculate routerCostCalculator
 	// Translated Anthropic usage reports fresh input, while the bound pricing
 	// calculator expects OpenAI/Gemini input to include cached tokens.
-	inputIncludesCache   bool
-	messageStartInput    int
-	messageStartRead     int
-	messageStartCreation int
+	inputIncludesCache bool
+	messageStartInput  int
+	messageStartRead   int
+	// messageStartCreation is the cache-creation aggregate; messageStartCreation1h
+	// its 1-hour-tier portion when the upstream reported the TTL breakdown.
+	messageStartCreation   int
+	messageStartCreation1h int
 }
 
 func newStreamCostWriter(inner http.ResponseWriter) *streamCostWriter {
@@ -175,6 +178,7 @@ func (w *streamCostWriter) annotateEvent(event []byte) []byte {
 		w.messageStartInput = int(usage.Get("input_tokens").Int())
 		w.messageStartRead = int(usage.Get("cache_read_input_tokens").Int())
 		w.messageStartCreation = int(usage.Get("cache_creation_input_tokens").Int())
+		w.messageStartCreation1h = int(usage.Get("cache_creation.ephemeral_1h_input_tokens").Int())
 		return event
 	}
 	if string(eventType) != "message_delta" || w.calculate == nil {
@@ -191,6 +195,7 @@ func (w *streamCostWriter) annotateEvent(event []byte) []byte {
 	inputTokens := int(usage.Get("input_tokens").Int())
 	outputTokens := int(usage.Get("output_tokens").Int())
 	cacheCreation := int(usage.Get("cache_creation_input_tokens").Int())
+	cacheCreation1h := int(usage.Get("cache_creation.ephemeral_1h_input_tokens").Int())
 	cacheRead := int(usage.Get("cache_read_input_tokens").Int())
 	if inputTokens == 0 {
 		inputTokens = w.messageStartInput
@@ -198,13 +203,16 @@ func (w *streamCostWriter) annotateEvent(event []byte) []byte {
 	if cacheCreation == 0 {
 		cacheCreation = w.messageStartCreation
 	}
+	if cacheCreation1h == 0 {
+		cacheCreation1h = w.messageStartCreation1h
+	}
 	if cacheRead == 0 {
 		cacheRead = w.messageStartRead
 	}
 	if w.inputIncludesCache {
 		inputTokens += cacheCreation + cacheRead
 	}
-	cost, err := json.Marshal(w.calculate(inputTokens, outputTokens, cacheCreation, cacheRead))
+	cost, err := json.Marshal(w.calculate(inputTokens, outputTokens, cacheCreation, cacheRead, cacheCreation1h))
 	if err != nil {
 		return event
 	}

--- a/internal/proxy/cost_response_test.go
+++ b/internal/proxy/cost_response_test.go
@@ -16,7 +16,7 @@ import (
 func TestStreamCostWriterAnnotatesFinalMessageDelta(t *testing.T) {
 	rec := httptest.NewRecorder()
 	writer := newStreamCostWriter(rec)
-	writer.SetCostCalculator(func(input, output, creation, read int) routerResponseCost {
+	writer.SetCostCalculator(func(input, output, creation, read, creation1h int) routerResponseCost {
 		return routerResponseCost{
 			TotalUSD:            1.25,
 			InputUSD:            0.75,
@@ -87,7 +87,7 @@ func TestRouterResponseCostFromPricingRoundsFloatNoise(t *testing.T) {
 	// gpt-5.4-mini pricing: 12 input + 9 output tokens yielded
 	// 0.000049500000000000004 before rounding.
 	pricing := catalog.Pricing{InputUSDPer1M: 0.75, OutputUSDPer1M: 4.5}
-	cost := routerResponseCostFromPricing(pricing, providers.ProviderOpenAI, 12, 9, 0, 0)
+	cost := routerResponseCostFromPricing(pricing, providers.ProviderOpenAI, 12, 9, 0, 0, 0)
 
 	rec := httptest.NewRecorder()
 	setRouterCostHeaders(rec.Header(), cost)

--- a/internal/proxy/fastmode_internal_test.go
+++ b/internal/proxy/fastmode_internal_test.go
@@ -102,7 +102,7 @@ func TestProxyMessages_FastModeAnthropicDispatchesFastAndBillsFastRate(t *testin
 
 	fast, ok := catalog.FastPriceFor(providers.ProviderAnthropic, fastOpusModel)
 	require.True(t, ok)
-	want := routerResponseCostFromPricing(fast, providers.ProviderAnthropic, inputTokens, outputTokens, 0, 0)
+	want := routerResponseCostFromPricing(fast, providers.ProviderAnthropic, inputTokens, outputTokens, 0, 0, 0)
 	assert.Equal(t, strconv.FormatFloat(want.TotalUSD, 'f', -1, 64), rec.Header().Get(HeaderRouterCostUSD))
 }
 
@@ -124,7 +124,7 @@ func TestProxyMessages_FastModeOffLeavesRequestAndListPrice(t *testing.T) {
 
 	base, ok := catalog.PriceFor(providers.ProviderAnthropic, fastOpusModel)
 	require.True(t, ok)
-	want := routerResponseCostFromPricing(base, providers.ProviderAnthropic, inputTokens, outputTokens, 0, 0)
+	want := routerResponseCostFromPricing(base, providers.ProviderAnthropic, inputTokens, outputTokens, 0, 0, 0)
 	assert.Equal(t, strconv.FormatFloat(want.TotalUSD, 'f', -1, 64), rec.Header().Get(HeaderRouterCostUSD))
 }
 
@@ -171,7 +171,7 @@ func TestProxyMessages_FastModeQuotaRejectionRetriesAtStandardSpeedAndBillsListP
 
 	base, ok := catalog.PriceFor(providers.ProviderAnthropic, fastOpusModel)
 	require.True(t, ok)
-	want := routerResponseCostFromPricing(base, providers.ProviderAnthropic, inputTokens, outputTokens, 0, 0)
+	want := routerResponseCostFromPricing(base, providers.ProviderAnthropic, inputTokens, outputTokens, 0, 0, 0)
 	assert.Equal(t, strconv.FormatFloat(want.TotalUSD, 'f', -1, 64), rec.Header().Get(HeaderRouterCostUSD), "a turn served at standard speed bills at list price")
 }
 

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -308,8 +308,9 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 
 	in, out := extractor.Tokens()
 	cacheCreation, cacheRead := extractor.CacheTokens()
+	cacheCreation1h := extractor.CacheCreation1hTokens()
 	if responseBuffer != nil && proxyErr == nil {
-		setRouterCostHeaders(w.Header(), routerResponseCostFromPricing(actPricing, decision.Provider, in, out, cacheCreation, cacheRead))
+		setRouterCostHeaders(w.Header(), routerResponseCostFromPricing(actPricing, decision.Provider, in, out, cacheCreation, cacheRead, cacheCreation1h))
 	}
 	geminiUpstreamBuilder := otel.NewAttrBuilder(40).
 		String("request_id", requestID).
@@ -328,9 +329,9 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		Int64("usage.output_tokens", int64(out)).
 		Int64("usage.cache_creation_input_tokens", int64(cacheCreation)).
 		Int64("usage.cache_read_input_tokens", int64(cacheRead)).
-		Float64("cost.requested_input_usd", catalog.EffectiveInputCost(in, cacheCreation, cacheRead, reqPricing, decision.Provider)).
+		Float64("cost.requested_input_usd", catalog.EffectiveInputCost(in, cacheCreation, cacheCreation1h, cacheRead, reqPricing, decision.Provider)).
 		Float64("cost.requested_output_usd", catalog.EffectiveOutputCost(in, out, reqPricing)).
-		Float64("cost.actual_input_usd", catalog.EffectiveInputCost(in, cacheCreation, cacheRead, actPricing, decision.Provider)).
+		Float64("cost.actual_input_usd", catalog.EffectiveInputCost(in, cacheCreation, cacheCreation1h, cacheRead, actPricing, decision.Provider)).
 		Float64("cost.actual_output_usd", catalog.EffectiveOutputCost(in, out, actPricing)).
 		Bool("cost.subscription_served", servedOnSubscription(ctx)).
 		Int64("latency.upstream_ms", proxyMs).
@@ -356,7 +357,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	s.recordTurnUsage(routeRes, finalProvider, decision.ServedIdentity(), in, out, cacheCreation, cacheRead)
 
 	if proxyErr == nil {
-		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
+		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheCreation1h, cacheRead)
 		if compRes.Summarized {
 			s.billCompactionSummary(ctx, requestID, externalID, compRes.SummaryUsage)
 		}
@@ -367,6 +368,6 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	s.maybeDisableProviderAfterOverload(ctx, stickyHit, proxyErr, finalProvider, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes), routeRes.PinRole)
 
 	log.Info("ProxyGeminiGenerateContent complete", append([]any{"requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "embedded_tokens", len(promptText) / 4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr)}, plannerLogFields(routeRes)...)...)
-	s.reportPolicyOutcome(ctx, routeRes, decision, effortServed, decision.Provider, false, feats.Tokens, in, out, cacheCreation, cacheRead, routeMs, proxyMs, proxyErr, nil)
+	s.reportPolicyOutcome(ctx, routeRes, decision, effortServed, decision.Provider, false, feats.Tokens, in, out, cacheCreation, cacheCreation1h, cacheRead, routeMs, proxyMs, proxyErr, nil)
 	return proxyErr
 }

--- a/internal/proxy/handover.go
+++ b/internal/proxy/handover.go
@@ -227,10 +227,11 @@ func extractAnthropicUsage(body []byte) handover.Usage {
 		return handover.Usage{}
 	}
 	return handover.Usage{
-		InputTokens:   int(usage.Get("input_tokens").Int()),
-		OutputTokens:  int(usage.Get("output_tokens").Int()),
-		CacheCreation: int(usage.Get("cache_creation_input_tokens").Int()),
-		CacheRead:     int(usage.Get("cache_read_input_tokens").Int()),
+		InputTokens:     int(usage.Get("input_tokens").Int()),
+		OutputTokens:    int(usage.Get("output_tokens").Int()),
+		CacheCreation:   int(usage.Get("cache_creation_input_tokens").Int()),
+		CacheCreation1h: int(usage.Get("cache_creation.ephemeral_1h_input_tokens").Int()),
+		CacheRead:       int(usage.Get("cache_read_input_tokens").Int()),
 	}
 }
 

--- a/internal/proxy/hmm_outcome_internal_test.go
+++ b/internal/proxy/hmm_outcome_internal_test.go
@@ -61,13 +61,13 @@ func TestReportPolicyOutcome_UsesFreshMetadataForStickyServedDecision(t *testing
 		inputTokens  = 90
 		outputTokens = 10
 	)
-	s.reportPolicyOutcome(ctx, routeRes, served, effortResolution{}, providers.ProviderAnthropic, false, 100, inputTokens, outputTokens, 0, 0, 12, 34, nil, &policyOutcomeResponse{
+	s.reportPolicyOutcome(ctx, routeRes, served, effortResolution{}, providers.ProviderAnthropic, false, 100, inputTokens, outputTokens, 0, 0, 0, 12, 34, nil, &policyOutcomeResponse{
 		Body: []byte(`{"content":[{"type":"text","text":"done"}]}`),
 	})
 
 	price, ok := catalog.PriceFor(providers.ProviderAnthropic, "claude-haiku-4-5")
 	require.True(t, ok)
-	wantCost := catalog.EffectiveInputCost(inputTokens, 0, 0, price, providers.ProviderAnthropic) +
+	wantCost := catalog.EffectiveInputCost(inputTokens, 0, 0, 0, price, providers.ProviderAnthropic) +
 		catalog.EffectiveOutputCost(inputTokens, outputTokens, price)
 
 	select {
@@ -107,7 +107,7 @@ func TestReportPolicyOutcome_OmitsResponseBodyWhenTrainingIsNotAllowed(t *testin
 		Metadata: &router.RoutingMetadata{RouteID: "route-1", Strategy: string(router.StrategyHMM)},
 	}}
 
-	s.reportPolicyOutcome(context.Background(), routeRes, routeRes.Fresh, effortResolution{}, providers.ProviderFireworks, false, 1, 1, 1, 0, 0, 1, 1, nil, &policyOutcomeResponse{Body: []byte("private response")})
+	s.reportPolicyOutcome(context.Background(), routeRes, routeRes.Fresh, effortResolution{}, providers.ProviderFireworks, false, 1, 1, 1, 0, 0, 0, 1, 1, nil, &policyOutcomeResponse{Body: []byte("private response")})
 
 	select {
 	case payload := <-reporter.ch:
@@ -151,6 +151,7 @@ func TestReportPolicyOutcome_AuthoritativeMismatchFailsClosedForTraining(t *test
 		100,
 		90,
 		10,
+		0,
 		0,
 		0,
 		12,
@@ -199,7 +200,7 @@ func TestReportPolicyOutcome_EffortMismatchExcludedFromTraining(t *testing.T) {
 		decision,
 		effort,
 		providers.ProviderOpenAI,
-		false, 100, 90, 10, 0, 0, 12, 34, nil,
+		false, 100, 90, 10, 0, 0, 0, 12, 34, nil,
 		&policyOutcomeResponse{Body: []byte("must not train")},
 	)
 

--- a/internal/proxy/openai_responses_pipeline_test.go
+++ b/internal/proxy/openai_responses_pipeline_test.go
@@ -129,7 +129,7 @@ func TestService_ProxyOpenAIChatCompletion_ResponsesUsageDebitsBilling(t *testin
 	price, ok := catalog.PriceFor(providers.ProviderOpenAI, "gpt-5.6-luna")
 	require.True(t, ok)
 	want := catalog.USDToMicros(
-		catalog.EffectiveInputCost(40, 0, 32, price, providers.ProviderOpenAI) +
+		catalog.EffectiveInputCost(40, 0, 0, 32, price, providers.ProviderOpenAI) +
 			catalog.EffectiveOutputCost(40, 6, price))
 
 	debits := repo.recordedDebits()

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -4285,8 +4285,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	in, out := extractor.Tokens()
 	cacheCreation, cacheRead := extractor.CacheTokens()
+	cacheCreation1h := extractor.CacheCreation1hTokens()
 	if responseBuffer != nil && proxyErr == nil {
-		setRouterCostHeaders(w.Header(), routerResponseCostFromPricing(actPricing, decision.Provider, in, out, cacheCreation, cacheRead))
+		setRouterCostHeaders(w.Header(), routerResponseCostFromPricing(actPricing, decision.Provider, in, out, cacheCreation, cacheRead, cacheCreation1h))
 	}
 	upstreamBuilder := otel.NewAttrBuilder(40).
 		String("request_id", requestID).
@@ -4310,9 +4311,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		Int64("usage.output_tokens", int64(out)).
 		Int64("usage.cache_creation_input_tokens", int64(cacheCreation)).
 		Int64("usage.cache_read_input_tokens", int64(cacheRead)).
-		Float64("cost.requested_input_usd", catalog.EffectiveInputCost(in, cacheCreation, cacheRead, reqPricing, decision.Provider)).
+		Float64("cost.requested_input_usd", catalog.EffectiveInputCost(in, cacheCreation, cacheCreation1h, cacheRead, reqPricing, decision.Provider)).
 		Float64("cost.requested_output_usd", catalog.EffectiveOutputCost(in, out, reqPricing)).
-		Float64("cost.actual_input_usd", catalog.EffectiveInputCost(in, cacheCreation, cacheRead, actPricing, decision.Provider)).
+		Float64("cost.actual_input_usd", catalog.EffectiveInputCost(in, cacheCreation, cacheCreation1h, cacheRead, actPricing, decision.Provider)).
 		Float64("cost.actual_output_usd", catalog.EffectiveOutputCost(in, out, actPricing)).
 		Bool("cost.subscription_served", servedOnSubscription(ctx)).
 		Bool("cost.fast_mode", fastServed).
@@ -4393,9 +4394,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			EmbedInput:             embedInput,
 			InputTokens:            int32(in),
 			OutputTokens:           int32(out),
-			RequestedInputCostUSD:  catalog.EffectiveInputCost(in, cacheCreation, cacheRead, reqPricing, decision.Provider),
+			RequestedInputCostUSD:  catalog.EffectiveInputCost(in, cacheCreation, cacheCreation1h, cacheRead, reqPricing, decision.Provider),
 			RequestedOutputCostUSD: catalog.EffectiveOutputCost(in, out, reqPricing),
-			ActualInputCostUSD:     catalog.EffectiveInputCost(in, cacheCreation, cacheRead, actPricing, decision.Provider),
+			ActualInputCostUSD:     catalog.EffectiveInputCost(in, cacheCreation, cacheCreation1h, cacheRead, actPricing, decision.Provider),
 			ActualOutputCostUSD:    catalog.EffectiveOutputCost(in, out, actPricing),
 			RouteLatencyMs:         routeMs,
 			UpstreamLatencyMs:      proxyMs,
@@ -4477,7 +4478,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// No-op when billing is unwired (selfhosted); only reached on a real
 	// upstream call since the cache-hit branch above already returned.
 	if proxyErr == nil && !agentShadowMode {
-		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
+		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheCreation1h, cacheRead)
 		if compRes.Summarized {
 			s.billCompactionSummary(ctx, requestID, externalID, compRes.SummaryUsage)
 		}
@@ -4531,7 +4532,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		policyResp = &policyOutcomeResponse{Body: policyRespBody, Truncated: policyRespTrunc}
 	}
 	if !agentShadowMode {
-		s.reportPolicyOutcome(ctx, routeRes, decision, effortServed, finalProvider, fastServed, feats.Tokens, in, out, cacheCreation, cacheRead, routeMs, proxyMs, proxyErr, policyResp)
+		s.reportPolicyOutcome(ctx, routeRes, decision, effortServed, finalProvider, fastServed, feats.Tokens, in, out, cacheCreation, cacheCreation1h, cacheRead, routeMs, proxyMs, proxyErr, policyResp)
 	}
 	return proxyErr
 }
@@ -4849,7 +4850,7 @@ func (s *Service) capturePolicyOutcomeResponse(ctx context.Context, w http.Respo
 	return capture, capture
 }
 
-func (s *Service) reportPolicyOutcome(ctx context.Context, res turnLoopResult, decision router.Decision, effort effortResolution, finalProvider string, servedFast bool, estimatedInputTokens, inputTokens, outputTokens, cacheCreation, cacheRead int, routeMs, proxyMs int64, proxyErr error, response *policyOutcomeResponse) {
+func (s *Service) reportPolicyOutcome(ctx context.Context, res turnLoopResult, decision router.Decision, effort effortResolution, finalProvider string, servedFast bool, estimatedInputTokens, inputTokens, outputTokens, cacheCreation, cacheCreation1h, cacheRead int, routeMs, proxyMs int64, proxyErr error, response *policyOutcomeResponse) {
 	routeDecision, routeMetadata, reporter, ok := s.policyOutcomeRoute(res, decision)
 	if !ok {
 		return
@@ -4941,7 +4942,7 @@ func (s *Service) reportPolicyOutcome(ctx context.Context, res turnLoopResult, d
 		payload["error"] = proxyErr.Error()
 	}
 	if price, ok := servedPricing(finalProvider, decision.Model, servedFast); ok {
-		inputCost := catalog.EffectiveInputCost(inputTokens, cacheCreation, cacheRead, price, finalProvider)
+		inputCost := catalog.EffectiveInputCost(inputTokens, cacheCreation, cacheCreation1h, cacheRead, price, finalProvider)
 		outputCost := catalog.EffectiveOutputCost(inputTokens, outputTokens, price)
 		payload["cost_usd"] = inputCost + outputCost
 	}
@@ -5549,7 +5550,7 @@ func (s *Service) fireTelemetry(p InsertTelemetryParams) {
 // (`_summary` request_id suffix). No-op when billing is unwired or
 // externalID is empty. Unknown summarizer model prices as zero rather than
 // skipping the ledger row, keeping the audit trail complete.
-func (s *Service) emitBilling(ctx context.Context, requestID, externalID string, decision router.Decision, actPricing catalog.Pricing, routeRes turnLoopResult, in, out, cacheCreation, cacheRead int) {
+func (s *Service) emitBilling(ctx context.Context, requestID, externalID string, decision router.Decision, actPricing catalog.Pricing, routeRes turnLoopResult, in, out, cacheCreation, cacheCreation1h, cacheRead int) {
 	if s.billing == nil || externalID == "" {
 		return
 	}
@@ -5563,6 +5564,7 @@ func (s *Service) emitBilling(ctx context.Context, requestID, externalID string,
 		InputTokens:        in,
 		OutputTokens:       out,
 		CacheCreation:      cacheCreation,
+		CacheCreation1h:    cacheCreation1h,
 		CacheRead:          cacheRead,
 		Pricing:            actPricing,
 		HasOverride:        hasOverride,
@@ -6603,8 +6605,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	in, out := extractor.Tokens()
 	cacheCreation, cacheRead := extractor.CacheTokens()
+	cacheCreation1h := extractor.CacheCreation1hTokens()
 	if !env.Stream() && proxyErr == nil {
-		setRouterCostHeaders(w.Header(), routerResponseCostFromPricing(actPricing, decision.Provider, in, out, cacheCreation, cacheRead))
+		setRouterCostHeaders(w.Header(), routerResponseCostFromPricing(actPricing, decision.Provider, in, out, cacheCreation, cacheRead, cacheCreation1h))
 	}
 	openaiUpstreamBuilder := otel.NewAttrBuilder(40).
 		String("request_id", requestID).
@@ -6626,9 +6629,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		Int64("usage.output_tokens", int64(out)).
 		Int64("usage.cache_creation_input_tokens", int64(cacheCreation)).
 		Int64("usage.cache_read_input_tokens", int64(cacheRead)).
-		Float64("cost.requested_input_usd", catalog.EffectiveInputCost(in, cacheCreation, cacheRead, reqPricing, decision.Provider)).
+		Float64("cost.requested_input_usd", catalog.EffectiveInputCost(in, cacheCreation, cacheCreation1h, cacheRead, reqPricing, decision.Provider)).
 		Float64("cost.requested_output_usd", catalog.EffectiveOutputCost(in, out, reqPricing)).
-		Float64("cost.actual_input_usd", catalog.EffectiveInputCost(in, cacheCreation, cacheRead, actPricing, decision.Provider)).
+		Float64("cost.actual_input_usd", catalog.EffectiveInputCost(in, cacheCreation, cacheCreation1h, cacheRead, actPricing, decision.Provider)).
 		Float64("cost.actual_output_usd", catalog.EffectiveOutputCost(in, out, actPricing)).
 		Bool("cost.subscription_served", servedOnSubscription(ctx)).
 		Bool("cost.fast_mode", fastServed).
@@ -6678,7 +6681,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	s.recordTurnUsage(routeRes, finalProvider, decision.ServedIdentity(), in, out, cacheCreation, cacheRead)
 
 	if proxyErr == nil {
-		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
+		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheCreation1h, cacheRead)
 		if compResOAI.Summarized {
 			s.billCompactionSummary(ctx, requestID, externalID, compResOAI.SummaryUsage)
 		}
@@ -6710,9 +6713,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			EmbedInput:             embedInput,
 			InputTokens:            int32(in),
 			OutputTokens:           int32(out),
-			RequestedInputCostUSD:  catalog.EffectiveInputCost(in, cacheCreation, cacheRead, reqPricing, decision.Provider),
+			RequestedInputCostUSD:  catalog.EffectiveInputCost(in, cacheCreation, cacheCreation1h, cacheRead, reqPricing, decision.Provider),
 			RequestedOutputCostUSD: catalog.EffectiveOutputCost(in, out, reqPricing),
-			ActualInputCostUSD:     catalog.EffectiveInputCost(in, cacheCreation, cacheRead, actPricing, decision.Provider),
+			ActualInputCostUSD:     catalog.EffectiveInputCost(in, cacheCreation, cacheCreation1h, cacheRead, actPricing, decision.Provider),
 			ActualOutputCostUSD:    catalog.EffectiveOutputCost(in, out, actPricing),
 			RouteLatencyMs:         routeMs,
 			UpstreamLatencyMs:      proxyMs,
@@ -6783,7 +6786,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	}
 
 	log.Info("ProxyOpenAIChatCompletion complete", append([]any{"requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "primary_model", primaryModel, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "embedded_tokens", len(promptText) / 4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_err_body", providers.UpstreamErrorBodyMessage(proxyErr), "upstream_status", upstreamStatus(proxyErr), "upstream_finish_reason", respSummary.UpstreamFinishReason, "resp_stop_reason", respSummary.StopReason, "routing_marker", marker, "prior_served_model", routeRes.PriorServedModel, "hard_pinned", routeRes.HardPinned}, plannerLogFields(routeRes)...)...)
-	s.reportPolicyOutcome(ctx, routeRes, decision, effortServed, finalProvider, fastServed, feats.Tokens, in, out, cacheCreation, cacheRead, routeMs, proxyMs, proxyErr, nil)
+	s.reportPolicyOutcome(ctx, routeRes, decision, effortServed, finalProvider, fastServed, feats.Tokens, in, out, cacheCreation, cacheCreation1h, cacheRead, routeMs, proxyMs, proxyErr, nil)
 
 	// Subscription-only mode disables paid failover by pinning dispatch to the
 	// single subscription binding above, so a dispatch failure here is the

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -357,11 +357,12 @@ func (s *Service) bypassToAnthropic(
 	// actual to $0 downstream when cost.subscription_served is set.
 	in, out := extractor.Tokens()
 	cacheCreation, cacheRead := extractor.CacheTokens()
+	cacheCreation1h := extractor.CacheCreation1hTokens()
 	pricing, _ := servedPricing(decision.Provider, decision.Model, opts.FastMode)
 	if !env.Stream() && proxyErr == nil {
-		setRouterCostHeaders(w.Header(), routerResponseCostFromPricing(pricing, decision.Provider, in, out, cacheCreation, cacheRead))
+		setRouterCostHeaders(w.Header(), routerResponseCostFromPricing(pricing, decision.Provider, in, out, cacheCreation, cacheRead, cacheCreation1h))
 	}
-	inputCost := catalog.EffectiveInputCost(in, cacheCreation, cacheRead, pricing, decision.Provider)
+	inputCost := catalog.EffectiveInputCost(in, cacheCreation, cacheCreation1h, cacheRead, pricing, decision.Provider)
 	outputCost := catalog.EffectiveOutputCost(in, out, pricing)
 
 	// Same identity block as the routed upstream span so Weave groups bypass turns by user/session.

--- a/internal/proxy/usage_bypass_internal_test.go
+++ b/internal/proxy/usage_bypass_internal_test.go
@@ -347,7 +347,7 @@ func TestBypass_NonStreamResponseIncludesCostHeaders(t *testing.T) {
 
 	pricing, ok := catalog.PriceFor(providers.ProviderAnthropic, feats.Model)
 	require.True(t, ok, "test model must have catalog pricing")
-	want := routerResponseCostFromPricing(pricing, providers.ProviderAnthropic, inputTokens, outputTokens, 0, 0)
+	want := routerResponseCostFromPricing(pricing, providers.ProviderAnthropic, inputTokens, outputTokens, 0, 0, 0)
 	assert.Equal(t, strconv.FormatFloat(want.TotalUSD, 'f', -1, 64), rec.Header().Get(HeaderRouterCostUSD))
 	assert.Equal(t, strconv.FormatFloat(want.InputUSD, 'f', -1, 64), rec.Header().Get(HeaderRouterCostInputUSD))
 	assert.Equal(t, strconv.FormatFloat(want.OutputUSD, 'f', -1, 64), rec.Header().Get(HeaderRouterCostOutputUSD))
@@ -582,7 +582,7 @@ func TestBypass_EmitsUsageAndCost(t *testing.T) {
 	pricing, ok := catalog.PriceFor(providers.ProviderAnthropic, model)
 	require.True(t, ok, "test model must have catalog pricing")
 	wantOut := catalog.EffectiveOutputCost(inputTokens, outputTokens, pricing)
-	wantIn := catalog.EffectiveInputCost(inputTokens, 0, 0, pricing, providers.ProviderAnthropic)
+	wantIn := catalog.EffectiveInputCost(inputTokens, 0, 0, 0, pricing, providers.ProviderAnthropic)
 
 	// Bypass never substitutes the model, so requested == actual on the span;
 	// Weave zeroes actual downstream when subscription_served is set.

--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -40,9 +40,14 @@ func (t Tier) String() string {
 type Pricing struct {
 	InputUSDPer1M  float64
 	OutputUSDPer1M float64
-	// CacheWriteMultiplier is the cache-creation price relative to base input price.
-	// Zero means unspecified — existing production pricing is preserved.
+	// CacheWriteMultiplier is the cache-creation price relative to base input price
+	// for 5-minute writes. Zero means unspecified — existing production pricing is
+	// preserved.
 	CacheWriteMultiplier float64
+	// CacheWriteMultiplier1h is the cache-creation price relative to base input
+	// price for 1-hour writes (Anthropic's ttl "1h" tier). Zero means
+	// "unspecified — use DefaultCacheWriteMultiplier1h".
+	CacheWriteMultiplier1h float64
 	// CacheReadMultiplier is the cost of a cache hit relative to the base
 	// input price (e.g. 0.10 for Anthropic, 0.50 for OpenAI). Zero means
 	// "unspecified — use DefaultCacheReadMultiplier".
@@ -54,11 +59,12 @@ type Pricing struct {
 
 // LongContextPricing holds alternate rates for a provider's long-context tier.
 type LongContextPricing struct {
-	ThresholdTokens      int
-	InputUSDPer1M        float64
-	OutputUSDPer1M       float64
-	CacheWriteMultiplier float64
-	CacheReadMultiplier  float64
+	ThresholdTokens        int
+	InputUSDPer1M          float64
+	OutputUSDPer1M         float64
+	CacheWriteMultiplier   float64
+	CacheWriteMultiplier1h float64
+	CacheReadMultiplier    float64
 }
 
 // DefaultCacheReadMultiplier is the fallback multiplier for bindings
@@ -69,6 +75,11 @@ const DefaultCacheReadMultiplier = 0.5
 // DefaultCacheWriteMultiplier preserves the legacy production cache-creation
 // calculation until provider/model/retention-specific data is verified.
 const DefaultCacheWriteMultiplier = 1.25
+
+// DefaultCacheWriteMultiplier1h is Anthropic's published 1-hour cache-write
+// price. Like the 5-minute default it applies only where the binding does not
+// carry its own value.
+const DefaultCacheWriteMultiplier1h = 2.0
 
 // EffectiveCacheReadMultiplier returns CacheReadMultiplier if set, else
 // DefaultCacheReadMultiplier.
@@ -88,6 +99,15 @@ func (p Pricing) EffectiveCacheWriteMultiplier() float64 {
 	return DefaultCacheWriteMultiplier
 }
 
+// EffectiveCacheWriteMultiplier1h returns the binding-specific 1-hour
+// cache-write multiplier when known, otherwise Anthropic's published rate.
+func (p Pricing) EffectiveCacheWriteMultiplier1h() float64 {
+	if p.CacheWriteMultiplier1h > 0 {
+		return p.CacheWriteMultiplier1h
+	}
+	return DefaultCacheWriteMultiplier1h
+}
+
 // ForInputTokens returns the applicable pricing tier for a provider-reported
 // prompt token count.
 func (p Pricing) ForInputTokens(inputTokens int) Pricing {
@@ -96,10 +116,11 @@ func (p Pricing) ForInputTokens(inputTokens int) Pricing {
 	}
 	long := p.LongContext
 	return Pricing{
-		InputUSDPer1M:        long.InputUSDPer1M,
-		OutputUSDPer1M:       long.OutputUSDPer1M,
-		CacheWriteMultiplier: long.CacheWriteMultiplier,
-		CacheReadMultiplier:  long.CacheReadMultiplier,
+		InputUSDPer1M:          long.InputUSDPer1M,
+		OutputUSDPer1M:         long.OutputUSDPer1M,
+		CacheWriteMultiplier:   long.CacheWriteMultiplier,
+		CacheWriteMultiplier1h: long.CacheWriteMultiplier1h,
+		CacheReadMultiplier:    long.CacheReadMultiplier,
 	}
 }
 

--- a/internal/router/catalog/catalog_test.go
+++ b/internal/router/catalog/catalog_test.go
@@ -529,8 +529,8 @@ func TestAnthropicGatewayPricesCacheReadsLikeDirectAnthropic(t *testing.T) {
 
 			assert.InDelta(t, 0.10, gateway.CacheReadMultiplier, 1e-9)
 			assert.InDelta(t,
-				EffectiveInputCost(0, 0, 1_000_000, direct, providers.ProviderAnthropic),
-				EffectiveInputCost(0, 0, 1_000_000, gateway, providers.ProviderAnthropicGateway),
+				EffectiveInputCost(0, 0, 0, 1_000_000, direct, providers.ProviderAnthropic),
+				EffectiveInputCost(0, 0, 0, 1_000_000, gateway, providers.ProviderAnthropicGateway),
 				1e-9,
 			)
 		})

--- a/internal/router/catalog/cost.go
+++ b/internal/router/catalog/cost.go
@@ -7,15 +7,18 @@ import (
 )
 
 // EffectiveInputCost returns the true USD input cost after applying cache
-// pricing. Fresh tokens at base rate; cache-creation at the binding's
-// effective write multiplier; cache-read at the binding's effective read
-// multiplier. upstreamProvider distinguishes
-// Anthropic (input_tokens is fresh-only) from OpenAI / Gemini
-// (prompt_tokens includes cached tokens — must subtract).
+// pricing. Fresh tokens at base rate; 5-minute cache-creation at the binding's
+// effective write multiplier; 1-hour cache-creation (Anthropic's ttl "1h"
+// tier) at the binding's effective 1-hour write multiplier; cache-read at the
+// binding's effective read multiplier. cacheCreation1h is the portion of
+// cacheCreation written on the 1-hour tier; 0 prices every write at the
+// 5-minute rate, preserving aggregate-only payloads (Bedrock/Vertex).
+// upstreamProvider distinguishes Anthropic (input_tokens is fresh-only) from
+// OpenAI / Gemini (prompt_tokens includes cached tokens — must subtract).
 //
 // Single source of truth for the proxy's OTel emitter, telemetry write
 // path, and the billing debit hook.
-func EffectiveInputCost(inputTokens, cacheCreation, cacheRead int, p Pricing, upstreamProvider string) float64 {
+func EffectiveInputCost(inputTokens, cacheCreation, cacheCreation1h, cacheRead int, p Pricing, upstreamProvider string) float64 {
 	p = p.ForInputTokens(inputTokens)
 	fresh := inputTokens
 	if upstreamProvider != providers.ProviderAnthropic {
@@ -24,8 +27,15 @@ func EffectiveInputCost(inputTokens, cacheCreation, cacheRead int, p Pricing, up
 	if fresh < 0 {
 		fresh = 0
 	}
+	if cacheCreation1h > cacheCreation {
+		// Inconsistent payload (1h breakdown above the aggregate) — never let
+		// the 5-minute remainder go negative and under-price the turn.
+		cacheCreation1h = cacheCreation
+	}
+	cacheCreation5m := cacheCreation - cacheCreation1h
 	return (float64(fresh) +
-		float64(cacheCreation)*p.EffectiveCacheWriteMultiplier() +
+		float64(cacheCreation5m)*p.EffectiveCacheWriteMultiplier() +
+		float64(cacheCreation1h)*p.EffectiveCacheWriteMultiplier1h() +
 		float64(cacheRead)*p.EffectiveCacheReadMultiplier()) / 1_000_000 * p.InputUSDPer1M
 }
 

--- a/internal/router/catalog/cost_test.go
+++ b/internal/router/catalog/cost_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"testing"
 
+	"weave-os/router/internal/providers"
 	"weave-os/router/internal/router/catalog"
 
 	"github.com/stretchr/testify/assert"
@@ -71,12 +72,51 @@ func TestUSDToMicros_RoundsHalfAwayFromZero(t *testing.T) {
 
 func TestEffectiveInputCost_UsesBindingCacheWritePrice(t *testing.T) {
 	price := catalog.Pricing{InputUSDPer1M: 2, CacheReadMultiplier: 0.5, CacheWriteMultiplier: 2}
-	got := catalog.EffectiveInputCost(100, 10, 20, price, "openai")
+	got := catalog.EffectiveInputCost(100, 10, 0, 20, price, "openai")
 	assert.InDelta(t, 0.0002, got, 1e-12)
 
 	price.CacheWriteMultiplier = 0
-	legacy := catalog.EffectiveInputCost(100, 10, 20, price, "openai")
+	legacy := catalog.EffectiveInputCost(100, 10, 0, 20, price, "openai")
 	assert.InDelta(t, 0.000185, legacy, 1e-12, "unspecified values preserve legacy 1.25x behavior")
+}
+
+// The 1-hour TTL tier (issue #867): Anthropic charges 2x base input for 1h
+// cache writes, not the 5-minute 1.25x the aggregate-only math applied.
+func TestEffectiveInputCost_OneHourCacheWrite(t *testing.T) {
+	// claude-opus-5's published rate, as in the issue's worked example.
+	opus := catalog.Pricing{InputUSDPer1M: 5, CacheReadMultiplier: 0.10}
+
+	// All 1M creation tokens on the 1h tier, 10 fresh: (10 + 1M*2) * 5/1M
+	// = $10.00005 — the issue's expected number, vs $6.25005 before.
+	got := catalog.EffectiveInputCost(10, 1_000_000, 1_000_000, 0, opus, providers.ProviderAnthropic)
+	assert.Equal(t, int64(10_000_050), catalog.USDToMicros(got))
+
+	// No TTL breakdown (Bedrock/Vertex aggregate-only): byte-identical legacy
+	// behavior — every write at 1.25x.
+	legacy := catalog.EffectiveInputCost(10, 1_000_000, 0, 0, opus, providers.ProviderAnthropic)
+	assert.Equal(t, int64(6_250_050), catalog.USDToMicros(legacy))
+
+	// Mixed tiers, as a real Claude Code session reports them.
+	mixed := catalog.EffectiveInputCost(2, 248, 100, 0, opus, providers.ProviderAnthropic)
+	wantMixed := (float64(2) + 148*1.25 + 100*2.0) / 1_000_000 * 5
+	assert.InDelta(t, wantMixed, mixed, 1e-15)
+
+	// Anthropic's documented web_search anomaly: aggregate above the split's
+	// sum — the unattributed remainder prices at the 5-minute rate, never 2x.
+	remainder := catalog.EffectiveInputCost(0, 1000, 100, 0, opus, providers.ProviderAnthropic)
+	wantRemainder := (900*1.25 + 100*2.0) / 1_000_000 * 5
+	assert.InDelta(t, wantRemainder, remainder, 1e-15)
+
+	// Inconsistent payload (1h above the aggregate) must not under-price via
+	// a negative 5-minute term; the 1h count clamps to the aggregate.
+	clamped := catalog.EffectiveInputCost(0, 80, 100, 0, opus, providers.ProviderAnthropic)
+	wantClamped := 80 * 2.0 / 1_000_000 * 5
+	assert.InDelta(t, wantClamped, clamped, 1e-15)
+
+	// A binding may carry its own 1h rate; zero inherits the default 2x.
+	custom := catalog.Pricing{InputUSDPer1M: 5, CacheWriteMultiplier1h: 3}
+	customGot := catalog.EffectiveInputCost(0, 100, 100, 0, custom, providers.ProviderAnthropic)
+	assert.InDelta(t, 100*3.0/1_000_000*5, customGot, 1e-15)
 }
 
 func TestEffectiveCost_SelectsLongContextTier(t *testing.T) {
@@ -94,12 +134,12 @@ func TestEffectiveCost_SelectsLongContextTier(t *testing.T) {
 		},
 	}
 
-	shortInput := catalog.EffectiveInputCost(100_000, 10_000, 80_000, price, "openai")
+	shortInput := catalog.EffectiveInputCost(100_000, 10_000, 0, 80_000, price, "openai")
 	shortOutput := catalog.EffectiveOutputCost(100_000, 1_000, price)
 	assert.InDelta(t, 0.0061, shortInput, 1e-12)
 	assert.InDelta(t, 0.0012, shortOutput, 1e-12)
 
-	longInput := catalog.EffectiveInputCost(300_000, 200_000, 90_000, price, "openai")
+	longInput := catalog.EffectiveInputCost(300_000, 200_000, 0, 90_000, price, "openai")
 	longOutput := catalog.EffectiveOutputCost(300_000, 1_000, price)
 	assert.InDelta(t, 0.1076, longInput, 1e-12)
 	assert.InDelta(t, 0.0018, longOutput, 1e-12)

--- a/internal/router/handover/summarizer.go
+++ b/internal/router/handover/summarizer.go
@@ -17,10 +17,11 @@ import (
 // bill the summary turn separately from the main inference debit. Zero
 // values mean usage wasn't reported.
 type Usage struct {
-	InputTokens   int
-	OutputTokens  int
-	CacheCreation int
-	CacheRead     int
+	InputTokens     int
+	OutputTokens    int
+	CacheCreation   int
+	CacheCreation1h int
+	CacheRead       int
 	// Model and Provider identify the upstream the summarizer dispatched
 	// to so the ledger row can record them. Empty means "not reported".
 	Model    string

--- a/internal/translate/cache_usage_test.go
+++ b/internal/translate/cache_usage_test.go
@@ -13,12 +13,14 @@ import (
 	"weave-os/router/internal/translate"
 )
 
-// fakeUsageSink records the last RecordUsage / RecordCacheUsage calls.
+// fakeUsageSink records the last RecordUsage / RecordCacheUsage /
+// RecordCacheCreation1hTokens calls.
 type fakeUsageSink struct {
-	input         int
-	output        int
-	cacheCreation int
-	cacheRead     int
+	input           int
+	output          int
+	cacheCreation   int
+	cacheCreation1h int
+	cacheRead       int
 }
 
 func (f *fakeUsageSink) RecordUsage(input, output int) {
@@ -31,6 +33,10 @@ func (f *fakeUsageSink) RecordCacheUsage(creation, read int) {
 	f.cacheRead = read
 }
 
+func (f *fakeUsageSink) RecordCacheCreation1hTokens(tokens int) {
+	f.cacheCreation1h = tokens
+}
+
 // Catches typos in the message_start cache_creation_input_tokens /
 // cache_read_input_tokens JSON paths.
 func TestSSETranslator_ForwardsAnthropicCacheTokens(t *testing.T) {
@@ -41,13 +47,14 @@ func TestSSETranslator_ForwardsAnthropicCacheTokens(t *testing.T) {
 	translator.Header().Set("Content-Type", "text/event-stream")
 	translator.WriteHeader(http.StatusOK)
 
-	event := "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-4-5\",\"usage\":{\"input_tokens\":150,\"output_tokens\":0,\"cache_creation_input_tokens\":512,\"cache_read_input_tokens\":2048}}}\n\n"
+	event := "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-4-5\",\"usage\":{\"input_tokens\":150,\"output_tokens\":0,\"cache_creation_input_tokens\":512,\"cache_read_input_tokens\":2048,\"cache_creation\":{\"ephemeral_5m_input_tokens\":412,\"ephemeral_1h_input_tokens\":100}}}}\n\n"
 	_, err := translator.Write([]byte(event))
 	require.NoError(t, err)
 
 	assert.Equal(t, 150, sink.input)
 	assert.Equal(t, 512, sink.cacheCreation)
 	assert.Equal(t, 2048, sink.cacheRead)
+	assert.Equal(t, 100, sink.cacheCreation1h, "message_start must forward the 1-hour TTL breakdown")
 }
 
 // Catches typos in the prompt_tokens_details.cached_tokens nested path that

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -132,6 +132,9 @@ func (t *SSETranslator) Finalize() error {
 				int(usage.Get("cache_creation_input_tokens").Int()),
 				int(usage.Get("cache_read_input_tokens").Int()),
 			)
+			t.usageSink.RecordCacheCreation1hTokens(
+				int(usage.Get("cache_creation.ephemeral_1h_input_tokens").Int()),
+			)
 		}
 	}
 
@@ -240,6 +243,9 @@ func (t *SSETranslator) handleMessageStart(data []byte) error {
 			t.usageSink.RecordCacheUsage(
 				int(usageResult.Get("cache_creation_input_tokens").Int()),
 				int(usageResult.Get("cache_read_input_tokens").Int()),
+			)
+			t.usageSink.RecordCacheCreation1hTokens(
+				int(usageResult.Get("cache_creation.ephemeral_1h_input_tokens").Int()),
 			)
 		}
 	}

--- a/internal/translate/usage_sink.go
+++ b/internal/translate/usage_sink.go
@@ -9,4 +9,8 @@ package translate
 type UsageSink interface {
 	RecordUsage(inputTokens, outputTokens int)
 	RecordCacheUsage(cacheCreationTokens, cacheReadTokens int)
+	// RecordCacheCreation1hTokens reports the 1-hour-tier portion of the
+	// cache-creation aggregate. Called only when the upstream emitted the
+	// TTL breakdown (usage.cache_creation); 0 means "all writes 5-minute".
+	RecordCacheCreation1hTokens(tokens int)
 }


### PR DESCRIPTION
## Summary

- Price Anthropic 1-hour cache writes at their 2x input rate while keeping 5-minute writes and aggregate-only payloads at 1.25x.
- Carry the reported 1-hour split through streaming and non-streaming cost calculation into billing debits.

## Why

The aggregate cache-creation count currently prices every write at the 5-minute rate, including the 1-hour tier.

## Verification

- Before, on current `main`: 10 fresh tokens plus 1M 1-hour cache writes at $5/M calculated to $6.250050 instead of $10.000050.
- After: `go test ./internal/router/catalog ./internal/observability/otel ./internal/translate ./internal/billing -count=1` and `go test ./internal/proxy -count=1` pass. The catalog test covers 1-hour, mixed-tier, aggregate-only, and inconsistent usage breakdowns.

Fixes #867
