### PR TITLE
Add even more OTel spans

### DIFF
--- a/internal/observability/trace.go
+++ b/internal/observability/trace.go
@@ -15,6 +15,27 @@ const (
 	gcpSpanField  = "logging.googleapis.com/spanId"
 )
 
+type clientSessionIDContextKey struct{}
+
+// WithClientSessionID attaches the caller's session identifier to ctx for
+// request-scoped trace instrumentation.
+func WithClientSessionID(ctx context.Context, clientSessionID string) context.Context {
+	if clientSessionID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, clientSessionIDContextKey{}, clientSessionID)
+}
+
+// ClientSessionIDFromContext returns the client session identifier attached
+// for request-scoped trace instrumentation, or "" when none is known.
+func ClientSessionIDFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	clientSessionID, _ := ctx.Value(clientSessionIDContextKey{}).(string)
+	return clientSessionID
+}
+
 // LoggerWithTraceContext adds the active OpenTelemetry trace and span IDs to a
 // logger using the field names Cloud Logging recognizes for trace correlation.
 // When GCP_PROJECT_ID is set, the trace field is the fully-qualified resource

--- a/internal/observability/trace_test.go
+++ b/internal/observability/trace_test.go
@@ -43,6 +43,13 @@ func TestLoggerWithTraceContextUsesCloudLoggingFields(t *testing.T) {
 	assert.Equal(t, "0123456789abcdef", record["logging.googleapis.com/spanId"])
 }
 
+func TestClientSessionIDContextRoundTrip(t *testing.T) {
+	ctx := observability.WithClientSessionID(context.Background(), "client-session-abc")
+
+	assert.Equal(t, "client-session-abc", observability.ClientSessionIDFromContext(ctx))
+	assert.Empty(t, observability.ClientSessionIDFromContext(context.Background()))
+}
+
 func TestWrapHTTPClientPropagatesTraceContextWithoutBaggage(t *testing.T) {
 	previous := otel.GetTextMapPropagator()
 	t.Cleanup(func() { otel.SetTextMapPropagator(previous) })

--- a/internal/postgres/pgx_tracer.go
+++ b/internal/postgres/pgx_tracer.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"regexp"
 
+	"weave-os/router/internal/observability"
+
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -89,6 +91,9 @@ func (t *pgxTracer) TraceQueryStart(ctx context.Context, conn *pgx.Conn, data pg
 		dbPIDKey.Int(int(connectionPID(conn))),
 		semconv.DBQueryText(data.SQL),
 	}
+	if clientSessionID := observability.ClientSessionIDFromContext(ctx); clientSessionID != "" {
+		attrs = append(attrs, attribute.String("client.session_id", clientSessionID))
+	}
 	if metadata != nil {
 		attrs = append(attrs,
 			sqlcQueryNameKey.String(metadata.name),
@@ -122,11 +127,15 @@ func (t *pgxTracer) TraceAcquireStart(ctx context.Context, _ *pgxpool.Pool, _ pg
 	ctx, span := t.provider.Tracer(tracerName).Start(ctx, "pgxpool.acquire", trace.WithSpanKind(trace.SpanKindClient))
 	ctx = context.WithValue(ctx, acquireTraceKey{}, acquireTrace{span: span})
 	if span.IsRecording() {
-		span.SetAttributes(
+		attrs := []attribute.KeyValue{
 			semconv.DBSystemNamePostgreSQL,
 			semconv.DBNamespace(t.databaseName),
 			pgxPoolConnOperationKey.String("acquire"),
-		)
+		}
+		if clientSessionID := observability.ClientSessionIDFromContext(ctx); clientSessionID != "" {
+			attrs = append(attrs, attribute.String("client.session_id", clientSessionID))
+		}
+		span.SetAttributes(attrs...)
 	}
 	return ctx
 }

--- a/internal/postgres/pgx_tracer_test.go
+++ b/internal/postgres/pgx_tracer_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"weave-os/router/internal/observability"
+
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -30,6 +32,7 @@ func TestPGXTracerEmitsNamedSQLCQuerySpan(t *testing.T) {
 	require.NoError(t, err)
 
 	parentCtx, parent := provider.Tracer("test").Start(context.Background(), "request")
+	parentCtx = observability.WithClientSessionID(parentCtx, "client-session-abc")
 	queryCtx := tracer.TraceQueryStart(parentCtx, nil, pgx.TraceQueryStartData{
 		SQL:  "-- name: GetInstallation :one\nSELECT * FROM router.installations WHERE id = $1",
 		Args: []any{"installation-id"},
@@ -46,6 +49,7 @@ func TestPGXTracerEmitsNamedSQLCQuerySpan(t *testing.T) {
 	assert.Equal(t, "GetInstallation", spanAttribute(t, span.Attributes(), "sqlc.query.name").AsString())
 	assert.Equal(t, "one", spanAttribute(t, span.Attributes(), "sqlc.query.command").AsString())
 	assert.Equal(t, "GetInstallation", spanAttribute(t, span.Attributes(), "db.query.summary").AsString())
+	assert.Equal(t, "client-session-abc", spanAttribute(t, span.Attributes(), "client.session_id").AsString())
 	assert.False(t, hasSpanAttribute(span.Attributes(), "db.operation.name"))
 	assert.Equal(t, "SELECT 1", spanAttribute(t, span.Attributes(), "db.query.command.tag").AsString())
 	assert.Contains(t, spanAttribute(t, span.Attributes(), "db.query.text").AsString(), "router.installations")
@@ -78,6 +82,7 @@ func TestPGXTracerEmitsPoolAcquireSpan(t *testing.T) {
 	require.NoError(t, err)
 
 	parentCtx, parent := provider.Tracer("test").Start(context.Background(), "request")
+	parentCtx = observability.WithClientSessionID(parentCtx, "client-session-abc")
 	acquireCtx := tracer.TraceAcquireStart(parentCtx, nil, pgxpool.TraceAcquireStartData{})
 	tracer.TraceAcquireEnd(acquireCtx, nil, pgxpool.TraceAcquireEndData{})
 	parent.End()
@@ -86,6 +91,7 @@ func TestPGXTracerEmitsPoolAcquireSpan(t *testing.T) {
 	assert.Equal(t, trace.SpanKindClient, span.SpanKind())
 	assert.Equal(t, parent.SpanContext().SpanID(), span.Parent().SpanID())
 	assert.Equal(t, "acquire", spanAttribute(t, span.Attributes(), "pgx.pool.operation").AsString())
+	assert.Equal(t, "client-session-abc", spanAttribute(t, span.Attributes(), "client.session_id").AsString())
 	assert.Equal(t, int64(0), spanAttribute(t, span.Attributes(), "db.client.connection.pid").AsInt64())
 	assert.Equal(t, sdktrace.Status{Code: codes.Ok}, span.Status())
 }

--- a/internal/proxy/apm_spans.go
+++ b/internal/proxy/apm_spans.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 
+	"weave-os/router/internal/observability"
 	"weave-os/router/internal/router"
 
 	"go.opentelemetry.io/otel"
@@ -16,8 +17,10 @@ const proxyTracerName = "weave-os/router/internal/proxy"
 var proxyFlowTracer = otel.Tracer(proxyTracerName)
 
 func startRoutingSpan(ctx context.Context, req router.Request) (context.Context, trace.Span) {
+	ctx = observability.WithClientSessionID(ctx, req.ClientSessionID)
 	return proxyFlowTracer.Start(ctx, "router.routing",
 		trace.WithAttributes(
+			attribute.String("client.session_id", req.ClientSessionID),
 			attribute.String("requested.model", req.RequestedModel),
 			attribute.Int("request.estimated_input_tokens", req.EstimatedInputTokens),
 			attribute.Bool("request.has_tools", req.HasTools),
@@ -35,9 +38,11 @@ func finishRoutingSpan(span trace.Span, decision router.Decision, err error) {
 	finishFlowSpan(span, err)
 }
 
-func startInferenceSpan(ctx context.Context, decision router.Decision) (context.Context, trace.Span) {
+func startInferenceSpan(ctx context.Context, decision router.Decision, clientSessionID string) (context.Context, trace.Span) {
+	ctx = observability.WithClientSessionID(ctx, clientSessionID)
 	return proxyFlowTracer.Start(ctx, "router.inference",
 		trace.WithAttributes(
+			attribute.String("client.session_id", clientSessionID),
 			attribute.String("decision.model", decision.Model),
 			attribute.String("decision.provider", decision.Provider),
 			attribute.String("decision.reason", decision.Reason),

--- a/internal/proxy/apm_spans_internal_test.go
+++ b/internal/proxy/apm_spans_internal_test.go
@@ -74,6 +74,7 @@ func TestProxyMessagesEmitsHighLevelFlowSpans(t *testing.T) {
 	)
 
 	ctx, requestSpan := provider.Tracer("test").Start(context.Background(), "request")
+	ctx = context.WithValue(ctx, ClientIdentityContextKey{}, ClientIdentity{SessionID: "client-session-abc"})
 	body := []byte(`{"model":"claude-opus-4-8","max_tokens":4096,"tools":[{"name":"Read","input_schema":{"type":"object"}}],"messages":[{"role":"user","content":"inspect the repository"}]}`)
 	err := svc.ProxyMessages(ctx, body, httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/v1/messages", nil))
 	requestSpan.End()
@@ -87,6 +88,8 @@ func TestProxyMessagesEmitsHighLevelFlowSpans(t *testing.T) {
 	assert.Equal(t, inference.SpanContext().SpanID(), providerImpl.spanID)
 	assert.Equal(t, codes.Ok, routing.Status().Code)
 	assert.Equal(t, codes.Ok, inference.Status().Code)
+	assert.Equal(t, "client-session-abc", proxySpanAttribute(t, routing.Attributes(), "client.session_id").AsString())
+	assert.Equal(t, "client-session-abc", proxySpanAttribute(t, inference.Attributes(), "client.session_id").AsString())
 	assert.Equal(t, "claude-opus-4-8", proxySpanAttribute(t, routing.Attributes(), "requested.model").AsString())
 	assert.Equal(t, "claude-haiku-4-5", proxySpanAttribute(t, routing.Attributes(), "decision.model").AsString())
 	assert.Equal(t, providers.ProviderAnthropic, proxySpanAttribute(t, inference.Attributes(), "served.provider").AsString())

--- a/internal/proxy/client_identity.go
+++ b/internal/proxy/client_identity.go
@@ -82,6 +82,7 @@ func ResolveUserFromContext(ctx context.Context, authSvc *auth.Service, installa
 		return ctx
 	}
 	id := ClientIdentityFrom(ctx)
+	ctx = observability.WithClientSessionID(ctx, id.SessionID)
 	if id.Email == "" && id.AccountID == "" {
 		log.Info("ResolveUserFromContext bailout",
 			"reason", "no_identity_signal",

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -258,7 +258,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 
 	proxyStart := time.Now()
 	inferenceParentCtx := ctx
-	ctx, inferenceSpan := startInferenceSpan(ctx, decision)
+	ctx, inferenceSpan := startInferenceSpan(ctx, decision, clientSessionIDForRequest(ctx, env))
 	defer inferenceSpan.End()
 	var extractor *otel.UsageExtractor
 	// Append the one-click feedback thumbs as a trailing part on streaming

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3592,7 +3592,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	proxyStart := time.Now()
 	inferenceParentCtx := ctx
-	ctx, inferenceSpan := startInferenceSpan(ctx, decision)
+	ctx, inferenceSpan := startInferenceSpan(ctx, decision, clientSessionIDForRequest(ctx, env))
 	defer inferenceSpan.End()
 	var proxyErr error
 	crossFormat := false
@@ -6274,7 +6274,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	proxyStart := time.Now()
 	inferenceParentCtx := ctx
-	ctx, inferenceSpan := startInferenceSpan(ctx, decision)
+	ctx, inferenceSpan := startInferenceSpan(ctx, decision, clientSessionIDForRequest(ctx, env))
 	defer inferenceSpan.End()
 	var proxyErr error
 	crossFormat := false

--- a/internal/proxy/session_key.go
+++ b/internal/proxy/session_key.go
@@ -64,6 +64,7 @@ func bindRequestLogger(
 	apiKeyID, requestID, ingress string,
 ) (context.Context, *slog.Logger, [sessionpin.SessionKeyLen]byte) {
 	clientSessionID := clientSessionIDForRequest(ctx, env)
+	ctx = observability.WithClientSessionID(ctx, clientSessionID)
 	key := deriveSessionKey(env, apiKeyID, clientSessionID)
 	log := observability.FromContext(ctx).With(
 		"session_key", shortKey(key),

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -336,7 +336,7 @@ func (s *Service) bypassToAnthropic(
 
 	proxyStart := time.Now()
 	inferenceParentCtx := ctx
-	ctx, inferenceSpan := startInferenceSpan(ctx, decision)
+	ctx, inferenceSpan := startInferenceSpan(ctx, decision, clientSessionIDForRequest(ctx, env))
 	proxyErr := p.Proxy(ctx, decision, prep, respW, r)
 	finishInferenceSpan(inferenceSpan, decision, decision.Provider, 0, proxyErr)
 	ctx = restoreParentSpan(ctx, inferenceParentCtx)

--- a/internal/server/middleware/apm_spans.go
+++ b/internal/server/middleware/apm_spans.go
@@ -1,0 +1,95 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"weave-os/router/internal/observability"
+
+	"github.com/gin-gonic/gin"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const middlewareTracerName = "weave-os/router/internal/server/middleware"
+
+var middlewareFlowTracer = otel.Tracer(middlewareTracerName)
+
+type billingSpanState struct {
+	span   trace.Span
+	parent context.Context
+	ended  bool
+}
+
+type billingSpanContextKey struct{}
+
+func startAuthSpan(ctx context.Context, clientSessionID string) (context.Context, trace.Span) {
+	ctx = observability.WithClientSessionID(ctx, clientSessionID)
+	return middlewareFlowTracer.Start(ctx, "router.auth",
+		trace.WithAttributes(attribute.String("client.session_id", clientSessionID)),
+	)
+}
+
+func finishAuthSpan(span trace.Span, err error) {
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	} else {
+		span.SetStatus(codes.Ok, "")
+	}
+	span.End()
+}
+
+func startBillingSpan(ctx context.Context) (context.Context, *billingSpanState) {
+	clientSessionID := observability.ClientSessionIDFromContext(ctx)
+	spanCtx, span := middlewareFlowTracer.Start(ctx, "router.billing",
+		trace.WithAttributes(attribute.String("client.session_id", clientSessionID)),
+	)
+	state := &billingSpanState{span: span, parent: ctx}
+	return context.WithValue(spanCtx, billingSpanContextKey{}, state), state
+}
+
+func finishBillingSpan(state *billingSpanState, status int) {
+	if state == nil || state.ended {
+		return
+	}
+	state.ended = true
+	state.span.SetAttributes(attribute.Int("http.response.status_code", status))
+	if status >= http.StatusBadRequest {
+		state.span.SetStatus(codes.Error, "billing gate rejected request")
+	} else {
+		state.span.SetStatus(codes.Ok, "")
+	}
+	state.span.End()
+}
+
+// WithBillingSpan wraps the managed-mode billing admission checks in one
+// bounded span. WithBillingSpanEnd ends it before routing starts.
+func WithBillingSpan() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, state := startBillingSpan(c.Request.Context())
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+		c.Request = c.Request.WithContext(restoreRequestParent(c.Request.Context(), state.parent))
+		finishBillingSpan(state, c.Writer.Status())
+	}
+}
+
+// WithBillingSpanEnd closes the billing admission span before later handlers
+// (including routing) execute, restoring the HTTP request span as parent.
+func WithBillingSpanEnd() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		state, _ := c.Request.Context().Value(billingSpanContextKey{}).(*billingSpanState)
+		finishBillingSpan(state, c.Writer.Status())
+		if state != nil {
+			c.Request = c.Request.WithContext(restoreRequestParent(c.Request.Context(), state.parent))
+		}
+		c.Next()
+	}
+}
+
+func restoreRequestParent(ctx, parent context.Context) context.Context {
+	return trace.ContextWithSpan(ctx, trace.SpanFromContext(parent))
+}

--- a/internal/server/middleware/apm_spans_internal_test.go
+++ b/internal/server/middleware/apm_spans_internal_test.go
@@ -1,0 +1,199 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"weave-os/router/internal/auth"
+	"weave-os/router/internal/observability"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type tracingAPIKeyRepository struct {
+	spanID trace.SpanID
+}
+
+func (*tracingAPIKeyRepository) Create(context.Context, auth.CreateAPIKeyParams) (*auth.APIKey, error) {
+	return nil, errors.New("not used")
+}
+
+func (r *tracingAPIKeyRepository) GetActiveByHashWithInstallation(ctx context.Context, _ string) (*auth.APIKey, *auth.Installation, error) {
+	r.spanID = trace.SpanContextFromContext(ctx).SpanID()
+	return nil, nil, errors.New("database unavailable")
+}
+
+func (*tracingAPIKeyRepository) ListForInstallation(context.Context, string) ([]*auth.APIKey, error) {
+	return nil, errors.New("not used")
+}
+
+func (*tracingAPIKeyRepository) MarkUsed(context.Context, string) error {
+	return errors.New("not used")
+}
+
+func (*tracingAPIKeyRepository) SoftDelete(context.Context, string, string) (int64, error) {
+	return 0, errors.New("not used")
+}
+
+func TestWithAuthEmitsSpanAroundRepositoryWork(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+
+	previousTracer := middlewareFlowTracer
+	middlewareFlowTracer = provider.Tracer("test")
+	t.Cleanup(func() { middlewareFlowTracer = previousTracer })
+
+	repo := &tracingAPIKeyRepository{}
+	svc := auth.NewService(nil, repo, nil, nil, auth.NoOpAPIKeyCache{}, nil, time.Now)
+	engine := gin.New()
+	var requestSpan trace.Span
+	engine.Use(func(c *gin.Context) {
+		ctx, span := provider.Tracer("test").Start(c.Request.Context(), "request")
+		requestSpan = span
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+		span.End()
+	})
+	engine.Use(WithAuth(svc, false))
+	engine.GET("/probe", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+	req.Header.Set(RouterKeyHeader, "rk_trace")
+	req.Header.Set("Session-Id", "client-session-abc")
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, response.Code)
+	authSpan := middlewareEndedSpanByName(t, recorder.Ended(), "router.auth")
+	assert.Equal(t, requestSpan.SpanContext().SpanID(), authSpan.Parent().SpanID())
+	assert.Equal(t, authSpan.SpanContext().SpanID(), repo.spanID)
+	assert.Equal(t, "client-session-abc", middlewareSpanAttribute(t, authSpan.Attributes(), "client.session_id").AsString())
+	assert.Equal(t, codes.Error, authSpan.Status().Code)
+}
+
+func TestRestoreRequestParentMakesFlowSpansAuthSiblings(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+
+	parentCtx, requestSpan := provider.Tracer("test").Start(context.Background(), "request")
+	authCtx, authSpan := provider.Tracer("test").Start(parentCtx, "router.auth")
+	authSpan.End()
+	routingCtx := restoreRequestParent(authCtx, parentCtx)
+	_, routingSpan := provider.Tracer("test").Start(routingCtx, "router.routing")
+	routingSpan.End()
+	requestSpan.End()
+
+	routing := middlewareEndedSpanByName(t, recorder.Ended(), "router.routing")
+	assert.Equal(t, requestSpan.SpanContext().SpanID(), routing.Parent().SpanID())
+	assert.NotEqual(t, authSpan.SpanContext().SpanID(), routing.Parent().SpanID())
+}
+
+func TestWithBillingSpanEndsBeforeDownstreamHandlers(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+
+	previousTracer := middlewareFlowTracer
+	middlewareFlowTracer = provider.Tracer("test")
+	t.Cleanup(func() { middlewareFlowTracer = previousTracer })
+
+	var requestSpan trace.Span
+	var downstreamParent trace.SpanContext
+	engine := gin.New()
+	engine.Use(func(c *gin.Context) {
+		ctx, span := provider.Tracer("test").Start(c.Request.Context(), "request")
+		requestSpan = span
+		ctx = observability.WithClientSessionID(ctx, "client-session-abc")
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+		span.End()
+	})
+	engine.Use(WithBillingSpan(), WithBillingSpanEnd())
+	engine.GET("/probe", func(c *gin.Context) {
+		downstreamParent = trace.SpanContextFromContext(c.Request.Context())
+		c.Status(http.StatusOK)
+	})
+
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/probe", nil))
+
+	require.Equal(t, http.StatusOK, response.Code)
+	billingSpan := middlewareEndedSpanByName(t, recorder.Ended(), "router.billing")
+	assert.Equal(t, requestSpan.SpanContext().SpanID(), billingSpan.Parent().SpanID())
+	assert.Equal(t, "client-session-abc", middlewareSpanAttribute(t, billingSpan.Attributes(), "client.session_id").AsString())
+	assert.Equal(t, requestSpan.SpanContext().SpanID(), downstreamParent.SpanID())
+	assert.Equal(t, codes.Ok, billingSpan.Status().Code)
+}
+
+func TestWithBillingSpanRestoresParentWhenGateAborts(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+
+	previousTracer := middlewareFlowTracer
+	middlewareFlowTracer = provider.Tracer("test")
+	t.Cleanup(func() { middlewareFlowTracer = previousTracer })
+
+	var requestSpan trace.Span
+	var afterParent trace.SpanContext
+	engine := gin.New()
+	engine.Use(func(c *gin.Context) {
+		ctx, span := provider.Tracer("test").Start(c.Request.Context(), "request")
+		requestSpan = span
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+		afterParent = trace.SpanContextFromContext(c.Request.Context())
+		span.End()
+	})
+	engine.Use(WithBillingSpan())
+	engine.Use(func(c *gin.Context) { c.AbortWithStatus(http.StatusPaymentRequired) })
+	engine.Use(WithBillingSpanEnd())
+	engine.GET("/probe", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/probe", nil))
+
+	require.Equal(t, http.StatusPaymentRequired, response.Code)
+	billingSpan := middlewareEndedSpanByName(t, recorder.Ended(), "router.billing")
+	assert.Equal(t, requestSpan.SpanContext().SpanID(), afterParent.SpanID())
+	assert.Equal(t, codes.Error, billingSpan.Status().Code)
+	assert.Equal(t, int64(http.StatusPaymentRequired), middlewareSpanAttribute(t, billingSpan.Attributes(), "http.response.status_code").AsInt64())
+}
+
+func middlewareEndedSpanByName(t *testing.T, spans []sdktrace.ReadOnlySpan, name string) sdktrace.ReadOnlySpan {
+	t.Helper()
+	for _, span := range spans {
+		if span.Name() == name {
+			return span
+		}
+	}
+	require.FailNow(t, "span not found", "name=%s", name)
+	return nil
+}
+
+func middlewareSpanAttribute(t *testing.T, attrs []attribute.KeyValue, key string) attribute.Value {
+	t.Helper()
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			return attr.Value
+		}
+	}
+	require.FailNow(t, "span attribute not found", "key=%s", key)
+	return attribute.Value{}
+}

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -87,15 +87,19 @@ func WithAdminOnly(svc *auth.Service) gin.HandlerFunc {
 // single ctx key, so gating it here decides the whole path in one place.
 func withAPIKey(svc *auth.Service, byokRequiresOptIn bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		parentCtx := c.Request.Context()
+		clientSessionID := proxy.ClientIdentityFromHeaders(c.Request.Header).SessionID
+		authCtx, authSpan := startAuthSpan(parentCtx, clientSessionID)
 		token := extractToken(c)
-		installation, apiKey, externalKeys, clusterModelLists, err := svc.VerifyAPIKey(c.Request.Context(), token)
+		installation, apiKey, externalKeys, clusterModelLists, err := svc.VerifyAPIKey(authCtx, token)
 		if err != nil {
+			finishAuthSpan(authSpan, err)
 			handleAuthError(c, err)
 			return
 		}
 		c.Set(ctxKeyInstallation, installation)
 		c.Set(ctxKeyAPIKey, apiKey)
-		ctx := c.Request.Context()
+		ctx := authCtx
 		if apiKey != nil {
 			ctx = context.WithValue(ctx, proxy.APIKeyIDContextKey{}, apiKey.ID)
 			ctx = proxy.WithManagedSubscriptionUsage(ctx)
@@ -225,6 +229,8 @@ func withAPIKey(svc *auth.Service, byokRequiresOptIn bool) gin.HandlerFunc {
 		if acct := strings.TrimSpace(c.GetHeader(OpenAIAccountIDHeader)); acct != "" {
 			ctx = context.WithValue(ctx, proxy.OpenAIAccountIDContextKey{}, acct)
 		}
+		finishAuthSpan(authSpan, nil)
+		ctx = restoreRequestParent(ctx, parentCtx)
 		c.Request = c.Request.WithContext(ctx)
 		c.Next()
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -221,7 +221,13 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		middleware.WithAgentShadowEvaluation(),
 	}
 	if billingSvc != nil {
-		messagesMiddleware = append(messagesMiddleware, middleware.WithBalanceCheck(billingSvc, billing.MinBalanceMicros), middleware.WithAPIKeySpendCap(billingSvc), middleware.WithOrgMonthlySpendCap(billingSvc))
+		messagesMiddleware = append(messagesMiddleware,
+			middleware.WithBillingSpan(),
+			middleware.WithBalanceCheck(billingSvc, billing.MinBalanceMicros),
+			middleware.WithAPIKeySpendCap(billingSvc),
+			middleware.WithOrgMonthlySpendCap(billingSvc),
+			middleware.WithBillingSpanEnd(),
+		)
 	}
 	messagesMiddleware = append(messagesMiddleware,
 		middleware.WithEmbedOnlyUserMessageOverride(),
@@ -241,7 +247,13 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		middleware.WithAuth(authSvc, byokRequiresOptIn),
 	}
 	if billingSvc != nil {
-		chatCompletionMiddleware = append(chatCompletionMiddleware, middleware.WithBalanceCheck(billingSvc, billing.MinBalanceMicros), middleware.WithAPIKeySpendCap(billingSvc), middleware.WithOrgMonthlySpendCap(billingSvc))
+		chatCompletionMiddleware = append(chatCompletionMiddleware,
+			middleware.WithBillingSpan(),
+			middleware.WithBalanceCheck(billingSvc, billing.MinBalanceMicros),
+			middleware.WithAPIKeySpendCap(billingSvc),
+			middleware.WithOrgMonthlySpendCap(billingSvc),
+			middleware.WithBillingSpanEnd(),
+		)
 	}
 	chatCompletionMiddleware = append(chatCompletionMiddleware,
 		middleware.WithEmbedOnlyUserMessageOverride(),
@@ -280,7 +292,13 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		middleware.WithAuth(authSvc, byokRequiresOptIn),
 	}
 	if billingSvc != nil {
-		routeMiddleware = append(routeMiddleware, middleware.WithBalanceCheck(billingSvc, billing.MinBalanceMicros), middleware.WithAPIKeySpendCap(billingSvc), middleware.WithOrgMonthlySpendCap(billingSvc))
+		routeMiddleware = append(routeMiddleware,
+			middleware.WithBillingSpan(),
+			middleware.WithBalanceCheck(billingSvc, billing.MinBalanceMicros),
+			middleware.WithAPIKeySpendCap(billingSvc),
+			middleware.WithOrgMonthlySpendCap(billingSvc),
+			middleware.WithBillingSpanEnd(),
+		)
 	}
 	routeMiddleware = append(routeMiddleware,
 		middleware.WithEmbedOnlyUserMessageOverride(),


### PR DESCRIPTION
## Summary
- add client.session_id to routing, inference, auth, billing, and PostgreSQL spans
- add bounded router.auth and router.billing admission spans with correct parent restoration
- add tracing context propagation and coverage for success/error paths

## Tests
- go test ./...
- go vet ./...