### PR TITLE
Don't include model choice in Codex title gen requests

### DIFF
--- a/internal/proxy/codex_title_gen_internal_test.go
+++ b/internal/proxy/codex_title_gen_internal_test.go
@@ -1,0 +1,69 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"weave-os/router/internal/providers"
+	"weave-os/router/internal/router"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type codexTitleRouter struct {
+	routeCalls int
+}
+
+func (r *codexTitleRouter) Route(context.Context, router.Request) (router.Decision, error) {
+	r.routeCalls++
+	return router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-5.6-sol", Reason: "scored"}, nil
+}
+
+type codexTitleProvider struct {
+	endpoints []providers.Endpoint
+}
+
+func (p *codexTitleProvider) Proxy(_ context.Context, _ router.Decision, prep providers.PreparedRequest, w http.ResponseWriter, _ *http.Request) error {
+	p.endpoints = append(p.endpoints, prep.Endpoint)
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"id":"resp_1","object":"response","output":[]}`))
+	return nil
+}
+
+func (p *codexTitleProvider) Passthrough(context.Context, providers.PreparedRequest, http.ResponseWriter, *http.Request) error {
+	return providers.ErrNotImplemented
+}
+
+func TestCodexResponsesTitleGenerationHardPinsWithoutScoring(t *testing.T) {
+	routerSpy := &codexTitleRouter{}
+	provider := &codexTitleProvider{}
+	svc := NewService(
+		routerSpy,
+		map[string]providers.Client{providers.ProviderOpenAI: provider},
+		nil, false, nil, nil, false,
+		providers.ProviderOpenAI, "gpt-5.6-luna", nil,
+	)
+	body := []byte(`{
+		"model":"gpt-5.6-sol",
+		"stream":true,
+		"tools":[{"type":"function","name":"shell","parameters":{"type":"object"}}],
+		"text":{"format":{"type":"json_schema","schema":{
+			"type":"object",
+			"properties":{"title":{"type":"string"}},
+			"required":["title"],
+			"additionalProperties":false
+		}}},
+		"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"Generate a concise task title."}]}]
+	}`)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	ctx := context.WithValue(context.Background(), ClientIdentityContextKey{}, ClientIdentity{ClientApp: ClientAppCodex})
+
+	require.NoError(t, svc.ProxyOpenAIResponses(ctx, body, rec, req))
+	require.Len(t, provider.endpoints, 1)
+	require.Zero(t, routerSpy.routeCalls, "Codex title generation must use the hard-pin path")
+	assert.NotContains(t, rec.Body.String(), "Weave Router", "hard-pinned title responses must not carry a routing marker")
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -454,6 +454,12 @@ type codexFeedbackSkillContextKey struct{}
 // already carries a rating hint after the last human turn.
 type responsesFooterEchoedContextKey struct{}
 
+// codexTitleGenerationContextKey carries the native Responses title shape
+// into the shared Chat Completions turn loop. It is set only after the request
+// is identified as coming from Codex, so other clients' structured outputs are
+// unaffected.
+type codexTitleGenerationContextKey struct{}
+
 // InstallationExcludedModelsContextKey is the context key for the authed
 // installation's model exclusion list. Carried as []string.
 type InstallationExcludedModelsContextKey struct{}
@@ -5758,7 +5764,11 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		log.Info("Stripped beta artifacts from OpenAI history", "removed_messages", removed)
 	}
 	embedFlag := s.ResolveEmbedOnlyUserMessage(ctx)
+	codexTitleGen, _ := ctx.Value(codexTitleGenerationContextKey{}).(bool)
 	feats := env.RoutingFeatures(embedFlag)
+	if codexTitleGen {
+		feats.TitleGenHint = true
+	}
 	promptText := feats.PromptText
 	embedInput := "concatenated_stream"
 	if embedFlag && feats.OnlyUserMessageText != "" {
@@ -5838,6 +5848,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	}
 	if requestBodyChanged {
 		feats = env.RoutingFeatures(embedFlag)
+		if codexTitleGen {
+			feats.TitleGenHint = true
+		}
 		promptText = feats.PromptText
 		embedInput = "concatenated_stream"
 		if embedFlag && feats.OnlyUserMessageText != "" {
@@ -5941,6 +5954,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		}
 		if compResOAI.Applied {
 			feats = env.RoutingFeatures(embedFlag)
+			if codexTitleGen {
+				feats.TitleGenHint = true
+			}
 			log.Info("Proactive compaction applied",
 				"tool_results_cleared", compResOAI.ToolResultsCleared,
 				"summarized", compResOAI.Summarized,
@@ -6870,6 +6886,9 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 		ctx = context.WithValue(ctx, nativeResponsesToolHashContextKey{}, originalEnvelope.ToolConfigurationSHA256())
 	}
 	ctx = context.WithValue(ctx, responsesRequirementsContextKey{}, conversion.Requirements)
+	if clientAppCodex && conversion.TitleGeneration {
+		ctx = context.WithValue(ctx, codexTitleGenerationContextKey{}, true)
+	}
 	ctx = context.WithValue(ctx, responsesTransformsContextKey{}, conversion.Report)
 	// Routing, billing, and telemetry are reused via
 	// ProxyOpenAIChatCompletion; chatBody is used only for routing features.

--- a/internal/router/turntype/detect.go
+++ b/internal/router/turntype/detect.go
@@ -69,7 +69,7 @@ func DetectFromEnvelope(env *translate.RequestEnvelope, feats translate.RoutingF
 	if isProbe(feats) {
 		return Probe
 	}
-	if isTitleGen(env, feats.HasTools) {
+	if isTitleGen(env, feats.HasTools) || (feats.TitleGenHint && env.SourceFormat() == translate.FormatOpenAI) {
 		return TitleGen
 	}
 	systemText := env.SystemText()

--- a/internal/router/turntype/detect_test.go
+++ b/internal/router/turntype/detect_test.go
@@ -509,3 +509,19 @@ func TestDetectFromEnvelope_NilEnv(t *testing.T) {
 	got := turntype.DetectFromEnvelope(nil, translate.RoutingFeatures{}, "")
 	assert.Equal(t, turntype.MainLoop, got)
 }
+
+func TestDetectFromEnvelope_CodexTitleHintOverridesToolRegistry(t *testing.T) {
+	env, err := translate.ParseOpenAI([]byte(`{
+		"model":"gpt-5.6-sol",
+		"tools":[{"type":"function","function":{"name":"shell"}}],
+		"response_format":{"type":"json_schema","json_schema":{"schema":{"type":"object","properties":{"title":{"type":"string"}}}}},
+		"messages":[{"role":"user","content":"Generate a title"}]
+	}`))
+	require.NoError(t, err)
+	feats := env.RoutingFeatures(false)
+	assert.Equal(t, turntype.MainLoop, turntype.DetectFromEnvelope(env, feats, ""),
+		"a tool-bearing Chat Completions request remains a main loop without the Codex signal")
+	feats.TitleGenHint = true
+	assert.Equal(t, turntype.TitleGen, turntype.DetectFromEnvelope(env, feats, ""),
+		"the trusted native Codex shape must hard-pin even when the converted body carries tools")
+}

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -366,25 +366,56 @@ func (e *RequestEnvelope) HasImages() bool {
 }
 
 // RequestsTitleSchema reports whether the request asks for a JSON-schema response
-// with a top-level string "title" property. Used to identify Claude Code's
-// sidebar-title generation call without content-matching the system prompt.
+// with a top-level string "title" property. Used to identify client title
+// generation calls without content-matching the prompt.
 func (e *RequestEnvelope) RequestsTitleSchema() bool {
-	switch e.format {
+	return requestRootRequestsTitleSchema(gjson.ParseBytes(e.body), e.format)
+}
+
+func requestRootRequestsTitleSchema(root gjson.Result, format Format) bool {
+	switch format {
 	case FormatAnthropic:
-		fmtNode := gjson.GetBytes(e.body, "output_config.format")
-		if fmtNode.Get("type").String() != "json_schema" {
-			return false
-		}
-		return fmtNode.Get("schema.properties.title.type").String() == "string"
+		formatNode := root.Get("output_config.format")
+		return formatNode.Get("type").String() == "json_schema" &&
+			formatNode.Get("schema.properties.title.type").String() == "string"
 	case FormatOpenAI:
-		rf := gjson.GetBytes(e.body, "response_format")
-		if rf.Get("type").String() != "json_schema" {
-			return false
+		// Chat Completions uses response_format; Responses uses text.format.
+		if formatNode := root.Get("response_format"); formatNode.Exists() {
+			return formatNode.Get("type").String() == "json_schema" &&
+				formatNode.Get("json_schema.schema.properties.title.type").String() == "string"
 		}
-		return rf.Get("json_schema.schema.properties.title.type").String() == "string"
+		formatNode := root.Get("text.format")
+		return formatNode.Get("type").String() == "json_schema" &&
+			formatNode.Get("schema.properties.title.type").String() == "string"
 	default:
 		return false
 	}
+}
+
+func requestRootRequestsCodexTitleSchema(root gjson.Result) bool {
+	formatNode := root.Get("text.format")
+	if formatNode.Get("type").String() != "json_schema" {
+		return false
+	}
+	schema := formatNode.Get("schema")
+	if schema.Get("type").String() != "object" {
+		return false
+	}
+	properties := schema.Get("properties")
+	if !properties.IsObject() || len(properties.Map()) != 1 ||
+		properties.Get("title.type").String() != "string" {
+		return false
+	}
+	required := schema.Get("required")
+	if !required.IsArray() {
+		return false
+	}
+	requiredItems := required.Array()
+	if len(requiredItems) != 1 || requiredItems[0].String() != "title" {
+		return false
+	}
+	additionalProperties := schema.Get("additionalProperties")
+	return additionalProperties.Exists() && additionalProperties.Type == gjson.False
 }
 
 // EmitOverrides describes byte-level mutations for same-format serialization.

--- a/internal/translate/features.go
+++ b/internal/translate/features.go
@@ -42,6 +42,10 @@ type RoutingFeatures struct {
 	// MaxTokens is the caller's requested output cap. 0 means unset.
 	// Probe detection keys off this — Anthropic SDK quota probes set max_tokens=1.
 	MaxTokens int
+	// TitleGenHint marks a Codex Responses title-generation request. The
+	// Responses ingress sets this only for the Codex client after inspecting
+	// the native request shape; it is deliberately not inferred from prompt text.
+	TitleGenHint bool
 	// LastKind: "user_prompt", "tool_result", or "assistant".
 	LastKind string
 	// LastPreview: first previewMaxChars of the last message's text.

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -35,6 +35,10 @@ type ResponsesConversion struct {
 	Requirements       router.TranslationRequirements
 	Report             []ResponseTransform
 	ToolMappings       map[string]ResponsesToolMapping
+	// TitleGeneration reports the native Codex title-generation shape (a
+	// closed object containing only the required string title). It is consumed
+	// only when the proxy has independently identified the Codex client.
+	TitleGeneration bool
 }
 
 // ResponseTransform reports an ingress conversion outcome with a stable code.
@@ -103,6 +107,7 @@ func ConvertResponsesToChatCompletions(body []byte) (ResponsesConversion, error)
 	result.Requirements.Audio, result.Requirements.Files = openAIMediaRequirements(body)
 	result.Requirements.CitationsOrSearch = len(nativeServerToolsFromBody(body, FormatOpenAI)) > 0
 	result.Requirements.StructuredOutput = root.Get("text.format").Exists() || root.Get("response_format").Exists()
+	result.TitleGeneration = requestRootRequestsCodexTitleSchema(root)
 	out := map[string]any{}
 
 	model := root.Get("model").Str

--- a/internal/translate/responses_codex.go
+++ b/internal/translate/responses_codex.go
@@ -153,6 +153,7 @@ func convertPortableCodexResponses(body []byte) (ResponsesConversion, error) {
 		toolAliases:     make(map[responsesToolIdentity]string),
 		declaredAliases: make(map[string]struct{}),
 	}
+	converter.result.TitleGeneration = requestRootRequestsCodexTitleSchema(root)
 	converter.result.Requirements.Images = root.Get("input").Exists() && containsAnyKey(body, "image_url", "input_image")
 	converter.result.Requirements.Audio, converter.result.Requirements.Files = openAIMediaRequirements(body)
 	converter.result.Requirements.CitationsOrSearch = len(nativeServerToolsFromBody(body, FormatOpenAI)) > 0

--- a/internal/translate/responses_codex_test.go
+++ b/internal/translate/responses_codex_test.go
@@ -11,6 +11,40 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexTitleGenerationShape(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-5.6-sol",
+		"tools":[{"type":"function","name":"shell","parameters":{"type":"object"}}],
+		"text":{"format":{"type":"json_schema","schema":{
+			"type":"object","properties":{"title":{"type":"string"}},"required":["title"],"additionalProperties":false
+		}}},
+		"input":"Generate a concise task title."
+	}`)
+
+	converted, err := translate.ConvertResponsesToChatCompletionsWithOptions(body, translate.ResponsesConversionOptions{PortableCodex: true})
+	require.NoError(t, err)
+	assert.True(t, converted.TitleGeneration)
+	assert.True(t, converted.Requirements.FunctionTools)
+	assert.True(t, gjson.GetBytes(converted.Body, "tools").IsArray(), "routing projection must retain tool requirements")
+}
+
+func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexTitleShapeIsStrict(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-5.6-sol",
+		"text":{"format":{"type":"json_schema","schema":{
+			"type":"object",
+			"properties":{"title":{"type":"string"},"summary":{"type":"string"}},
+			"required":["title","summary"],
+			"additionalProperties":false
+		}}},
+		"input":"Return structured metadata."
+	}`)
+
+	converted, err := translate.ConvertResponsesToChatCompletionsWithOptions(body, translate.ResponsesConversionOptions{PortableCodex: true})
+	require.NoError(t, err)
+	assert.False(t, converted.TitleGeneration, "other structured-output objects must not be treated as hidden title calls")
+}
+
 func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexTools(t *testing.T) {
 	body := []byte(`{
 		"model":"gpt-5.6-sol",


### PR DESCRIPTION
## Summary

- Detect Codex workspace title-generation requests from their closed JSON schema, even when the request includes tools.
- Carry the hint through translation and proxy routing so these requests use the title-generation route and do not receive the routing marker banner.
- Add regression coverage for native and portable Codex paths.

## Tests

- `go test ./internal/router/turntype ./internal/translate ./internal/proxy -run 'Title|Responses' -count=1`\n- `go test ./...`