### PR TITLE
Don't include model choice in Codex title gen requests

### DIFF
--- a/internal/proxy/codex_title_gen_internal_test.go
+++ b/internal/proxy/codex_title_gen_internal_test.go
@@ -67,3 +67,57 @@ func TestCodexResponsesTitleGenerationHardPinsWithoutScoring(t *testing.T) {
 	require.Zero(t, routerSpy.routeCalls, "Codex title generation must use the hard-pin path")
 	assert.NotContains(t, rec.Body.String(), "Weave Router", "hard-pinned title responses must not carry a routing marker")
 }
+
+func TestCodexResponsesTitlePromptHardPinsWithoutScoring(t *testing.T) {
+	routerSpy := &codexTitleRouter{}
+	provider := &codexTitleProvider{}
+	svc := NewService(
+		routerSpy,
+		map[string]providers.Client{providers.ProviderOpenAI: provider},
+		nil, false, nil, nil, false,
+		providers.ProviderOpenAI, "gpt-5.6-luna", nil,
+	)
+	body := []byte(`{
+		"model":"gpt-5.6-sol",
+		"parallel_tool_calls":true,
+		"store":false,
+		"stream":true,
+		"text":{"verbosity":"low"},
+		"tool_choice":"auto",
+		"input":[
+			{"type":"message","role":"developer","content":[{"type":"input_text","text":"Base instructions."}]},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"Respond directly to the user's prompt.\n\nYou are generating a short conversation title. Keep it concise."}]}
+		]
+	}`)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	ctx := context.WithValue(context.Background(), ClientIdentityContextKey{}, ClientIdentity{ClientApp: ClientAppCodex})
+
+	require.NoError(t, svc.ProxyOpenAIResponses(ctx, body, rec, req))
+	require.Len(t, provider.endpoints, 1)
+	require.Zero(t, routerSpy.routeCalls, "Codex title generation must use the hard-pin path")
+	assert.NotContains(t, rec.Body.String(), "Weave Router", "hard-pinned title responses must not carry a routing marker")
+}
+
+func TestResponsesTitlePromptWithoutCodexIdentityUsesScorer(t *testing.T) {
+	routerSpy := &codexTitleRouter{}
+	provider := &codexTitleProvider{}
+	svc := NewService(
+		routerSpy,
+		map[string]providers.Client{providers.ProviderOpenAI: provider},
+		nil, false, nil, nil, false,
+		providers.ProviderOpenAI, "gpt-5.6-luna", nil,
+	)
+	body := []byte(`{
+		"model":"gpt-5.6-sol",
+		"stream":true,
+		"text":{"verbosity":"low"},
+		"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"Respond directly to the user's prompt. You are generating a short conversation title."}]}]
+	}`)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	require.NoError(t, svc.ProxyOpenAIResponses(context.Background(), body, rec, req))
+	require.Len(t, provider.endpoints, 1)
+	assert.Equal(t, 1, routerSpy.routeCalls, "prompt matching must remain gated to Codex ingress")
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -460,7 +460,7 @@ type codexFeedbackSkillContextKey struct{}
 // already carries a rating hint after the last human turn.
 type responsesFooterEchoedContextKey struct{}
 
-// codexTitleGenerationContextKey carries the native Responses title shape
+// codexTitleGenerationContextKey carries the native Responses title signal
 // into the shared Chat Completions turn loop. It is set only after the request
 // is identified as coming from Codex, so other clients' structured outputs are
 // unaffected.

--- a/internal/router/turntype/AGENTS.md
+++ b/internal/router/turntype/AGENTS.md
@@ -13,7 +13,7 @@ Classifies inbound requests into:
 - `SubAgentDispatch`
 - `Compaction` — harness-issued compaction turn (Claude Code's summary instruction, or Codex's "CONTEXT CHECKPOINT COMPACTION" handoff prompt); hard-pinned
 - `Probe` — proxy bypasses routing entirely
-- `TitleGen` — Claude Code sidebar-title generation; hard-pinned AND skips session-pin creation (an anchored pin here would leak the cheap-model decision into the real conversation that follows ~25ms later)
+- `TitleGen` — harness sidebar-title generation; hard-pinned AND skips session-pin creation (an anchored pin here would leak the cheap-model decision into the real conversation that follows ~25ms later). Claude Code is identified by its title JSON schema; Codex title requests are trusted only on Codex Responses ingress and match either the closed title schema or Conductor's fresh hidden-session prompt fingerprint.
 - `Classifier` — short-form classification call (e.g. Claude Code's security monitor); hard-pinned AND skips session-pin creation
 
 Used by [`../../proxy`](../../proxy) to keep the action loop cheap + correct.

--- a/internal/router/turntype/CLAUDE.md
+++ b/internal/router/turntype/CLAUDE.md
@@ -13,7 +13,7 @@ Classifies inbound requests into:
 - `SubAgentDispatch`
 - `Compaction` — harness-issued compaction turn (Claude Code's summary instruction, or Codex's "CONTEXT CHECKPOINT COMPACTION" handoff prompt); hard-pinned
 - `Probe` — proxy bypasses routing entirely
-- `TitleGen` — Claude Code sidebar-title generation; hard-pinned AND skips session-pin creation (an anchored pin here would leak the cheap-model decision into the real conversation that follows ~25ms later)
+- `TitleGen` — harness sidebar-title generation; hard-pinned AND skips session-pin creation (an anchored pin here would leak the cheap-model decision into the real conversation that follows ~25ms later). Claude Code is identified by its title JSON schema; Codex title requests are trusted only on Codex Responses ingress and match either the closed title schema or Conductor's fresh hidden-session prompt fingerprint.
 - `Classifier` — short-form classification call (e.g. Claude Code's security monitor); hard-pinned AND skips session-pin creation
 
 Used by [`../../proxy`](../../proxy) to keep the action loop cheap + correct.

--- a/internal/router/turntype/detect.go
+++ b/internal/router/turntype/detect.go
@@ -21,8 +21,8 @@ const (
 	// Probe: quota/liveness check (max_tokens=1..4). Hard-pinned to cheap
 	// model AND skips session-pin creation.
 	Probe TurnType = "probe"
-	// TitleGen: Claude Code sidebar-title generation. Hard-pinned AND
-	// skips session-pin creation.
+	// TitleGen: harness sidebar-title generation. Hard-pinned AND skips
+	// session-pin creation.
 	TitleGen TurnType = "title_gen"
 	// Classifier: short-form classification call (security monitor, etc.).
 	// Hard-pinned AND skips session-pin creation.

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -418,6 +418,63 @@ func requestRootRequestsCodexTitleSchema(root gjson.Result) bool {
 	return additionalProperties.Exists() && additionalProperties.Type == gjson.False
 }
 
+const (
+	codexTitlePromptMarker          = "you are generating a short conversation title."
+	codexDirectResponsePromptMarker = "respond directly to the user's prompt"
+)
+
+func requestRootRequestsCodexTitle(root gjson.Result) bool {
+	if requestRootRequestsCodexTitleSchema(root) {
+		return true
+	}
+	text, ok := freshCodexResponsesUserText(root.Get("input"))
+	if !ok {
+		return false
+	}
+	lower := strings.ToLower(text)
+	return strings.Contains(lower, codexTitlePromptMarker) &&
+		strings.Contains(lower, codexDirectResponsePromptMarker)
+}
+
+// freshCodexResponsesUserText returns the sole user message from a new
+// Responses conversation. Conductor generates titles in a separate hidden
+// session, so accepting conversation history here would make quoted title
+// instructions in a normal coding session a false positive.
+func freshCodexResponsesUserText(input gjson.Result) (string, bool) {
+	if input.Type == gjson.String {
+		return input.Str, input.Str != ""
+	}
+	if !input.IsArray() {
+		return "", false
+	}
+	var userText string
+	for _, item := range input.Array() {
+		itemType := item.Get("type").Str
+		if itemType == "" && item.Get("role").Str != "" {
+			itemType = "message"
+		}
+		switch itemType {
+		case "additional_tools":
+			continue
+		case "message":
+			role := item.Get("role").Str
+			if role == "developer" || role == "system" {
+				continue
+			}
+			if role != "user" || userText != "" {
+				return "", false
+			}
+			userText = contentTextGJSON(item.Get("content"))
+			if userText == "" {
+				return "", false
+			}
+		default:
+			return "", false
+		}
+	}
+	return userText, userText != ""
+}
+
 // EmitOverrides describes byte-level mutations for same-format serialization.
 // Zero-valued fields are no-ops.
 type EmitOverrides struct {

--- a/internal/translate/features.go
+++ b/internal/translate/features.go
@@ -43,8 +43,8 @@ type RoutingFeatures struct {
 	// Probe detection keys off this — Anthropic SDK quota probes set max_tokens=1.
 	MaxTokens int
 	// TitleGenHint marks a Codex Responses title-generation request. The
-	// Responses ingress sets this only for the Codex client after inspecting
-	// the native request shape; it is deliberately not inferred from prompt text.
+	// Responses ingress sets this only for the Codex client after matching the
+	// native request's schema or hidden-session prompt fingerprint.
 	TitleGenHint bool
 	// LastKind: "user_prompt", "tool_result", or "assistant".
 	LastKind string

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -35,9 +35,8 @@ type ResponsesConversion struct {
 	Requirements       router.TranslationRequirements
 	Report             []ResponseTransform
 	ToolMappings       map[string]ResponsesToolMapping
-	// TitleGeneration reports the native Codex title-generation shape (a
-	// closed object containing only the required string title). It is consumed
-	// only when the proxy has independently identified the Codex client.
+	// TitleGeneration reports a native Codex title-generation request. It is
+	// consumed only when the proxy has independently identified the Codex client.
 	TitleGeneration bool
 }
 
@@ -107,7 +106,7 @@ func ConvertResponsesToChatCompletions(body []byte) (ResponsesConversion, error)
 	result.Requirements.Audio, result.Requirements.Files = openAIMediaRequirements(body)
 	result.Requirements.CitationsOrSearch = len(nativeServerToolsFromBody(body, FormatOpenAI)) > 0
 	result.Requirements.StructuredOutput = root.Get("text.format").Exists() || root.Get("response_format").Exists()
-	result.TitleGeneration = requestRootRequestsCodexTitleSchema(root)
+	result.TitleGeneration = requestRootRequestsCodexTitle(root)
 	out := map[string]any{}
 
 	model := root.Get("model").Str

--- a/internal/translate/responses_codex.go
+++ b/internal/translate/responses_codex.go
@@ -153,7 +153,7 @@ func convertPortableCodexResponses(body []byte) (ResponsesConversion, error) {
 		toolAliases:     make(map[responsesToolIdentity]string),
 		declaredAliases: make(map[string]struct{}),
 	}
-	converter.result.TitleGeneration = requestRootRequestsCodexTitleSchema(root)
+	converter.result.TitleGeneration = requestRootRequestsCodexTitle(root)
 	converter.result.Requirements.Images = root.Get("input").Exists() && containsAnyKey(body, "image_url", "input_image")
 	converter.result.Requirements.Audio, converter.result.Requirements.Files = openAIMediaRequirements(body)
 	converter.result.Requirements.CitationsOrSearch = len(nativeServerToolsFromBody(body, FormatOpenAI)) > 0

--- a/internal/translate/responses_codex_test.go
+++ b/internal/translate/responses_codex_test.go
@@ -28,6 +28,63 @@ func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexTitleGenerati
 	assert.True(t, gjson.GetBytes(converted.Body, "tools").IsArray(), "routing projection must retain tool requirements")
 }
 
+func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexTitleGenerationPrompt(t *testing.T) {
+	body := []byte(`{
+		"client_metadata":{"originator":"conductor"},
+		"include":["reasoning.encrypted_content"],
+		"input":[
+			{"type":"message","role":"developer","content":[{"type":"input_text","text":"Base instructions."}]},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"Respond directly to the user's prompt.\n\nYou are generating a short conversation title. Keep it concise."}]}
+		],
+		"model":"gpt-5.6-sol",
+		"parallel_tool_calls":true,
+		"prompt_cache_key":"title-session",
+		"reasoning":{"effort":"medium","summary":"auto"},
+		"store":false,
+		"stream":true,
+		"text":{"verbosity":"low"},
+		"tool_choice":"auto"
+	}`)
+
+	converted, err := translate.ConvertResponsesToChatCompletionsWithOptions(body, translate.ResponsesConversionOptions{PortableCodex: true})
+	require.NoError(t, err)
+	assert.True(t, converted.TitleGeneration)
+	assert.False(t, gjson.GetBytes(body, "text.format").Exists(), "current title requests no longer carry a JSON schema")
+}
+
+func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexTitlePromptIsStrict(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "ordinary low verbosity request",
+			input: `[{"type":"message","role":"user","content":[{"type":"input_text","text":"Give this task a short title."}]}]`,
+		},
+		{
+			name:  "title marker without direct response instruction",
+			input: `[{"type":"message","role":"user","content":[{"type":"input_text","text":"You are generating a short conversation title."}]}]`,
+		},
+		{
+			name: "quoted prompt in an established conversation",
+			input: `[
+				{"type":"message","role":"user","content":[{"type":"input_text","text":"Respond directly to the user's prompt. You are generating a short conversation title."}]},
+				{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Example Title"}]},
+				{"type":"message","role":"user","content":[{"type":"input_text","text":"Why did that get hard-pinned?"}]}
+			]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := []byte(`{"model":"gpt-5.6-sol","text":{"verbosity":"low"},"input":` + tt.input + `}`)
+			converted, err := translate.ConvertResponsesToChatCompletionsWithOptions(body, translate.ResponsesConversionOptions{PortableCodex: true})
+			require.NoError(t, err)
+			assert.False(t, converted.TitleGeneration)
+		})
+	}
+}
+
 func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexTitleShapeIsStrict(t *testing.T) {
 	body := []byte(`{
 		"model":"gpt-5.6-sol",


### PR DESCRIPTION
## Summary

- recognize current schema-less Codex title requests from the fixed hidden-session prompt fingerprint
- require a fresh Responses conversation and Codex client identity to avoid hard-pinning ordinary turns
- keep title requests on the hard-pin path so routing markers do not enter generated titles

## Verification

- `go test ./...`
- `go vet ./...`
- `go build -o /dev/null ./...`
- `make test-install`
- `make check-agent-guides`
- `make check-docs`
- `make test-statusline` currently fails two unchanged background-refresh stamp-count assertions (45 pass, 2 fail); this branch has no installer/statusline diff