### PR TITLE
fix: sanitize overlong Anthropic tool use names

### DIFF
--- a/internal/translate/crossformat_request_test.go
+++ b/internal/translate/crossformat_request_test.go
@@ -2,6 +2,7 @@ package translate_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 var openAISimpleConversation = []byte(`{
@@ -2037,6 +2039,58 @@ func TestSanitizeToolUseIDs_AnthropicToAnthropic(t *testing.T) {
 	user := msgs[1].(map[string]any)
 	result := user["content"].([]any)[0].(map[string]any)
 	assert.Equal(t, "functions_Grep_11", result["tool_use_id"], "tool_use_id must be sanitized in same-format path")
+}
+
+func TestSanitizeOverlongToolUseNames(t *testing.T) {
+	overlongName := "Bname</arg_key><arg_value>" + strings.Repeat("x", 220)
+	tests := []struct {
+		name  string
+		parse func([]byte) (*translate.RequestEnvelope, error)
+		body  string
+	}{
+		{
+			name:  "anthropic history",
+			parse: translate.ParseAnthropic,
+			body: `{
+				"model": "claude-opus-4-7",
+				"messages": [
+					{"role": "assistant", "content": [
+						{"type": "tool_use", "id": "toolu_bad", "name": %q, "input": {}}
+					]},
+					{"role": "user", "content": [
+						{"type": "tool_result", "tool_use_id": "toolu_bad", "content": "unknown tool"}
+					]}
+				]
+			}`,
+		},
+		{
+			name:  "openai history",
+			parse: translate.ParseOpenAI,
+			body: `{
+				"model": "gpt-5",
+				"messages": [
+					{"role": "assistant", "tool_calls": [
+						{"id": "call_bad", "type": "function", "function": {"name": %q, "arguments": "{}"}}
+					]},
+					{"role": "tool", "tool_call_id": "call_bad", "content": "unknown tool"}
+				]
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env, err := tt.parse([]byte(fmt.Sprintf(tt.body, overlongName)))
+			require.NoError(t, err)
+			prep, err := env.PrepareAnthropic(http.Header{}, translate.EmitOptions{TargetModel: "claude-opus-4-7"})
+			require.NoError(t, err)
+
+			emittedName := gjson.GetBytes(prep.Body, "messages.0.content.0.name").String()
+			assert.LessOrEqual(t, len(emittedName), 200)
+			assert.Regexp(t, `^invalid_tool_[a-f0-9]{40}$`, emittedName)
+			assert.NotContains(t, string(prep.Body), overlongName)
+		})
+	}
 }
 
 // TestStripToolUseThoughtSignature_AnthropicToAnthropic checks a Gemini

--- a/internal/translate/crossformat_request_test.go
+++ b/internal/translate/crossformat_request_test.go
@@ -2053,6 +2053,8 @@ func TestSanitizeOverlongToolUseNames(t *testing.T) {
 			parse: translate.ParseAnthropic,
 			body: `{
 				"model": "claude-opus-4-7",
+				"tools": [{"name": %q, "input_schema": {"type": "object"}}],
+				"tool_choice": {"type": "tool", "name": %q},
 				"messages": [
 					{"role": "assistant", "content": [
 						{"type": "tool_use", "id": "toolu_bad", "name": %q, "input": {}}
@@ -2068,6 +2070,8 @@ func TestSanitizeOverlongToolUseNames(t *testing.T) {
 			parse: translate.ParseOpenAI,
 			body: `{
 				"model": "gpt-5",
+				"tools": [{"type": "function", "function": {"name": %q, "parameters": {"type": "object"}}}],
+				"tool_choice": {"type": "function", "function": {"name": %q}},
 				"messages": [
 					{"role": "assistant", "tool_calls": [
 						{"id": "call_bad", "type": "function", "function": {"name": %q, "arguments": "{}"}}
@@ -2080,14 +2084,21 @@ func TestSanitizeOverlongToolUseNames(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			env, err := tt.parse([]byte(fmt.Sprintf(tt.body, overlongName)))
+			env, err := tt.parse([]byte(fmt.Sprintf(tt.body, overlongName, overlongName, overlongName)))
 			require.NoError(t, err)
 			prep, err := env.PrepareAnthropic(http.Header{}, translate.EmitOptions{TargetModel: "claude-opus-4-7"})
 			require.NoError(t, err)
 
-			emittedName := gjson.GetBytes(prep.Body, "messages.0.content.0.name").String()
-			assert.LessOrEqual(t, len(emittedName), 200)
-			assert.Regexp(t, `^invalid_tool_[a-f0-9]{40}$`, emittedName)
+			emittedNames := []string{
+				gjson.GetBytes(prep.Body, "messages.0.content.0.name").String(),
+				gjson.GetBytes(prep.Body, "tools.0.name").String(),
+				gjson.GetBytes(prep.Body, "tool_choice.name").String(),
+			}
+			for _, emittedName := range emittedNames {
+				assert.LessOrEqual(t, len(emittedName), 200)
+				assert.Regexp(t, `^invalid_tool_[a-f0-9]{40}$`, emittedName)
+				assert.Equal(t, emittedNames[0], emittedName)
+			}
 			assert.NotContains(t, string(prep.Body), overlongName)
 		})
 	}

--- a/internal/translate/crossformat_request_test.go
+++ b/internal/translate/crossformat_request_test.go
@@ -2152,6 +2152,31 @@ func TestSanitizeAnthropicHistoricalToolNameCountsUnicodeCharacters(t *testing.T
 	assert.Regexp(t, `^invalid_tool_[a-f0-9]{40}$`, gjson.GetBytes(prep.Body, "messages.0.content.0.name").String())
 }
 
+func TestSanitizeAnthropicToolNamesAvoidsHistoricalAliasCollisions(t *testing.T) {
+	invalidDeclaredName := strings.Repeat("b", 65)
+	collidingHistoricalName := "invalid_tool_af8615a17a61c9bc8fec267292a3abde6a482f0b"
+	body := []byte(fmt.Sprintf(`{
+		"model": "claude-opus-4-7",
+		"tools": [{"name": %q, "input_schema": {"type": "object"}}],
+		"tool_choice": {"type": "tool", "name": %q},
+		"messages": [{"role": "assistant", "content": [
+			{"type": "tool_use", "id": "toolu_existing_alias", "name": %q, "input": {}},
+			{"type": "tool_use", "id": "toolu_invalid_declared", "name": %q, "input": {}}
+		]}]
+	}`, invalidDeclaredName, invalidDeclaredName, collidingHistoricalName, invalidDeclaredName))
+
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareAnthropic(http.Header{}, translate.EmitOptions{TargetModel: "claude-opus-4-7"})
+	require.NoError(t, err)
+
+	assert.Equal(t, collidingHistoricalName, gjson.GetBytes(prep.Body, "messages.0.content.0.name").String())
+	declaredAlias := gjson.GetBytes(prep.Body, "tools.0.name").String()
+	assert.NotEqual(t, collidingHistoricalName, declaredAlias)
+	assert.Equal(t, declaredAlias, gjson.GetBytes(prep.Body, "tool_choice.name").String())
+	assert.Equal(t, declaredAlias, gjson.GetBytes(prep.Body, "messages.0.content.1.name").String())
+}
+
 // TestStripToolUseThoughtSignature_AnthropicToAnthropic checks a Gemini
 // thought_signature on a tool_use block is stripped before forwarding to
 // Anthropic (which 400s on the unknown field), while the id — which smuggles

--- a/internal/translate/crossformat_request_test.go
+++ b/internal/translate/crossformat_request_test.go
@@ -2104,6 +2104,48 @@ func TestSanitizeOverlongToolUseNames(t *testing.T) {
 	}
 }
 
+func TestSanitizeAnthropicToolNamesUsesFieldSpecificLimits(t *testing.T) {
+	validHistoricalUnicodeName := strings.Repeat("界", 100)
+	invalidDeclaredName := strings.Repeat("a", 65)
+	body := []byte(fmt.Sprintf(`{
+		"model": "claude-opus-4-7",
+		"tools": [{"name": %q, "input_schema": {"type": "object"}}],
+		"tool_choice": {"type": "tool", "name": %q},
+		"messages": [{"role": "assistant", "content": [
+			{"type": "tool_use", "id": "toolu_valid_unicode", "name": %q, "input": {}},
+			{"type": "tool_use", "id": "toolu_invalid_declared", "name": %q, "input": {}}
+		]}]
+	}`, invalidDeclaredName, invalidDeclaredName, validHistoricalUnicodeName, invalidDeclaredName))
+
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareAnthropic(http.Header{}, translate.EmitOptions{TargetModel: "claude-opus-4-7"})
+	require.NoError(t, err)
+
+	assert.Equal(t, validHistoricalUnicodeName, gjson.GetBytes(prep.Body, "messages.0.content.0.name").String())
+	declaredAlias := gjson.GetBytes(prep.Body, "tools.0.name").String()
+	assert.Regexp(t, `^invalid_tool_[a-f0-9]{40}$`, declaredAlias)
+	assert.Equal(t, declaredAlias, gjson.GetBytes(prep.Body, "tool_choice.name").String())
+	assert.Equal(t, declaredAlias, gjson.GetBytes(prep.Body, "messages.0.content.1.name").String())
+}
+
+func TestSanitizeAnthropicHistoricalToolNameCountsUnicodeCharacters(t *testing.T) {
+	overlongHistoricalName := strings.Repeat("界", 201)
+	body := []byte(fmt.Sprintf(`{
+		"model": "claude-opus-4-7",
+		"messages": [{"role": "assistant", "content": [
+			{"type": "tool_use", "id": "toolu_overlong_unicode", "name": %q, "input": {}}
+		]}]
+	}`, overlongHistoricalName))
+
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareAnthropic(http.Header{}, translate.EmitOptions{TargetModel: "claude-opus-4-7"})
+	require.NoError(t, err)
+
+	assert.Regexp(t, `^invalid_tool_[a-f0-9]{40}$`, gjson.GetBytes(prep.Body, "messages.0.content.0.name").String())
+}
+
 // TestStripToolUseThoughtSignature_AnthropicToAnthropic checks a Gemini
 // thought_signature on a tool_use block is stripped before forwarding to
 // Anthropic (which 400s on the unknown field), while the id — which smuggles

--- a/internal/translate/crossformat_request_test.go
+++ b/internal/translate/crossformat_request_test.go
@@ -2107,15 +2107,19 @@ func TestSanitizeOverlongToolUseNames(t *testing.T) {
 func TestSanitizeAnthropicToolNamesUsesFieldSpecificLimits(t *testing.T) {
 	validHistoricalUnicodeName := strings.Repeat("界", 100)
 	invalidDeclaredName := strings.Repeat("a", 65)
+	collidingDeclaredName := "invalid_tool_11655326c708d70319be2610e8a57d9a5b959d3b"
 	body := []byte(fmt.Sprintf(`{
 		"model": "claude-opus-4-7",
-		"tools": [{"name": %q, "input_schema": {"type": "object"}}],
+		"tools": [
+			{"name": %q, "input_schema": {"type": "object"}},
+			{"name": %q, "input_schema": {"type": "object"}}
+		],
 		"tool_choice": {"type": "tool", "name": %q},
 		"messages": [{"role": "assistant", "content": [
 			{"type": "tool_use", "id": "toolu_valid_unicode", "name": %q, "input": {}},
 			{"type": "tool_use", "id": "toolu_invalid_declared", "name": %q, "input": {}}
 		]}]
-	}`, invalidDeclaredName, invalidDeclaredName, validHistoricalUnicodeName, invalidDeclaredName))
+	}`, collidingDeclaredName, invalidDeclaredName, invalidDeclaredName, validHistoricalUnicodeName, invalidDeclaredName))
 
 	env, err := translate.ParseAnthropic(body)
 	require.NoError(t, err)
@@ -2123,8 +2127,10 @@ func TestSanitizeAnthropicToolNamesUsesFieldSpecificLimits(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, validHistoricalUnicodeName, gjson.GetBytes(prep.Body, "messages.0.content.0.name").String())
-	declaredAlias := gjson.GetBytes(prep.Body, "tools.0.name").String()
+	assert.Equal(t, collidingDeclaredName, gjson.GetBytes(prep.Body, "tools.0.name").String())
+	declaredAlias := gjson.GetBytes(prep.Body, "tools.1.name").String()
 	assert.Regexp(t, `^invalid_tool_[a-f0-9]{40}$`, declaredAlias)
+	assert.NotEqual(t, collidingDeclaredName, declaredAlias)
 	assert.Equal(t, declaredAlias, gjson.GetBytes(prep.Body, "tool_choice.name").String())
 	assert.Equal(t, declaredAlias, gjson.GetBytes(prep.Body, "messages.0.content.1.name").String())
 }

--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -823,17 +823,30 @@ const maxAnthropicHistoricalToolNameChars = 200
 var anthropicDeclaredToolNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
 
 func sanitizeAnthropicToolNamesBytes(body []byte) ([]byte, error) {
+	tools := gjson.GetBytes(body, "tools").Array()
+	reservedNames := make(map[string]struct{}, len(tools))
+	for _, tool := range tools {
+		name := tool.Get("name").String()
+		if anthropicDeclaredToolNamePattern.MatchString(name) {
+			reservedNames[name] = struct{}{}
+		}
+	}
+
 	aliases := make(map[string]string)
-	for _, tool := range gjson.GetBytes(body, "tools").Array() {
+	for _, tool := range tools {
 		name := tool.Get("name").String()
 		if !anthropicDeclaredToolNamePattern.MatchString(name) {
-			aliases[name] = sanitizedAnthropicToolName(name)
+			if _, exists := aliases[name]; !exists {
+				aliases[name] = uniqueSanitizedAnthropicToolName(name, reservedNames)
+			}
 		}
 	}
 	choice := gjson.GetBytes(body, "tool_choice")
 	choiceName := choice.Get("name").String()
 	if choice.Get("type").String() == "tool" && !anthropicDeclaredToolNamePattern.MatchString(choiceName) {
-		aliases[choiceName] = sanitizedAnthropicToolName(choiceName)
+		if _, exists := aliases[choiceName]; !exists {
+			aliases[choiceName] = uniqueSanitizedAnthropicToolName(choiceName, reservedNames)
+		}
 	}
 
 	out, err := rewriteMessageBlocks(
@@ -887,6 +900,21 @@ func sanitizeAnthropicToolNamesBytes(body []byte) ([]byte, error) {
 func sanitizedAnthropicToolName(name string) string {
 	nameHash := sha1.Sum([]byte(name))
 	return fmt.Sprintf("invalid_tool_%x", nameHash)
+}
+
+func uniqueSanitizedAnthropicToolName(name string, reservedNames map[string]struct{}) string {
+	for attempt := 0; ; attempt++ {
+		hashInput := name
+		if attempt > 0 {
+			hashInput = fmt.Sprintf("%s_%d", name, attempt)
+		}
+		alias := sanitizedAnthropicToolName(hashInput)
+		if _, exists := reservedNames[alias]; exists {
+			continue
+		}
+		reservedNames[alias] = struct{}{}
+		return alias
+	}
 }
 
 func anthropicToolSchemaRaw(schema gjson.Result) string {

--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -1,6 +1,7 @@
 package translate
 
 import (
+	"crypto/sha1"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -30,6 +31,10 @@ func (e *RequestEnvelope) PrepareAnthropic(in http.Header, opts EmitOptions) (pr
 		}
 	default:
 		return providers.PreparedRequest{}, fmt.Errorf("unsupported source format for Anthropic emit: %d", e.format)
+	}
+	body, err = sanitizeAnthropicToolUseNamesBytes(body)
+	if err != nil {
+		return providers.PreparedRequest{}, fmt.Errorf("sanitize anthropic tool_use names: %w", err)
 	}
 	body, err = applyAnthropicCachePolicy(body, true)
 	if err != nil {
@@ -808,6 +813,29 @@ func sanitizeAnthropicToolSchemasBytes(body []byte) ([]byte, error) {
 		return nil, err
 	}
 	return sjson.SetRawBytes(body, "tools", raw)
+}
+
+// maxAnthropicToolUseNameLen is Anthropic's request limit for names in
+// historical tool_use blocks. Tool names produced by another provider can be
+// malformed while still surviving in client history, so overlong values are
+// replaced with a stable alias before that history is replayed to Anthropic.
+const maxAnthropicToolUseNameLen = 200
+
+func sanitizeAnthropicToolUseNamesBytes(body []byte) ([]byte, error) {
+	return rewriteMessageBlocks(body, hasOverlongAnthropicToolUseName, sanitizeAnthropicToolUseNameBlock)
+}
+
+func hasOverlongAnthropicToolUseName(block gjson.Result) bool {
+	return block.Get("type").String() == "tool_use" && len(block.Get("name").String()) > maxAnthropicToolUseNameLen
+}
+
+func sanitizeAnthropicToolUseNameBlock(raw string) (string, error) {
+	nameHash := sha1.Sum([]byte(gjson.Get(raw, "name").String()))
+	out, err := sjson.Set(raw, "name", fmt.Sprintf("invalid_tool_%x", nameHash))
+	if err != nil {
+		return "", fmt.Errorf("rewrite tool_use name: %w", err)
+	}
+	return out, nil
 }
 
 func anthropicToolSchemaRaw(schema gjson.Result) string {

--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -831,6 +831,13 @@ func sanitizeAnthropicToolNamesBytes(body []byte) ([]byte, error) {
 			reservedNames[name] = struct{}{}
 		}
 	}
+	for _, message := range gjson.GetBytes(body, "messages").Array() {
+		for _, block := range message.Get("content").Array() {
+			if block.Get("type").String() == "tool_use" {
+				reservedNames[block.Get("name").String()] = struct{}{}
+			}
+		}
+	}
 
 	aliases := make(map[string]string)
 	for _, tool := range tools {

--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"weave-os/router/internal/providers"
 	"weave-os/router/internal/router"
@@ -815,45 +817,69 @@ func sanitizeAnthropicToolSchemasBytes(body []byte) ([]byte, error) {
 	return sjson.SetRawBytes(body, "tools", raw)
 }
 
-// maxAnthropicToolNameLen is Anthropic's request limit for tool names. Tool
-// names produced by another provider can be malformed while still surviving in
-// client history, so every reference uses the same stable alias on replay.
-const maxAnthropicToolNameLen = 200
+// Anthropic permits longer historical tool_use names than declared tool names.
+const maxAnthropicHistoricalToolNameChars = 200
+
+var anthropicDeclaredToolNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
 
 func sanitizeAnthropicToolNamesBytes(body []byte) ([]byte, error) {
-	out, err := rewriteMessageBlocks(body, hasOverlongAnthropicToolUseName, sanitizeAnthropicToolUseNameBlock)
+	aliases := make(map[string]string)
+	for _, tool := range gjson.GetBytes(body, "tools").Array() {
+		name := tool.Get("name").String()
+		if !anthropicDeclaredToolNamePattern.MatchString(name) {
+			aliases[name] = sanitizedAnthropicToolName(name)
+		}
+	}
+	choice := gjson.GetBytes(body, "tool_choice")
+	choiceName := choice.Get("name").String()
+	if choice.Get("type").String() == "tool" && !anthropicDeclaredToolNamePattern.MatchString(choiceName) {
+		aliases[choiceName] = sanitizedAnthropicToolName(choiceName)
+	}
+
+	out, err := rewriteMessageBlocks(
+		body,
+		func(block gjson.Result) bool {
+			if block.Get("type").String() != "tool_use" {
+				return false
+			}
+			name := block.Get("name").String()
+			_, hasAlias := aliases[name]
+			return hasAlias || utf8.RuneCountInString(name) > maxAnthropicHistoricalToolNameChars
+		},
+		func(raw string) (string, error) {
+			name := gjson.Get(raw, "name").String()
+			alias, ok := aliases[name]
+			if !ok {
+				alias = sanitizedAnthropicToolName(name)
+			}
+			rewritten, rewriteErr := sjson.Set(raw, "name", alias)
+			if rewriteErr != nil {
+				return "", fmt.Errorf("rewrite tool_use name: %w", rewriteErr)
+			}
+			return rewritten, nil
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
 	for index, tool := range gjson.GetBytes(out, "tools").Array() {
 		name := tool.Get("name").String()
-		if len(name) <= maxAnthropicToolNameLen {
+		alias, ok := aliases[name]
+		if !ok {
 			continue
 		}
-		out, err = sjson.SetBytes(out, fmt.Sprintf("tools.%d.name", index), sanitizedAnthropicToolName(name))
+		out, err = sjson.SetBytes(out, fmt.Sprintf("tools.%d.name", index), alias)
 		if err != nil {
 			return nil, fmt.Errorf("rewrite declared tool name: %w", err)
 		}
 	}
-	choice := gjson.GetBytes(out, "tool_choice")
-	choiceName := choice.Get("name").String()
-	if choice.Get("type").String() == "tool" && len(choiceName) > maxAnthropicToolNameLen {
-		out, err = sjson.SetBytes(out, "tool_choice.name", sanitizedAnthropicToolName(choiceName))
-		if err != nil {
-			return nil, fmt.Errorf("rewrite tool_choice name: %w", err)
+	if choice.Get("type").String() == "tool" {
+		if alias, ok := aliases[choiceName]; ok {
+			out, err = sjson.SetBytes(out, "tool_choice.name", alias)
+			if err != nil {
+				return nil, fmt.Errorf("rewrite tool_choice name: %w", err)
+			}
 		}
-	}
-	return out, nil
-}
-
-func hasOverlongAnthropicToolUseName(block gjson.Result) bool {
-	return block.Get("type").String() == "tool_use" && len(block.Get("name").String()) > maxAnthropicToolNameLen
-}
-
-func sanitizeAnthropicToolUseNameBlock(raw string) (string, error) {
-	out, err := sjson.Set(raw, "name", sanitizedAnthropicToolName(gjson.Get(raw, "name").String()))
-	if err != nil {
-		return "", fmt.Errorf("rewrite tool_use name: %w", err)
 	}
 	return out, nil
 }

--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -32,9 +32,9 @@ func (e *RequestEnvelope) PrepareAnthropic(in http.Header, opts EmitOptions) (pr
 	default:
 		return providers.PreparedRequest{}, fmt.Errorf("unsupported source format for Anthropic emit: %d", e.format)
 	}
-	body, err = sanitizeAnthropicToolUseNamesBytes(body)
+	body, err = sanitizeAnthropicToolNamesBytes(body)
 	if err != nil {
-		return providers.PreparedRequest{}, fmt.Errorf("sanitize anthropic tool_use names: %w", err)
+		return providers.PreparedRequest{}, fmt.Errorf("sanitize anthropic tool names: %w", err)
 	}
 	body, err = applyAnthropicCachePolicy(body, true)
 	if err != nil {
@@ -815,27 +815,52 @@ func sanitizeAnthropicToolSchemasBytes(body []byte) ([]byte, error) {
 	return sjson.SetRawBytes(body, "tools", raw)
 }
 
-// maxAnthropicToolUseNameLen is Anthropic's request limit for names in
-// historical tool_use blocks. Tool names produced by another provider can be
-// malformed while still surviving in client history, so overlong values are
-// replaced with a stable alias before that history is replayed to Anthropic.
-const maxAnthropicToolUseNameLen = 200
+// maxAnthropicToolNameLen is Anthropic's request limit for tool names. Tool
+// names produced by another provider can be malformed while still surviving in
+// client history, so every reference uses the same stable alias on replay.
+const maxAnthropicToolNameLen = 200
 
-func sanitizeAnthropicToolUseNamesBytes(body []byte) ([]byte, error) {
-	return rewriteMessageBlocks(body, hasOverlongAnthropicToolUseName, sanitizeAnthropicToolUseNameBlock)
+func sanitizeAnthropicToolNamesBytes(body []byte) ([]byte, error) {
+	out, err := rewriteMessageBlocks(body, hasOverlongAnthropicToolUseName, sanitizeAnthropicToolUseNameBlock)
+	if err != nil {
+		return nil, err
+	}
+	for index, tool := range gjson.GetBytes(out, "tools").Array() {
+		name := tool.Get("name").String()
+		if len(name) <= maxAnthropicToolNameLen {
+			continue
+		}
+		out, err = sjson.SetBytes(out, fmt.Sprintf("tools.%d.name", index), sanitizedAnthropicToolName(name))
+		if err != nil {
+			return nil, fmt.Errorf("rewrite declared tool name: %w", err)
+		}
+	}
+	choice := gjson.GetBytes(out, "tool_choice")
+	choiceName := choice.Get("name").String()
+	if choice.Get("type").String() == "tool" && len(choiceName) > maxAnthropicToolNameLen {
+		out, err = sjson.SetBytes(out, "tool_choice.name", sanitizedAnthropicToolName(choiceName))
+		if err != nil {
+			return nil, fmt.Errorf("rewrite tool_choice name: %w", err)
+		}
+	}
+	return out, nil
 }
 
 func hasOverlongAnthropicToolUseName(block gjson.Result) bool {
-	return block.Get("type").String() == "tool_use" && len(block.Get("name").String()) > maxAnthropicToolUseNameLen
+	return block.Get("type").String() == "tool_use" && len(block.Get("name").String()) > maxAnthropicToolNameLen
 }
 
 func sanitizeAnthropicToolUseNameBlock(raw string) (string, error) {
-	nameHash := sha1.Sum([]byte(gjson.Get(raw, "name").String()))
-	out, err := sjson.Set(raw, "name", fmt.Sprintf("invalid_tool_%x", nameHash))
+	out, err := sjson.Set(raw, "name", sanitizedAnthropicToolName(gjson.Get(raw, "name").String()))
 	if err != nil {
 		return "", fmt.Errorf("rewrite tool_use name: %w", err)
 	}
 	return out, nil
+}
+
+func sanitizedAnthropicToolName(name string) string {
+	nameHash := sha1.Sum([]byte(name))
+	return fmt.Sprintf("invalid_tool_%x", nameHash)
 }
 
 func anthropicToolSchemaRaw(schema gjson.Result) string {


### PR DESCRIPTION
## Summary
- sanitize overlong historical `tool_use.name` values before emitting requests to Anthropic
- replace malformed names with stable hashed aliases so invalid cross-provider history does not poison future turns
- cover both Anthropic-format and OpenAI-format histories

## Why
A malformed tool call emitted by another provider can remain in client-supplied history. Anthropic rejects a later replay when the historical tool name exceeds its request limit, returning a non-retryable 400 before inference.

## Validation
- `go test ./internal/translate/...`
- `wv router test`
- `wv router typecheck`
- `go vet ./...`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes Anthropic tool names that violate Anthropic's name limits so malformed cross-provider history no longer triggers a non-retryable 400 before inference.

- Applies the 64-character limit to declared `tools` and named `tool_choice`, and the 200-character limit to historical `tool_use` names.
- Replaces invalid names with a stable `invalid_tool_` + SHA-1 hash alias shared across matching references.
- Reserves valid declared and historical names before generating aliases so prior calls aren't conflated, producing collision-free alternate aliases when a hash would clash.
- Counts Unicode characters and covers both Anthropic-format and OpenAI-format request histories.

<sup>Written for commit 6d5bbcd812ead82e0b0ef8937c69d1700e7861ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weave-os/router/pull/1219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

