### PR TITLE
fix(install): reject untrusted project endpoints

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -261,6 +261,11 @@ A rejected key is an error for `update` (exit 1), not a warning, so a scheduled
 run surfaces a revoked key instead of logging past it. `update` works for every
 target; a plain re-run of the installer reuses your installed key the same way.
 
+For a project-scoped Claude Code install, `update` also verifies that the
+endpoint in the tracked project settings is one you approved. If the endpoint
+was changed in the checkout, repeat it with `--base-url <url>` (or reinstall
+against that endpoint) before the update can send a local router key there.
+
 **Claude Code also refreshes itself.** `cc-statusline.sh` checks
 `raw.githubusercontent.com` for a newer copy of itself at most once every
 `$WEAVE_STATUSLINE_UPDATE_INTERVAL_DAYS` (default 7) in a detached background

--- a/install/install.sh
+++ b/install/install.sh
@@ -1785,6 +1785,17 @@ json_get() {
   jq -r "${2} // empty" "$1" 2>/dev/null || true
 }
 
+# strip_trailing_slashes removes every trailing slash from a URL while keeping
+# comparisons between config files stable when a value was written with more
+# than one separator.
+strip_trailing_slashes() {
+  local value="$1"
+  while [ "${value%/}" != "$value" ]; do
+    value="${value%/}"
+  done
+  printf '%s' "$value"
+}
+
 # read_claude_key prints the router key already installed in the given settings
 # file, or nothing when the file is absent / carries no key header. Claude Code
 # packs several headers into one newline-delimited ANTHROPIC_CUSTOM_HEADERS
@@ -1960,11 +1971,13 @@ resolve_installed_base_url() {
 # alongside the endpoint lets update apply the same provenance check as models
 # before it sends the installed key to that endpoint.
 resolve_installed_base_source() {
-  local expected="$1" candidate found
+  local expected="$1" normalized_expected candidate found normalized_found
+  normalized_expected="$(strip_trailing_slashes "$expected")"
   while IFS= read -r candidate; do
     [ -n "$candidate" ] || continue
     found="$(json_get "$candidate" '.env.ANTHROPIC_BASE_URL')"
-    if [ "${found%/}" = "${expected%/}" ]; then
+    normalized_found="$(strip_trailing_slashes "$found")"
+    if [ "$normalized_found" = "$normalized_expected" ]; then
       printf '%s' "$candidate"
       return 0
     fi
@@ -2049,9 +2062,10 @@ resolve_installed_endpoint() {
 # hosted default, or an explicit --base-url — rather than whatever the checkout
 # happened to contain.
 models_endpoint_is_trusted() {
-  local url="$1" base_src="$2" key_src="$3"
+  local url="$1" base_src="$2" key_src="$3" normalized_url normalized_marked_url
+  normalized_url="$(strip_trailing_slashes "$url")"
   [ "$base_url_explicit" = "true" ] && return 0
-  [ "$url" = "$HOSTED_BASE_URL" ] && return 0
+  [ "$normalized_url" = "$(strip_trailing_slashes "$HOSTED_BASE_URL")" ] && return 0
   [ -n "$base_src" ] && [ "$base_src" = "$key_src" ] && return 0
   # Project-scoped self-hosted installs intentionally split the endpoint and
   # key. The installer writes a gitignored marker beside the key; require that
@@ -2063,7 +2077,8 @@ models_endpoint_is_trusted() {
      && [ ! -L "$local_settings_file" ]; then
     local marked_url
     marked_url="$(json_get "$local_settings_file" '.env.WEAVE_ROUTER_BASE_URL')"
-    if [ "${marked_url%/}" = "${url%/}" ]; then
+    normalized_marked_url="$(strip_trailing_slashes "$marked_url")"
+    if [ "$normalized_marked_url" = "$normalized_url" ]; then
       command -v git >/dev/null 2>&1 || return 1
       git -C "$(dirname "$local_settings_file")" ls-files --error-unmatch -- "$local_settings_file" >/dev/null 2>&1 && return 1
       return 0

--- a/install/install.sh
+++ b/install/install.sh
@@ -1955,6 +1955,39 @@ resolve_installed_base_url() {
   printf ''
 }
 
+# resolve_installed_base_source prints the file that supplied the expected
+# Claude Code endpoint, or nothing when no file matches. Keeping the source
+# alongside the endpoint lets update apply the same provenance check as models
+# before it sends the installed key to that endpoint.
+resolve_installed_base_source() {
+  local expected="$1" candidate found
+  while IFS= read -r candidate; do
+    [ -n "$candidate" ] || continue
+    found="$(json_get "$candidate" '.env.ANTHROPIC_BASE_URL')"
+    if [ "${found%/}" = "${expected%/}" ]; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done <<<"$(models_base_file_order)"
+  printf ''
+}
+
+# resolve_installed_key_source prints the file that supplied the installed
+# Claude Code key, or nothing when the key came from the environment or is
+# absent. The update trust gate uses this to distinguish the normal project
+# split from a repo-planted endpoint.
+resolve_installed_key_source() {
+  local candidate
+  while IFS= read -r candidate; do
+    [ -n "$candidate" ] || continue
+    if [ -n "$(read_claude_key "$candidate")" ]; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done <<<"$(models_key_file_order)"
+  printf ''
+}
+
 # resolve_installed_endpoint prints the router endpoint this install already
 # points at, for whichever client is being installed, or nothing. `update` uses
 # it so a refresh never silently retargets a self-hosted install at the hosted
@@ -2024,12 +2057,15 @@ models_endpoint_is_trusted() {
   # key. The installer writes a gitignored marker beside the key; require that
   # marker to match before trusting the split. A tracked/symlinked local file is
   # not a teammate's private configuration and cannot vouch for an endpoint.
-  if [ "$key_src" = "$local_settings_file" ] && [ ! -L "$key_src" ]; then
+  # The marker vouches for the endpoint independently of whether this run uses
+  # the key from disk or a replacement supplied through WEAVE_ROUTER_KEY.
+  if [ "$target" = "claude" ] && [ -n "$local_settings_file" ] \
+     && [ ! -L "$local_settings_file" ]; then
     local marked_url
-    marked_url="$(json_get "$key_src" '.env.WEAVE_ROUTER_BASE_URL')"
+    marked_url="$(json_get "$local_settings_file" '.env.WEAVE_ROUTER_BASE_URL')"
     if [ "${marked_url%/}" = "${url%/}" ]; then
       command -v git >/dev/null 2>&1 || return 1
-      git -C "$(dirname "$key_src")" ls-files --error-unmatch -- "$key_src" >/dev/null 2>&1 && return 1
+      git -C "$(dirname "$local_settings_file")" ls-files --error-unmatch -- "$local_settings_file" >/dev/null 2>&1 && return 1
       return 0
     fi
   fi
@@ -2910,21 +2946,13 @@ if [ "$mode" = "models" ] || [ "$mode" = "accounts" ] || [ "$mode" = "login" ] |
       exit 1
     fi
     base_url="$models_base"
-    # resolve_installed_endpoint ran in a command substitution, so any global it
-    # set died with that subshell. Recover the source by walking the same
-    # precedence to find which file holds the endpoint we just adopted. Only
-    # Claude Code spreads its endpoint across several files; every other client
-    # keeps endpoint and key in one managed config, which is self-consistent by
-    # construction (see models_endpoint_is_trusted's same-file rule).
+    # resolve_installed_endpoint ran in a command substitution, so recover the
+    # source by walking the same precedence to find which file holds the
+    # endpoint we just adopted. Only Claude Code spreads its endpoint across
+    # several files; every other client keeps endpoint and key in one managed
+    # config, which is self-consistent by construction.
     if [ "$target" = "claude" ]; then
-      while IFS= read -r models_src_candidate; do
-        [ -n "$models_src_candidate" ] || continue
-        models_src_url="$(json_get "$models_src_candidate" '.env.ANTHROPIC_BASE_URL')"
-        if [ "${models_src_url%/}" = "$models_base" ]; then
-          models_base_source="$models_src_candidate"
-          break
-        fi
-      done <<<"$(models_base_file_order)"
+      models_base_source="$(resolve_installed_base_source "$models_base")"
     else
       models_base_source="$(models_config_file_for_target)"
     fi
@@ -2939,13 +2967,7 @@ if [ "$mode" = "models" ] || [ "$mode" = "accounts" ] || [ "$mode" = "login" ] |
     # came from by re-reading them in read_installed_key's own precedence.
     models_key_source=""
     if [ "$target" = "claude" ]; then
-      while IFS= read -r models_src_candidate; do
-        [ -n "$models_src_candidate" ] || continue
-        if [ -n "$(read_claude_key "$models_src_candidate")" ]; then
-          models_key_source="$models_src_candidate"
-          break
-        fi
-      done <<<"$(models_key_file_order)"
+      models_key_source="$(resolve_installed_key_source)"
     else
       models_key_source="$(models_config_file_for_target)"
     fi
@@ -2957,9 +2979,9 @@ if [ "$mode" = "models" ] || [ "$mode" = "accounts" ] || [ "$mode" = "login" ] |
   # Never send a key to an endpoint the checkout supplied. See
   # models_endpoint_is_trusted: a hostile repo can commit a settings.json naming
   # its own router, and pairing that with the teammate key from the gitignored
-  # settings.local.json would hand the key to whoever wrote the repo.
-  if [ "$models_key_source" != "env:WEAVE_ROUTER_KEY" ] \
-     && ! models_endpoint_is_trusted "$base_url" "$models_base_source" "$models_key_source"; then
+  # settings.local.json or WEAVE_ROUTER_KEY would hand the key to whoever wrote
+  # the repo.
+  if ! models_endpoint_is_trusted "$base_url" "$models_base_source" "$models_key_source"; then
     err "Refusing to send this installation's router key to $base_url."
     printf "  %sThat endpoint comes from %s, which git tracks — a checked-out repo can set it —%s\n" \
       "$C_DIM" "${models_base_source##*/}" "$C_RESET" >&2
@@ -3001,10 +3023,15 @@ fi
 # `off` parks the router URL and points Claude Code at Anthropic, so the parked
 # sidecar is the authority while toggled off — reading the live file there would
 # pin the install to api.anthropic.com.
+installed_base=""
+installed_base_source=""
 if [ "$mode" = "update" ] && [ "$base_url_explicit" != "true" ]; then
   installed_base="$(resolve_installed_endpoint)"
   if [ -n "$installed_base" ]; then
     base_url="${installed_base%/}"
+    if [ "$target" = "claude" ]; then
+      installed_base_source="$(resolve_installed_base_source "$base_url")"
+    fi
   fi
 fi
 
@@ -3072,6 +3099,31 @@ else
     exit 1
   fi
   prompt_for_key
+fi
+
+# A project-scoped Claude install intentionally reads its endpoint from the
+# tracked settings.json and its key from the ignored settings.local.json. An
+# update must not carry a newly changed tracked endpoint into the validation or
+# config write unless the user has independently vouched for it. The same gate
+# also protects cron/CI runs that provide WEAVE_ROUTER_KEY instead of reading
+# the installed key from disk.
+update_key_source=""
+if [ "$mode" = "update" ] && [ "$target" = "claude" ]; then
+  if [ -n "${WEAVE_ROUTER_KEY:-}" ]; then
+    update_key_source="env:WEAVE_ROUTER_KEY"
+  else
+    update_key_source="$(resolve_installed_key_source)"
+  fi
+fi
+if [ "$mode" = "update" ] && [ "$target" = "claude" ] \
+   && [ "$base_url_explicit" != "true" ] && [ -n "$installed_base" ] \
+   && ! models_endpoint_is_trusted "$base_url" "$installed_base_source" "$update_key_source"; then
+  err "Refusing to use the installed router endpoint $base_url."
+  printf "  %sThat endpoint comes from a git-tracked project file and has not been independently approved.%s\n" \
+    "$C_DIM" "$C_RESET" >&2
+  printf "  %sPass --base-url <url> to confirm it, or re-run the installer against the endpoint you want.%s\n" \
+    "$C_DIM" "$C_RESET" >&2
+  exit 1
 fi
 
 # ---------- identity (user email + name) ----------

--- a/install/tests/models_test.sh
+++ b/install/tests/models_test.sh
@@ -413,7 +413,7 @@ seed_project_split() { # seed_project_split <root> <committed-endpoint> [trusted
 }
 
 hostile="$work/hostile"
-seed_project_split "$hostile" "https://evil.example.com"
+seed_project_split "$hostile" "https://evil.example.com//"
 export REQUEST_LOG="$work/hostile.log"
 : >"$REQUEST_LOG"
 run_models_project "$hostile/repo"
@@ -461,7 +461,7 @@ check "the trusted self-hosted endpoint is actually called" \
 # guard must run before either side effect, including when CI supplies the key
 # through WEAVE_ROUTER_KEY instead of reading settings.local.json.
 update_hostile="$work/update-hostile"
-seed_project_split "$update_hostile" "http://evil.example.com"
+seed_project_split "$update_hostile" "http://evil.example.com//"
 export REQUEST_LOG="$work/update-hostile.log" KEY_LOG="$work/update-hostile.key"
 : >"$REQUEST_LOG"; : >"$KEY_LOG"
 run_update_project "$update_hostile/repo"

--- a/install/tests/models_test.sh
+++ b/install/tests/models_test.sh
@@ -375,7 +375,19 @@ run_models_project() { # run_models_project <repo> [extra args...]
   ( cd "$repo" && HOME="$repo/../home" XDG_CACHE_HOME="$repo/../home/.cache" \
       PATH="$test_path" NO_COLOR=1 ROUTER_MODE="${ROUTER_MODE:-full}" \
       REQUEST_LOG="${REQUEST_LOG:-}" \
+      KEY_LOG="${KEY_LOG:-}" WEAVE_ROUTER_KEY="${WEAVE_ROUTER_KEY:-}" \
       bash "$installer" models --claude --scope project "$@" </dev/null >"$work/out" 2>&1 )
+  rc=$?
+  out="$(cat "$work/out")"
+}
+
+run_update_project() { # run_update_project <repo> [extra args...]
+  local repo="$1"; shift
+  ( cd "$repo" && HOME="$repo/../home" XDG_CACHE_HOME="$repo/../home/.cache" \
+      PATH="$test_path" NO_COLOR=1 ROUTER_MODE="${ROUTER_MODE:-full}" \
+      REQUEST_LOG="${REQUEST_LOG:-}" KEY_LOG="${KEY_LOG:-}" \
+      WEAVE_ROUTER_KEY="${WEAVE_ROUTER_KEY:-}" \
+      bash "$installer" update --claude --scope project "$@" </dev/null >"$work/out" 2>&1 )
   rc=$?
   out="$(cat "$work/out")"
 }
@@ -409,6 +421,14 @@ check "a git-tracked endpoint paired with a local key is refused" "$rc" "1"
 contains "the refusal names the endpoint" "$out" "evil.example.com"
 check "the refusal sends no request at all" "$(wc -l <"$REQUEST_LOG" | tr -d ' ')" "0"
 
+export WEAVE_ROUTER_KEY="rk_env_secret"
+: >"$REQUEST_LOG"
+run_models_project "$hostile/repo"
+check "an env key does not bypass the endpoint trust check" "$rc" "1"
+check "an env key still sends no request to the hostile endpoint" \
+  "$(wc -l <"$REQUEST_LOG" | tr -d ' ')" "0"
+unset WEAVE_ROUTER_KEY
+
 # The same split against the hosted default is the layout the installer itself
 # writes, so it must keep working — the endpoint is one the user can vouch for.
 legit="$work/legit"
@@ -435,6 +455,44 @@ run_models_project "$selfhosted_project/repo"
 check "the installer's committed self-hosted layout still works" "$rc" "0"
 check "the trusted self-hosted endpoint is actually called" \
   "$(grep -c '^GET /admin/v1/models ' "$REQUEST_LOG")" "1"
+
+# `update` has the same endpoint/key split as `models`, but it also writes the
+# endpoint into the live project config and validates the key against it. The
+# guard must run before either side effect, including when CI supplies the key
+# through WEAVE_ROUTER_KEY instead of reading settings.local.json.
+update_hostile="$work/update-hostile"
+seed_project_split "$update_hostile" "http://evil.example.com"
+export REQUEST_LOG="$work/update-hostile.log" KEY_LOG="$work/update-hostile.key"
+: >"$REQUEST_LOG"; : >"$KEY_LOG"
+run_update_project "$update_hostile/repo"
+check "update refuses a tracked hostile endpoint" "$rc" "1"
+check "update sends no request to a hostile endpoint" "$(wc -l <"$REQUEST_LOG" | tr -d ' ')" "0"
+check "update sends no key to a hostile endpoint" "$(wc -c <"$KEY_LOG" | tr -d ' ')" "0"
+
+export WEAVE_ROUTER_KEY="rk_env_secret"
+: >"$REQUEST_LOG"; : >"$KEY_LOG"
+run_update_project "$update_hostile/repo"
+check "update refuses a tracked hostile endpoint with an env key" "$rc" "1"
+check "env-key update sends no request to a hostile endpoint" "$(wc -l <"$REQUEST_LOG" | tr -d ' ')" "0"
+unset WEAVE_ROUTER_KEY
+
+update_explicit="$work/update-explicit"
+seed_project_split "$update_explicit" "http://evil.example.com"
+export REQUEST_LOG="$work/update-explicit.log" KEY_LOG="$work/update-explicit.key"
+: >"$REQUEST_LOG"; : >"$KEY_LOG"
+run_update_project "$update_explicit/repo" --base-url http://127.0.0.1:8080
+check "explicit update endpoint is allowed" "$rc" "0"
+check "explicit update endpoint is called" "$(grep -c '^GET /health ' "$REQUEST_LOG")" "1"
+check "explicit update sends the local key" "$(grep -c 'X-Weave-Router-Key: rk_teammate' "$KEY_LOG")" "1"
+
+update_marked="$work/update-marked"
+seed_project_split "$update_marked" "http://127.0.0.1:8080" trusted
+export REQUEST_LOG="$work/update-marked.log" KEY_LOG="$work/update-marked.key"
+: >"$REQUEST_LOG"; : >"$KEY_LOG"
+run_update_project "$update_marked/repo"
+check "marked self-hosted update is allowed" "$rc" "0"
+check "marked self-hosted update endpoint is called" "$(grep -c '^GET /health ' "$REQUEST_LOG")" "1"
+check "marked self-hosted update sends the local key" "$(grep -c 'X-Weave-Router-Key: rk_teammate' "$KEY_LOG")" "1"
 
 # An explicit --base-url is the user vouching out-of-band, so it overrides the
 # committed value rather than being refused.

--- a/specs/plan/installer-endpoint-trust/OVERVIEW.md
+++ b/specs/plan/installer-endpoint-trust/OVERVIEW.md
@@ -1,0 +1,51 @@
+# Installer endpoint trust fix
+
+## Problem
+
+Project-scoped Claude Code installs intentionally split configuration: the
+tracked `.claude/settings.json` stores the router endpoint while the ignored
+`.claude/settings.local.json` stores each developer's router key. `update`
+currently carries the endpoint forward without checking its provenance, then
+validates and persists the key against that endpoint. A repository-controlled
+endpoint can therefore exfiltrate the key and become a persistent Claude Code
+MITM.
+
+## Proposed solution
+
+- Reuse the installer’s endpoint-provenance model for `update`, before any
+  settings write or health/key probe.
+- Treat an explicit `--base-url`, the hosted default, a same-file endpoint/key,
+  an untracked endpoint file, or a matching untracked project marker as trusted.
+- Treat a tracked endpoint with no independent user proof as untrusted,
+  including when the key came from `WEAVE_ROUTER_KEY`; require an explicit
+  `--base-url` to approve it.
+- Remove the `models` command’s environment-key bypass so both commands enforce
+  the same trust boundary.
+- Add offline regression coverage proving hostile project endpoints receive no
+  request, while hosted, explicitly approved, and marked self-hosted layouts
+  continue to work.
+
+## Files
+
+- `install/install.sh`: endpoint/key source helpers and trust gate.
+- `install/tests/models_test.sh`: model-command environment-key regression,
+  update exfiltration regression, and trusted-layout cases.
+
+## Implementation order
+
+1. Refactor source lookup into reusable helpers without changing accepted
+   trusted layouts.
+2. Gate `update` after key resolution and before identity/config writes or
+   network probes.
+3. Apply the same gate to `models` for environment-provided keys.
+4. Add tests and run the focused installer suites, then the full pre-commit
+   checks available for the router module.
+
+## Risks and decisions
+
+- A project-scoped custom endpoint must have been installed by this installer
+  (the ignored marker) or be explicitly repeated with `--base-url`; this is a
+  deliberate safety trade-off for unattended updates.
+- User-scope and `--dir` installs remain trusted because their endpoint and key
+  are not supplied by a checked-out repository.
+- No database, router API, or migration changes are needed.


### PR DESCRIPTION
## Summary

- Fixes the project-scoped Claude Code installer vulnerability reported in GHSA-w82m-mh93-g7jx.
- `update --scope project` now rejects a router endpoint supplied by a tracked checkout before writing settings or making `/health`/`/validate` requests.
- Removes the `WEAVE_ROUTER_KEY` bypass from the existing `models` endpoint trust check so environment-provided keys follow the same provenance rules.
- Preserves explicit `--base-url`, the hosted endpoint, same-file credentials, untracked endpoints, and installer-created self-hosted markers.
- Documents the approval behavior and adds offline regression coverage.

## Security impact

Before this change, a tracked `.claude/settings.json` could replace `ANTHROPIC_BASE_URL`; `update` would read the developer's key from `.claude/settings.local.json` (or `WEAVE_ROUTER_KEY`) and send it to that endpoint for validation. The new gate runs before any config write or network probe.

## Validation

- `make precommit` ✅
- `bash install/tests/models_test.sh` ✅ (95 passed)
- `bash install/tests/key_reuse_test.sh` ✅ (69 passed)
- `wv checks run --skip-cost` attempted, but this workspace has no Claude Code router configuration, so the CLI refused to run before analyzing the diff.
