### PR TITLE
fix: keep Anthropic tool aliases stable

### DIFF
--- a/internal/translate/crossformat_request_test.go
+++ b/internal/translate/crossformat_request_test.go
@@ -2152,29 +2152,46 @@ func TestSanitizeAnthropicHistoricalToolNameCountsUnicodeCharacters(t *testing.T
 	assert.Regexp(t, `^invalid_tool_[a-f0-9]{40}$`, gjson.GetBytes(prep.Body, "messages.0.content.0.name").String())
 }
 
-func TestSanitizeAnthropicToolNamesAvoidsHistoricalAliasCollisions(t *testing.T) {
-	invalidDeclaredName := strings.Repeat("b", 65)
-	collidingHistoricalName := "invalid_tool_af8615a17a61c9bc8fec267292a3abde6a482f0b"
-	body := []byte(fmt.Sprintf(`{
+func TestSanitizeAnthropicToolNameAliasStableAcrossReplay(t *testing.T) {
+	invalidDeclaredName := strings.Repeat("a", 65)
+	collidingDeclaredName := "invalid_tool_11655326c708d70319be2610e8a57d9a5b959d3b"
+	initialBody := []byte(fmt.Sprintf(`{
 		"model": "claude-opus-4-7",
-		"tools": [{"name": %q, "input_schema": {"type": "object"}}],
+		"tools": [
+			{"name": %q, "input_schema": {"type": "object"}},
+			{"name": %q, "input_schema": {"type": "object"}}
+		],
 		"tool_choice": {"type": "tool", "name": %q},
-		"messages": [{"role": "assistant", "content": [
-			{"type": "tool_use", "id": "toolu_existing_alias", "name": %q, "input": {}},
-			{"type": "tool_use", "id": "toolu_invalid_declared", "name": %q, "input": {}}
-		]}]
-	}`, invalidDeclaredName, invalidDeclaredName, collidingHistoricalName, invalidDeclaredName))
+		"messages": [{"role": "user", "content": "use the tool"}]
+	}`, collidingDeclaredName, invalidDeclaredName, invalidDeclaredName))
 
-	env, err := translate.ParseAnthropic(body)
+	env, err := translate.ParseAnthropic(initialBody)
 	require.NoError(t, err)
 	prep, err := env.PrepareAnthropic(http.Header{}, translate.EmitOptions{TargetModel: "claude-opus-4-7"})
 	require.NoError(t, err)
+	initialAlias := gjson.GetBytes(prep.Body, "tools.1.name").String()
+	require.NotEqual(t, collidingDeclaredName, initialAlias)
 
-	assert.Equal(t, collidingHistoricalName, gjson.GetBytes(prep.Body, "messages.0.content.0.name").String())
-	declaredAlias := gjson.GetBytes(prep.Body, "tools.0.name").String()
-	assert.NotEqual(t, collidingHistoricalName, declaredAlias)
-	assert.Equal(t, declaredAlias, gjson.GetBytes(prep.Body, "tool_choice.name").String())
-	assert.Equal(t, declaredAlias, gjson.GetBytes(prep.Body, "messages.0.content.1.name").String())
+	replayBody := []byte(fmt.Sprintf(`{
+		"model": "claude-opus-4-7",
+		"tools": [
+			{"name": %q, "input_schema": {"type": "object"}},
+			{"name": %q, "input_schema": {"type": "object"}}
+		],
+		"tool_choice": {"type": "tool", "name": %q},
+		"messages": [{"role": "assistant", "content": [
+			{"type": "tool_use", "id": "toolu_prior_alias", "name": %q, "input": {}}
+		]}]
+	}`, collidingDeclaredName, invalidDeclaredName, invalidDeclaredName, initialAlias))
+
+	replayEnv, err := translate.ParseAnthropic(replayBody)
+	require.NoError(t, err)
+	replay, err := replayEnv.PrepareAnthropic(http.Header{}, translate.EmitOptions{TargetModel: "claude-opus-4-7"})
+	require.NoError(t, err)
+
+	assert.Equal(t, initialAlias, gjson.GetBytes(replay.Body, "tools.1.name").String())
+	assert.Equal(t, initialAlias, gjson.GetBytes(replay.Body, "tool_choice.name").String())
+	assert.Equal(t, initialAlias, gjson.GetBytes(replay.Body, "messages.0.content.0.name").String())
 }
 
 // TestStripToolUseThoughtSignature_AnthropicToAnthropic checks a Gemini

--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -831,13 +831,6 @@ func sanitizeAnthropicToolNamesBytes(body []byte) ([]byte, error) {
 			reservedNames[name] = struct{}{}
 		}
 	}
-	for _, message := range gjson.GetBytes(body, "messages").Array() {
-		for _, block := range message.Get("content").Array() {
-			if block.Get("type").String() == "tool_use" {
-				reservedNames[block.Get("name").String()] = struct{}{}
-			}
-		}
-	}
 
 	aliases := make(map[string]string)
 	for _, tool := range tools {


### PR DESCRIPTION
## Summary
- keep generated Anthropic tool aliases stable when sanitized names appear in replayed history
- reserve only live declared tool names when avoiding alias collisions
- add a two-turn regression test covering an alternate alias replay

## Why
Historical tool names are request history, not live declarations. Including them in the alias uniqueness set causes a previously emitted alias to change on the next turn, breaking consistency between the current tool definition and earlier tool calls.

## Validation
- targeted `internal/translate` sanitizer tests
- `wv router typecheck`
- `go vet ./internal/translate`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Anthropic tool alias stability so sanitized tool names keep the same alias across replayed turns.

Previously, historical `tool_use` names in messages were reserved alongside live declarations, which could shift the alias on the next turn. Now only live declared tool names are reserved. Also adds a two-turn regression test covering alternate alias replay.

<sup>Written for commit 06ad42590f73c49776469ce0432c9327a4cc2036. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weave-os/router/pull/1221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

