### PR TITLE
fix(install): stop keying Codex config surgery on comment markers

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -596,15 +596,34 @@ TOML
 
   if [ -f "$config_file" ]; then
     local tmp; tmp="$(mktemp -t weave-codex.XXXXXX)"
-    # Strip the managed block (between markers) plus any top-level
-    # `model_provider =` outside it. We define "top-level" as everything
-    # before the first `[section]` header. The awk handles both passes in
-    # one sweep so we never emit a duplicate.
+    # Strip the managed block (between markers), any top-level
+    # `model_provider =` outside it, and any `[model_providers.weave]` table
+    # (with its subtables) outside it. "Top-level" means everything before the
+    # first `[section]` header. The awk handles every pass in one sweep so we
+    # never emit a duplicate.
+    #
+    # Dropping the out-of-marker provider table is what keeps a re-install
+    # idempotent once Codex has rewritten config.toml itself. Codex round-trips
+    # the whole file through a TOML serializer when it persists its own state
+    # (hook trust hashes, project trust levels), and comments do not survive
+    # that: the markers vanish while `[model_providers.weave]` remains. Keying
+    # the strip on the markers alone then left the stale table in place and
+    # appended a second one -- TOML rejects a table declared twice, so Codex
+    # refused to start with "duplicate key" while the installer reported
+    # success.
     awk -v begin="$WEAVE_CODEX_BEGIN_MARKER" -v end="$WEAVE_CODEX_END_MARKER" '
       $0 == begin { skip = 1; next }
       $0 == end   { skip = 0; next }
       skip        { next }
-      /^[[:space:]]*\[/ { in_section = 1 }
+      /^[[:space:]]*\[/ {
+        in_section = 1
+        if ($0 ~ /^[[:space:]]*\[[[:space:]]*model_providers[[:space:]]*\.[[:space:]]*weave[[:space:]]*(\.[^]]*)?\][[:space:]]*(#.*)?$/) {
+          in_weave_provider = 1
+          next
+        }
+        in_weave_provider = 0
+      }
+      in_weave_provider { next }
       !in_section && /^[[:space:]]*model_provider[[:space:]]*=/ { next }
       { print }
     ' "$config_file" >"$tmp"
@@ -1848,10 +1867,19 @@ key_source_is_own() {
 read_codex_key() {
   local f="$1"
   key_source_is_own "$f" || return 0
-  awk -v begin="$WEAVE_CODEX_BEGIN_MARKER" -v end="$WEAVE_CODEX_END_MARKER" '
-    $0 == begin { inblk = 1; next }
-    $0 == end   { inblk = 0; next }
-    inblk && match($0, /"X-Weave-Router-Key"[[:space:]]*=[[:space:]]*"[^"]*"/) {
+  # Scan the [model_providers.weave] table and its subtables rather than the
+  # managed markers, and accept the header name quoted or bare. Our own writer
+  # emits one inline `http_headers = { "X-Weave-Router-Key" = "..." }`; Codex's
+  # serializer re-emits the same value as a bare key in a
+  # [model_providers.weave.http_headers] subtable. Matching only the quoted
+  # in-marker spelling missed the key on any config Codex had rewritten, and a
+  # re-install then minted a second router key instead of reusing this one.
+  awk '
+    /^[[:space:]]*\[/ {
+      in_provider = ($0 ~ /^[[:space:]]*\[[[:space:]]*model_providers[[:space:]]*\.[[:space:]]*weave[[:space:]]*(\.[^]]*)?\][[:space:]]*(#.*)?$/)
+      next
+    }
+    in_provider && match($0, /"?X-Weave-Router-Key"?[[:space:]]*=[[:space:]]*"[^"]*"/) {
       hdr = substr($0, RSTART, RLENGTH)
       sub(/^.*=[[:space:]]*"/, "", hdr)
       sub(/"$/, "", hdr)
@@ -2019,11 +2047,19 @@ resolve_installed_endpoint() {
       return 0
       ;;
     codex)
+      # Read base_url from the [model_providers.weave] table wherever it sits,
+      # not only from between the managed markers. Codex drops our comment
+      # markers when it rewrites config.toml (see write_codex_config) while
+      # keeping the table, and a marker-scoped read then reported a live
+      # install as absent -- `login codex` and `status` claimed Codex was not
+      # configured until the user re-installed to restore the markers.
       if key_source_is_own "$codex_config_file"; then
-        found="$(awk -v begin="$WEAVE_CODEX_BEGIN_MARKER" -v end="$WEAVE_CODEX_END_MARKER" '
-          $0 == begin { inblk = 1; next }
-          $0 == end   { inblk = 0; next }
-          inblk && match($0, /^[[:space:]]*base_url[[:space:]]*=[[:space:]]*"[^"]*"/) {
+        found="$(awk '
+          /^[[:space:]]*\[/ {
+            in_provider = ($0 ~ /^[[:space:]]*\[[[:space:]]*model_providers[[:space:]]*\.[[:space:]]*weave[[:space:]]*\][[:space:]]*(#.*)?$/)
+            next
+          }
+          in_provider && match($0, /^[[:space:]]*base_url[[:space:]]*=[[:space:]]*"[^"]*"/) {
             line = substr($0, RSTART, RLENGTH)
             sub(/^.*=[[:space:]]*"/, "", line)
             sub(/"$/, "", line)
@@ -2947,6 +2983,12 @@ if [ "$mode" = "models" ] || [ "$mode" = "accounts" ] || [ "$mode" = "login" ] |
   # branches below so `set -u` holds on every path.
   models_base_source=""
   models_key_source=""
+  # The codex fallback below and run_router_status both resolve a Codex install
+  # even on a run whose target is Claude, and the per-target setup only defines
+  # codex_config_file when the target IS codex. Default it here or `set -u`
+  # aborts the whole command: `status` with a Codex-only install died on
+  # "codex_config_file: unbound variable" instead of reporting the install.
+  codex_config_file="${codex_config_file:-$settings_base/.codex/config.toml}"
   # Editing model selection needs the endpoint and key of one specific install,
   # never the hosted defaults: a self-hosted user pointing at their own router
   # would otherwise silently edit the hosted one's installation.

--- a/install/tests/codex_install_test.sh
+++ b/install/tests/codex_install_test.sh
@@ -202,4 +202,140 @@ run_uninstall
 grep -qx 'user-authored skill' "$skill" \
   || fail "uninstall removed a user-owned Codex disable-routing skill"
 
+
+# ---------- Codex rewrites config.toml and our comment markers do not survive ----------
+#
+# Codex round-trips the whole file through a TOML serializer whenever it
+# persists its own state (hook trust hashes, project trust levels, the model
+# NUX table). Comments are dropped, so the managed markers disappear while
+# `[model_providers.weave]` survives -- re-emitted in the serializer's own
+# shape: keys alphabetized and our inline `http_headers` expanded into a
+# [model_providers.weave.http_headers] subtable.
+#
+# Every reader and writer keyed on the markers alone broke on that config:
+# install appended a second provider table (TOML rejects a table declared
+# twice, so Codex refused to start), the endpoint reader reported a live
+# install as absent, the key reader missed the router key, and uninstall left
+# the provider and its key on disk. Seed exactly that file for each case.
+seed_codex_normalized_config() {
+  rm -rf "$home/.codex" "$home/.weave"
+  mkdir -p "$home/.codex"
+  cat >"$config" <<'NORMALIZED'
+model_provider = "weave"
+
+[features]
+hooks = true
+
+[hooks.state."/Users/a/.codex/config.toml:stop:0:0"]
+enabled = true
+trusted_hash = "sha256:deadbeef"
+
+[model_providers.weave]
+base_url = "https://router.workweave.ai/v1"
+name = "Weave Router"
+requires_openai_auth = true
+wire_api = "responses"
+
+[model_providers.weave.http_headers]
+X-App = "codex"
+X-Weave-Router-Key = "rk_normalized_key"
+
+[projects."/Users/a/Code/weave"]
+trust_level = "trusted"
+NORMALIZED
+}
+
+# assert_config_parses fails when config.toml is not loadable TOML -- the exact
+# check Codex performs at startup, and the one that caught the duplicate table.
+# Skipped rather than faked where no python3 is available; the count assertions
+# below still pin the regression.
+assert_config_parses() {
+  command -v python3 >/dev/null 2>&1 || return 0
+  python3 - "$config" <<'PARSE' || fail "$1"
+import sys, tomllib
+with open(sys.argv[1], "rb") as fh:
+    tomllib.load(fh)
+PARSE
+}
+
+seed_codex_normalized_config
+run_hosted_install
+assert_config_parses "install over a Codex-rewritten config produced unparseable TOML"
+[ "$(grep -c '^\[model_providers\.weave\]$' "$config")" -eq 1 ] \
+  || fail "install over a Codex-rewritten config duplicated [model_providers.weave]"
+[ "$(grep -c '^\[model_providers\.weave\.http_headers\]$' "$config")" -eq 0 ] \
+  || fail "install over a Codex-rewritten config left the serializer's headers subtable"
+[ "$(grep -c '^model_provider = "weave"$' "$config")" -eq 1 ] \
+  || fail "install over a Codex-rewritten config duplicated the top-level model_provider"
+# Unrelated Codex-owned state is not ours to drop while rewriting around it.
+grep -Fq '[hooks.state."/Users/a/.codex/config.toml:stop:0:0"]' "$config" \
+  || fail "install over a Codex-rewritten config dropped Codex hook state"
+grep -Fq '[projects."/Users/a/Code/weave"]' "$config" \
+  || fail "install over a Codex-rewritten config dropped Codex project trust"
+
+# The endpoint reader backs `login`/`status`. Reading only between the markers
+# reported "No Weave Router install found for codex in this scope" on a
+# perfectly good install, which sent users through a reinstall to fix it.
+seed_codex_normalized_config
+router_status="$(HOME="$home" PATH="$test_path" NO_COLOR=1 \
+  bash "$installer" status --scope user 2>&1 || true)"
+printf '%s' "$router_status" | grep -q 'Codex: points at Router' \
+  || fail "status did not detect a Codex install whose markers Codex had dropped"
+
+# `login codex` is where users hit this first: it refused to enroll a
+# subscription against a working install and told them to run the installer
+# again. The device-authorization step still fails offline here -- what must not
+# come back is the "no install" refusal that precedes it.
+login_out="$(HOME="$home" PATH="$test_path" NO_COLOR=1 \
+  bash "$installer" login codex --scope user 2>&1 || true)"
+if printf '%s' "$login_out" | grep -q 'No Weave Router install found'; then
+  fail "login codex did not see an install whose markers Codex had dropped"
+fi
+
+# The key reader has to accept both spellings of the header name: our writer
+# emits one quoted inline table, Codex re-emits it as a bare key in a subtable.
+# Missing it made a re-install mint a second router key -- or, non-interactively,
+# fail outright with no key to fall back on.
+seed_codex_normalized_config
+HOME="$home" PATH="$test_path" NO_COLOR=1 WEAVE_ROUTER_KEY="" \
+  bash "$installer" --codex --scope user --quiet --non-interactive \
+    --base-url https://router.workweave.ai </dev/null >/dev/null 2>&1 \
+  || fail "re-install could not reuse the key from a Codex-rewritten config"
+grep -Fq 'rk_normalized_key' "$config" \
+  || fail "re-install replaced the router key already in a Codex-rewritten config"
+
+# Uninstall reported success while leaving the provider -- and the key inside
+# it -- behind, so routing kept working and the credential stayed on disk.
+seed_codex_normalized_config
+run_uninstall
+[ "$(grep -c '^\[model_providers\.weave\]$' "$config")" -eq 0 ] \
+  || fail "uninstall left the provider table from a Codex-rewritten config"
+if grep -Fq 'rk_normalized_key' "$config"; then
+  fail "uninstall left the router key in a Codex-rewritten config"
+fi
+if grep -Fq 'model_provider = "weave"' "$config"; then
+  fail "uninstall left Codex routed at the Weave provider"
+fi
+# Codex's own state still has to survive an uninstall.
+grep -Fq '[projects."/Users/a/Code/weave"]' "$config" \
+  || fail "uninstall dropped Codex project trust"
+
+# A provider whose name merely starts with "weave" is a different provider and
+# must be left alone -- the table matcher is anchored, not a prefix search.
+seed_codex_normalized_config
+cat >>"$config" <<'NEIGHBOUR'
+
+[model_providers.weaver]
+base_url = "https://example.invalid/v1"
+name = "Weaver"
+NEIGHBOUR
+run_hosted_install
+grep -Fq '[model_providers.weaver]' "$config" \
+  || fail "install removed an unrelated provider whose name starts with weave"
+run_uninstall
+grep -Fq '[model_providers.weaver]' "$config" \
+  || fail "uninstall removed an unrelated provider whose name starts with weave"
+
+rm -rf "$home/.codex" "$home/.weave"
+
 echo "Codex installer routing regression tests passed"

--- a/install/tests/codex_install_test.sh
+++ b/install/tests/codex_install_test.sh
@@ -159,6 +159,8 @@ done
 # arrays. Preserve either user shape and install routing without managed hooks.
 for hooks_shape in scalar table; do
   if [ "$hooks_shape" = scalar ]; then
+    # The literal ${HOME} is the point: it must survive the install unexpanded.
+    # shellcheck disable=SC2016
     printf '%s\n' 'hooks = "${HOME}/.codex/hooks.json"' >"$config"
   else
     printf '%s\n' '[hooks]' 'enabled = true' >"$config"
@@ -170,6 +172,7 @@ for hooks_shape in scalar table; do
     fail "installer added inline hooks to conflicting hooks $hooks_shape config"
   fi
   if [ "$hooks_shape" = scalar ]; then
+    # shellcheck disable=SC2016
     grep -Fq 'hooks = "${HOME}/.codex/hooks.json"' "$config" \
       || fail "installer did not preserve hooks path"
   else

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -206,11 +206,17 @@ fi
 WEAVE_CODEX_BEGIN_MARKER="# >>> weave-router managed (do not edit between markers) >>>"
 WEAVE_CODEX_END_MARKER="# <<< weave-router managed <<<"
 
-# strip_codex_block rewrites config.toml without the managed block and any
+# strip_codex_block rewrites config.toml without the managed block, any
 # top-level `model_provider = "weave"` that lived outside the markers (which
-# can happen if the user copy-pasted our key into their own config). Other
-# top-level model_provider values are preserved so we don't yank a user back
-# into the OpenAI default when they meant to keep their own.
+# can happen if the user copy-pasted our key into their own config), and any
+# `[model_providers.weave]` table outside them. Other top-level model_provider
+# values are preserved so we don't yank a user back into the OpenAI default
+# when they meant to keep their own.
+#
+# The out-of-marker table has to go for the same reason install.sh strips it:
+# Codex rewrites config.toml through a TOML serializer and our comment markers
+# do not survive, so a marker-only uninstall reported success while leaving the
+# provider -- and the router key inside it -- on disk.
 strip_codex_block() {
   local config_file="$1"
   local tmp; tmp="$(mktemp -t weave-codex-uninstall.XXXXXX)"
@@ -218,7 +224,15 @@ strip_codex_block() {
     $0 == begin { skip = 1; next }
     $0 == end   { skip = 0; next }
     skip        { next }
-    /^[[:space:]]*\[/ { in_section = 1 }
+    /^[[:space:]]*\[/ {
+      in_section = 1
+      if ($0 ~ /^[[:space:]]*\[[[:space:]]*model_providers[[:space:]]*\.[[:space:]]*weave[[:space:]]*(\.[^]]*)?\][[:space:]]*(#.*)?$/) {
+        in_weave_provider = 1
+        next
+      }
+      in_weave_provider = 0
+    }
+    in_weave_provider { next }
     !in_section && /^[[:space:]]*model_provider[[:space:]]*=[[:space:]]*"weave"[[:space:]]*$/ { next }
     { print }
   ' "$config_file" >"$tmp"

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -27,7 +27,6 @@ set -euo pipefail
 scope="user"
 scope_explicit="false"
 install_dir=""
-script_dir="$(cd "$(dirname "$0")" 2>/dev/null && pwd || true)"
 
 # ---------- directive registry (embedded) ----------
 #
@@ -259,6 +258,9 @@ if [ "$target" = "opencode" ]; then
       printf "Project directory to uninstall from [default: %s]: " "$default_project_dir"
       read -r project_dir_choice </dev/tty || project_dir_choice=""
       project_dir="${project_dir_choice:-$default_project_dir}"
+      # Expand a leading ~ since `read` doesn't.
+      # The pattern intentionally matches a literal tilde.
+      # shellcheck disable=SC2088
       case "$project_dir" in
         "~")    project_dir="$HOME" ;;
         "~/"*)  project_dir="$HOME/${project_dir#~/}" ;;
@@ -409,6 +411,9 @@ if [ "$target" = "pi" ]; then
       printf "Project directory to uninstall from [default: %s]: " "$default_project_dir"
       read -r project_dir_choice </dev/tty || project_dir_choice=""
       project_dir="${project_dir_choice:-$default_project_dir}"
+      # Expand a leading ~ since `read` doesn't.
+      # The pattern intentionally matches a literal tilde.
+      # shellcheck disable=SC2088
       case "$project_dir" in
         "~")    project_dir="$HOME" ;;
         "~/"*)  project_dir="$HOME/${project_dir#~/}" ;;
@@ -515,6 +520,9 @@ if [ "$target" = "codex" ]; then
       printf "Project directory to uninstall from [default: %s]: " "$default_project_dir"
       read -r project_dir_choice </dev/tty || project_dir_choice=""
       project_dir="${project_dir_choice:-$default_project_dir}"
+      # Expand a leading ~ since `read` doesn't.
+      # The pattern intentionally matches a literal tilde.
+      # shellcheck disable=SC2088
       case "$project_dir" in
         "~")    project_dir="$HOME" ;;
         "~/"*)  project_dir="$HOME/${project_dir#~/}" ;;
@@ -686,6 +694,9 @@ else
     printf "Project directory to uninstall from [default: %s]: " "$default_project_dir"
     read -r project_dir_choice </dev/tty || project_dir_choice=""
     project_dir="${project_dir_choice:-$default_project_dir}"
+    # Expand a leading ~ since `read` doesn't.
+    # The pattern intentionally matches a literal tilde.
+    # shellcheck disable=SC2088
     case "$project_dir" in
       "~")    project_dir="$HOME" ;;
       "~/"*)  project_dir="$HOME/${project_dir#~/}" ;;


### PR DESCRIPTION
Reported internally: `codex login` refused to enroll against a working install, and after re-installing to work around that, the next Codex session died with

```
Error: failed to load configuration: /Users/andrew/.codex/config.toml:82:18: duplicate key
```

on a duplicated `[model_providers.weave]`.

## Root cause

Codex round-trips `config.toml` through a TOML serializer whenever it persists its own state (hook trust hashes, project trust levels, the model NUX table). Comments do not survive that, so the `# >>> weave-router managed` markers disappear while `[model_providers.weave]` stays — re-emitted in the serializer's shape, keys alphabetized and our inline `http_headers` expanded into a `[model_providers.weave.http_headers]` subtable.

Every reader and writer in the installer was anchored on those markers, so all of them misbehaved on a config Codex had touched:

| | Symptom |
|---|---|
| `write_codex_config` | Stripped only the marker block, left the orphaned provider table, appended a second one. TOML rejects a table declared twice → Codex refuses to start, while the installer prints `✓ Weave Router installed for Codex.` |
| `resolve_installed_endpoint` | Read `base_url` only from between the markers → reported a live install as absent → `login codex` refused with "No Weave Router install found for codex in this scope" |
| `read_codex_key` | Matched only the quoted in-marker spelling of the header → could not reuse the key already on disk; non-interactively the re-install failed outright |
| `strip_codex_block` (uninstall) | Left the provider — and the router key inside it — on disk while reporting success |

## Fix

Match the `[model_providers.weave]` table (and its subtables) directly instead of relying on comments surviving. The regex is anchored so a neighbouring `[model_providers.weaver]` is never touched, and the key reader accepts the header name quoted or bare (our writer emits one spelling, Codex's serializer the other).

Also fixes a fifth, pre-existing bug found while testing: `codex_config_file` is only defined when the run's target *is* codex, but the models/accounts/login/status preamble resolves a Codex install even when the target is Claude. `npx @weave-os/router status` against a Codex-only install therefore died under `set -u` with `codex_config_file: unbound variable` instead of reporting the install. Shout if you'd rather that landed separately — it's one line plus a comment, and it's on the same path as the `login` failure above.

## Verification

New regression tests in `install/tests/codex_install_test.sh` seed a Codex-normalized config (markers absent, provider present, headers in a subtable, alongside real `[hooks.state...]` and `[projects...]` entries) and assert:

- install stays idempotent — one provider table, no leftover headers subtable, one top-level `model_provider`, and the file still parses as TOML (the exact check Codex makes at startup)
- unrelated Codex-owned state (hook trust, project trust) survives both install and uninstall
- `status` reports `Codex: points at Router`, and `login codex` gets past the "no install" refusal
- a non-interactive re-install reuses the key already in the config instead of minting a new one
- uninstall removes the provider, the key, and the routing default
- `[model_providers.weaver]` is left alone by both install and uninstall

Confirmed these fail against the pre-fix installer and pass after. Full `make test-install` suite is green locally (codex_install, codex-status, key_reuse 69/69, models 95/95, registry 50/50, packaging 22/22, tool_search, cc-statusline 47/47).

Not run locally: shellcheck (not installed on this machine) — CI's `check_non_go` job covers it. The awk regexes were checked against BSD awk only; they use POSIX ERE constructs (`[[:space:]]`, `(...)?`, `[^]]`) so mawk/gawk on the runner should agree.

## Follow-up not in this PR

The managed block's `[[hooks.SessionStart]]` / `[[hooks.Stop]]` entries get duplicated the same way. Array-of-tables entries append rather than collide, so this is legal TOML and does not break startup — it just runs `codex-status.sh` twice per session. Attributing an out-of-marker hook entry to us needs a different signal (matching the command path), so I left it out rather than guess at the semantics.
