### PR TITLE
fix(install): preserve Codex hooks and ignore commented credentials

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -611,10 +611,43 @@ TOML
     # appended a second one -- TOML rejects a table declared twice, so Codex
     # refused to start with "duplicate key" while the installer reported
     # success.
-    awk -v begin="$WEAVE_CODEX_BEGIN_MARKER" -v end="$WEAVE_CODEX_END_MARKER" '
-      $0 == begin { skip = 1; next }
+    # Remove only our command children from markerless hook arrays; preserve
+    # other commands, including children sharing the same event entry.
+    awk -v begin="$WEAVE_CODEX_BEGIN_MARKER" -v end="$WEAVE_CODEX_END_MARKER" -v status="$esc_status" '
+      function flush_child() {
+        if (child != "" && !owned_child) kept_children = kept_children child
+        if (owned_child) removed_child = 1
+        child = ""; owned_child = 0
+      }
+      function flush_hook() {
+        flush_child()
+        if (hook_header != "" && (kept_children != "" || !removed_child))
+          printf "%s%s", hook_header, kept_children
+        hook_header = ""; kept_children = ""; removed_child = 0
+      }
+      $0 == begin { flush_hook(); skip = 1; next }
       $0 == end   { skip = 0; next }
       skip        { next }
+      hook_header != "" && /^[[:space:]]*\[\[hooks\.(SessionStart|Stop)\.hooks\]\][[:space:]]*(#.*)?$/ {
+        flush_child(); child = $0 "\n"; next
+      }
+      /^[[:space:]]*\[/ { flush_hook() }
+      /^[[:space:]]*\[\[hooks\.(SessionStart|Stop)\]\][[:space:]]*(#.*)?$/ {
+        in_section = 1; in_weave_provider = 0; hook_header = $0 "\n"; next
+      }
+      hook_header != "" {
+        if (child == "") hook_header = hook_header $0 "\n"
+        else {
+          child = child $0 "\n"
+          if ($0 ~ /^[[:space:]]*command[[:space:]]*=/) {
+            command = $0
+            sub(/^[[:space:]]*command[[:space:]]*=[[:space:]]*"/, "", command)
+            sub(/"[[:space:]]*(#.*)?$/, "", command)
+            if (command == status) owned_child = 1
+          }
+        }
+        next
+      }
       /^[[:space:]]*\[/ {
         in_section = 1
         if ($0 ~ /^[[:space:]]*\[[[:space:]]*model_providers[[:space:]]*\.[[:space:]]*weave[[:space:]]*(\.[^]]*)?\][[:space:]]*(#.*)?$/) {
@@ -626,6 +659,7 @@ TOML
       in_weave_provider { next }
       !in_section && /^[[:space:]]*model_provider[[:space:]]*=/ { next }
       { print }
+      END { flush_hook() }
     ' "$config_file" >"$tmp"
 
     # Insert the managed block at TOML top-level scope, NOT end-of-file. In
@@ -1879,7 +1913,7 @@ read_codex_key() {
       in_provider = ($0 ~ /^[[:space:]]*\[[[:space:]]*model_providers[[:space:]]*\.[[:space:]]*weave[[:space:]]*(\.[^]]*)?\][[:space:]]*(#.*)?$/)
       next
     }
-    in_provider && match($0, /"?X-Weave-Router-Key"?[[:space:]]*=[[:space:]]*"[^"]*"/) {
+    in_provider && $0 ~ /^[[:space:]]*(http_headers[[:space:]]*=[[:space:]]*\{|"?X-Weave-Router-Key"?[[:space:]]*=)/ && match($0, /"?X-Weave-Router-Key"?[[:space:]]*=[[:space:]]*"[^"]*"/) {
       hdr = substr($0, RSTART, RLENGTH)
       sub(/^.*=[[:space:]]*"/, "", hdr)
       sub(/"$/, "", hdr)

--- a/install/tests/codex_install_test.sh
+++ b/install/tests/codex_install_test.sh
@@ -241,6 +241,7 @@ wire_api = "responses"
 
 [model_providers.weave.http_headers]
 X-App = "codex"
+# X-Weave-Router-Key = "rk_commented_key"
 X-Weave-Router-Key = "rk_normalized_key"
 
 [projects."/Users/a/Code/weave"]
@@ -275,6 +276,42 @@ grep -Fq '[hooks.state."/Users/a/.codex/config.toml:stop:0:0"]' "$config" \
   || fail "install over a Codex-rewritten config dropped Codex hook state"
 grep -Fq '[projects."/Users/a/Code/weave"]' "$config" \
   || fail "install over a Codex-rewritten config dropped Codex project trust"
+
+# Rewritten configs can retain our hook children next to user-owned children.
+seed_codex_normalized_config
+cat >>"$config" <<HOOKS
+
+[[hooks.SessionStart]]
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = "$status_helper"
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = "echo user-hook"
+[[hooks.SessionStart]]
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = "$status_helper"
+[[hooks.Stop]]
+[[hooks.Stop.hooks]]
+type = "command"
+command = "$status_helper"
+HOOKS
+for pass in 1 2; do
+  run_hosted_install
+  assert_config_parses "hook reconciliation produced invalid TOML"
+  python3 - "$config" "$status_helper" <<'HOOK_CHECK'
+import sys, tomllib
+with open(sys.argv[1], "rb") as stream:
+    config = tomllib.load(stream)
+for event in ("SessionStart", "Stop"):
+    commands = [hook["command"] for entry in config["hooks"][event] for hook in entry["hooks"]]
+    assert commands.count(sys.argv[2]) == 1, commands
+    assert commands.count("echo user-hook") == (1 if event == "SessionStart" else 0), commands
+HOOK_CHECK
+  sed '/^[[:space:]]*#/d' "$config" >"$config.rewritten"
+  mv "$config.rewritten" "$config"
+done
 
 # The endpoint reader backs `login`/`status`. Reading only between the markers
 # reported "No Weave Router install found for codex in this scope" on a


### PR DESCRIPTION
Codex can rewrite config.toml without the installer's markers. Reinstall now removes only the managed status-hook commands before adding one fresh pair, preserving user commands even within the same hook event. Credential discovery ignores commented assignments and matches active header assignments.

Addresses the two installer findings on weave-os/weave#13216 in the canonical source. After this merges, that PR can update its Router pin and embedded installer together.

Validation: Codex installer regression suite passed, including duplicate managed hooks, mixed user hooks, repeated markerless reinstalls, and commented credentials; key reuse suite passed 69 checks; bash syntax and git diff checks passed.
