### PR TITLE
Fix compaction dropping the user routing boundary

### DIFF
--- a/internal/translate/compaction.go
+++ b/internal/translate/compaction.go
@@ -36,11 +36,12 @@ func (e *RequestEnvelope) ClearOldToolResults(keepRecent int) int {
 }
 
 // RewriteForCompaction rewrites history to [summary + recent keepRecentTurns
-// non-system messages], aligned to begin on a user turn so roles alternate.
-// Orphaned tool results (whose tool_use was elided) are stripped to keep the
-// request wire-valid. Unlike RewriteForHandover, a tail is kept so the model
-// retains immediate working context. Returns the number of messages elided.
-// Pure: no I/O. keepRecentTurns <= 0 is treated as 1.
+// non-system messages], aligned to begin on a text-bearing user turn so the
+// request retains a routing boundary. Orphaned tool results (whose tool_use
+// was elided) are stripped to keep the request wire-valid. Unlike
+// RewriteForHandover, a tail is kept so the model retains immediate working
+// context. Returns the number of messages elided. Pure: no I/O.
+// keepRecentTurns <= 0 is treated as 1.
 func (e *RequestEnvelope) RewriteForCompaction(summary string, keepRecentTurns int) int {
 	if e == nil {
 		return 0
@@ -58,18 +59,17 @@ func (e *RequestEnvelope) RewriteForCompaction(summary string, keepRecentTurns i
 	}
 }
 
-// userAlignedStart returns the index at which to begin a recent-message window
-// of size keepRecent drawn from msgs, advanced forward to the first user
-// message so the window starts on a user turn. Falls back to the last user
-// message's index when the window contains none.
-func userAlignedStart(msgs []gjson.Result, keepRecent int) int {
+// userTextAlignedStart returns the index at which to begin a recent-message
+// window, advanced to a user turn that still carries request text. Tool-result
+// turns do not establish a usable routing boundary.
+func userTextAlignedStart(msgs []gjson.Result, keepRecent int, format Format) int {
 	start := max(len(msgs)-keepRecent, 0)
-	for start < len(msgs) && msgs[start].Get("role").String() != "user" {
+	for start < len(msgs) && !isTextBearingUserMessage(msgs[start], format) {
 		start++
 	}
 	if start >= len(msgs) {
 		for i := len(msgs) - 1; i >= 0; i-- {
-			if msgs[i].Get("role").String() == "user" {
+			if isTextBearingUserMessage(msgs[i], format) {
 				return i
 			}
 		}
@@ -279,7 +279,7 @@ func (e *RequestEnvelope) rewriteAnthropicForCompaction(summary string, keepRece
 	if len(all) == 0 {
 		return 0
 	}
-	start := userAlignedStart(all, keepRecent)
+	start := userTextAlignedStart(all, keepRecent, FormatAnthropic)
 	cleaned, _ := stripOrphanedAnthropicToolResults(all[start:])
 	rebuilt := append([]string{anthropicAssistantSummaryBlock(summary)}, cleaned...)
 	elided := max(len(all)-len(cleaned), 0)
@@ -307,7 +307,7 @@ func (e *RequestEnvelope) rewriteOpenAIForCompaction(summary string, keepRecent 
 	if len(others) == 0 {
 		return 0
 	}
-	start := userAlignedStart(others, keepRecent)
+	start := userTextAlignedStart(others, keepRecent, FormatOpenAI)
 	keptRaw := make([]string, 0, len(others)-start)
 	for _, m := range others[start:] {
 		keptRaw = append(keptRaw, m.Raw)
@@ -330,7 +330,7 @@ func (e *RequestEnvelope) rewriteGeminiForCompaction(summary string, keepRecent 
 	if len(all) == 0 {
 		return 0
 	}
-	start := userAlignedStart(all, keepRecent)
+	start := userTextAlignedStart(all, keepRecent, FormatGemini)
 	kept := stripLeadingGeminiOrphanFunctionResponses(all[start:])
 
 	tagged := HandoverSummaryTag + summary

--- a/internal/translate/compaction_test.go
+++ b/internal/translate/compaction_test.go
@@ -230,26 +230,38 @@ func TestCompactionPreservesUserTextBoundaryAcrossToolLoop(t *testing.T) {
 			`{"role":"user","parts":[{"functionResponse":{"name":"`+toolUseID+`","response":{"result":"tool output"}}}]}`,
 		)
 	}
+	// Claude Code can append an injected reminder beside a tool result. The
+	// reminder is not a routing boundary, but it keeps the user message alive
+	// if orphan cleanup removes only the tool_result block.
+	anthropicMessages[2] = `{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool-0","content":"tool output"},{"type":"text","text":"<system-reminder>injected</system-reminder>"}]}`
 
 	testCases := []struct {
-		name  string
-		parse func([]byte) (*RequestEnvelope, error)
-		body  string
+		name              string
+		parse             func([]byte) (*RequestEnvelope, error)
+		body              string
+		messageArrayPath  string
+		wireAssistantRole string
 	}{
 		{
-			name:  "anthropic",
-			parse: ParseAnthropic,
-			body:  `{"messages":[` + strings.Join(anthropicMessages, ",") + `]}`,
+			name:              "anthropic",
+			parse:             ParseAnthropic,
+			body:              `{"messages":[` + strings.Join(anthropicMessages, ",") + `]}`,
+			messageArrayPath:  "messages",
+			wireAssistantRole: "assistant",
 		},
 		{
-			name:  "openai",
-			parse: ParseOpenAI,
-			body:  `{"messages":[` + strings.Join(openAIMessages, ",") + `]}`,
+			name:              "openai",
+			parse:             ParseOpenAI,
+			body:              `{"messages":[` + strings.Join(openAIMessages, ",") + `]}`,
+			messageArrayPath:  "messages",
+			wireAssistantRole: "assistant",
 		},
 		{
-			name:  "gemini",
-			parse: ParseGemini,
-			body:  `{"contents":[` + strings.Join(geminiContents, ",") + `]}`,
+			name:              "gemini",
+			parse:             ParseGemini,
+			body:              `{"contents":[` + strings.Join(geminiContents, ",") + `]}`,
+			messageArrayPath:  "contents",
+			wireAssistantRole: "model",
 		},
 	}
 
@@ -271,6 +283,10 @@ func TestCompactionPreservesUserTextBoundaryAcrossToolLoop(t *testing.T) {
 			envelope.TrimLastNMessages(12)
 			assertUserTextBoundary(t, envelope)
 			assert.NotContains(t, string(envelope.body), "tool-0", "orphaned first tool result must be removed")
+			wireMessages := gjson.GetBytes(envelope.body, testCase.messageArrayPath).Array()
+			require.GreaterOrEqual(t, len(wireMessages), 2)
+			assert.Equal(t, "user", wireMessages[0].Get("role").String())
+			assert.Equal(t, testCase.wireAssistantRole, wireMessages[1].Get("role").String())
 		})
 
 		t.Run(testCase.name+"/summary rewrite", func(t *testing.T) {

--- a/internal/translate/compaction_test.go
+++ b/internal/translate/compaction_test.go
@@ -1,6 +1,7 @@
 package translate
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -206,4 +207,78 @@ func TestTrimLastNMessages_Gemini_DropsHeadLeftWithOnlyOrphanResponse(t *testing
 	require.Len(t, contents, 2)
 	assert.Equal(t, "m2", contents[0].Get("parts.0.text").String())
 	assert.NotContains(t, string(e.body), "functionResponse")
+}
+
+func TestCompactionPreservesUserTextBoundaryAcrossToolLoop(t *testing.T) {
+	const toolTurns = 6
+
+	anthropicMessages := []string{`{"role":"user","content":"actual request"}`}
+	openAIMessages := []string{`{"role":"user","content":"actual request"}`}
+	geminiContents := []string{`{"role":"user","parts":[{"text":"actual request"}]}`}
+	for i := 0; i < toolTurns; i++ {
+		toolUseID := "tool-" + strconv.Itoa(i)
+		anthropicMessages = append(anthropicMessages,
+			anthropicAssistantToolUse(toolUseID),
+			anthropicToolResultMsg(toolUseID, "tool output"),
+		)
+		openAIMessages = append(openAIMessages,
+			`{"role":"assistant","tool_calls":[{"id":"`+toolUseID+`","type":"function","function":{"name":"read","arguments":"{}"}}]}`,
+			`{"role":"tool","tool_call_id":"`+toolUseID+`","content":"tool output"}`,
+		)
+		geminiContents = append(geminiContents,
+			`{"role":"model","parts":[{"functionCall":{"name":"`+toolUseID+`","args":{}}}]}`,
+			`{"role":"user","parts":[{"functionResponse":{"name":"`+toolUseID+`","response":{"result":"tool output"}}}]}`,
+		)
+	}
+
+	testCases := []struct {
+		name  string
+		parse func([]byte) (*RequestEnvelope, error)
+		body  string
+	}{
+		{
+			name:  "anthropic",
+			parse: ParseAnthropic,
+			body:  `{"messages":[` + strings.Join(anthropicMessages, ",") + `]}`,
+		},
+		{
+			name:  "openai",
+			parse: ParseOpenAI,
+			body:  `{"messages":[` + strings.Join(openAIMessages, ",") + `]}`,
+		},
+		{
+			name:  "gemini",
+			parse: ParseGemini,
+			body:  `{"contents":[` + strings.Join(geminiContents, ",") + `]}`,
+		},
+	}
+
+	assertUserTextBoundary := func(t *testing.T, envelope *RequestEnvelope) {
+		t.Helper()
+		for _, message := range envelope.ConversationMessages() {
+			if message.Role == "user" && message.Text == "actual request" {
+				return
+			}
+		}
+		assert.Fail(t, "text-bearing user boundary was elided")
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name+"/emergency trim", func(t *testing.T) {
+			envelope, err := testCase.parse([]byte(testCase.body))
+			require.NoError(t, err)
+
+			envelope.TrimLastNMessages(12)
+			assertUserTextBoundary(t, envelope)
+			assert.NotContains(t, string(envelope.body), "tool-0", "orphaned first tool result must be removed")
+		})
+
+		t.Run(testCase.name+"/summary rewrite", func(t *testing.T) {
+			envelope, err := testCase.parse([]byte(testCase.body))
+			require.NoError(t, err)
+
+			envelope.RewriteForCompaction("summary", 12)
+			assertUserTextBoundary(t, envelope)
+		})
+	}
 }

--- a/internal/translate/handover.go
+++ b/internal/translate/handover.go
@@ -31,8 +31,10 @@ func (e *RequestEnvelope) RewriteForHandover(summary string) int {
 	}
 }
 
-// TrimLastNMessages keeps the most recent n non-system messages plus system
-// blocks. Falls back to n=3 when n <= 0. Returns the number elided.
+// TrimLastNMessages keeps a bounded window of n non-system messages plus
+// system blocks. When the recent tail has no text-bearing user turn, its
+// oldest slot is replaced with the newest earlier one. Falls back to n=3 when
+// n <= 0. Returns the number elided.
 func (e *RequestEnvelope) TrimLastNMessages(n int) int {
 	if e == nil {
 		return 0
@@ -127,7 +129,7 @@ func (e *RequestEnvelope) trimAnthropicLastN(n int) int {
 	if len(all) <= n {
 		return 0
 	}
-	keep := all[len(all)-n:]
+	keep, _ := recentMessagesWithUserTextBoundary(all, n, FormatAnthropic)
 	rebuilt, _ := stripOrphanedAnthropicToolResults(keep)
 	newMessages := "[" + strings.Join(rebuilt, ",") + "]"
 	out, err := sjson.SetRawBytes(e.body, "messages", []byte(newMessages))
@@ -222,19 +224,23 @@ func (e *RequestEnvelope) trimOpenAILastN(n int) int {
 		return 0
 	}
 	systems := make([]string, 0)
-	others := make([]string, 0, len(all))
+	others := make([]gjson.Result, 0, len(all))
 	for _, m := range all {
 		if m.Get("role").String() == "system" {
 			systems = append(systems, m.Raw)
 			continue
 		}
-		others = append(others, m.Raw)
+		others = append(others, m)
 	}
 	if len(others) <= n {
 		return 0
 	}
-	keep := others[len(others)-n:]
-	cleaned := stripOrphanedOpenAIToolMessages(keep)
+	keep, _ := recentMessagesWithUserTextBoundary(others, n, FormatOpenAI)
+	keepRaw := make([]string, 0, len(keep))
+	for _, message := range keep {
+		keepRaw = append(keepRaw, message.Raw)
+	}
+	cleaned := stripOrphanedOpenAIToolMessages(keepRaw)
 	rebuilt := make([]string, 0, len(systems)+len(cleaned))
 	rebuilt = append(rebuilt, systems...)
 	rebuilt = append(rebuilt, cleaned...)
@@ -302,7 +308,13 @@ func (e *RequestEnvelope) trimGeminiLastN(n int) int {
 	if len(all) <= n {
 		return 0
 	}
-	rebuilt := stripLeadingGeminiOrphanFunctionResponses(all[len(all)-n:])
+	keep, boundaryPulledBack := recentMessagesWithUserTextBoundary(all, n, FormatGemini)
+	var rebuilt []string
+	if boundaryPulledBack {
+		rebuilt = append([]string{keep[0].Raw}, stripLeadingGeminiOrphanFunctionResponses(keep[1:])...)
+	} else {
+		rebuilt = stripLeadingGeminiOrphanFunctionResponses(keep)
+	}
 	newContents := "[" + strings.Join(rebuilt, ",") + "]"
 	out, err := sjson.SetRawBytes(e.body, "contents", []byte(newContents))
 	if err != nil {
@@ -310,6 +322,46 @@ func (e *RequestEnvelope) trimGeminiLastN(n int) int {
 	}
 	e.body = out
 	return len(all) - len(rebuilt)
+}
+
+// recentMessagesWithUserTextBoundary keeps the newest messages while ensuring
+// the window still describes the user's request. Tool-result-only user entries
+// do not qualify because the routing policy cannot derive intent from them.
+func recentMessagesWithUserTextBoundary(messages []gjson.Result, limit int, format Format) ([]gjson.Result, bool) {
+	if limit <= 0 || len(messages) <= limit {
+		return messages, false
+	}
+	recent := messages[len(messages)-limit:]
+	for i := len(recent) - 1; i >= 0; i-- {
+		if isTextBearingUserMessage(recent[i], format) {
+			return recent, false
+		}
+	}
+	for i := len(messages) - limit - 1; i >= 0; i-- {
+		if !isTextBearingUserMessage(messages[i], format) {
+			continue
+		}
+		preserved := make([]gjson.Result, 0, limit)
+		preserved = append(preserved, messages[i])
+		return append(preserved, recent[1:]...), true
+	}
+	return recent, false
+}
+
+func isTextBearingUserMessage(message gjson.Result, format Format) bool {
+	switch format {
+	case FormatAnthropic:
+		return message.Get("role").String() == "user" &&
+			strings.TrimSpace(userPromptTextGJSON(message.Get("content"))) != ""
+	case FormatOpenAI:
+		return message.Get("role").String() == "user" &&
+			strings.TrimSpace(openAIContentTextGJSON(message.Get("content"))) != ""
+	case FormatGemini:
+		role := message.Get("role").String()
+		return (role == "user" || role == "") && strings.TrimSpace(geminiPartsText(message.Get("parts"))) != ""
+	default:
+		return false
+	}
 }
 
 // stripOrphanedAnthropicToolResults drops tool_result blocks whose tool_use_id

--- a/internal/translate/handover.go
+++ b/internal/translate/handover.go
@@ -32,9 +32,9 @@ func (e *RequestEnvelope) RewriteForHandover(summary string) int {
 }
 
 // TrimLastNMessages keeps a bounded window of n non-system messages plus
-// system blocks. When the recent tail has no text-bearing user turn, its
-// oldest slot is replaced with the newest earlier one. Falls back to n=3 when
-// n <= 0. Returns the number elided.
+// system blocks. When the recent tail has no text-bearing user turn, it pulls
+// back the newest earlier one and resumes the retained tail on an assistant
+// turn. Falls back to n=3 when n <= 0. Returns the number elided.
 func (e *RequestEnvelope) TrimLastNMessages(n int) int {
 	if e == nil {
 		return 0
@@ -326,7 +326,8 @@ func (e *RequestEnvelope) trimGeminiLastN(n int) int {
 
 // recentMessagesWithUserTextBoundary keeps the newest messages while ensuring
 // the window still describes the user's request. Tool-result-only user entries
-// do not qualify because the routing policy cannot derive intent from them.
+// do not qualify, and a pulled-back user boundary resumes on an assistant turn
+// so the rewritten wire history does not contain consecutive user roles.
 func recentMessagesWithUserTextBoundary(messages []gjson.Result, limit int, format Format) ([]gjson.Result, bool) {
 	if limit <= 0 || len(messages) <= limit {
 		return messages, false
@@ -341,11 +342,23 @@ func recentMessagesWithUserTextBoundary(messages []gjson.Result, limit int, form
 		if !isTextBearingUserMessage(messages[i], format) {
 			continue
 		}
-		preserved := make([]gjson.Result, 0, limit)
-		preserved = append(preserved, messages[i])
-		return append(preserved, recent[1:]...), true
+		preserved := []gjson.Result{messages[i]}
+		for suffixStart := 1; suffixStart < len(recent); suffixStart++ {
+			if isAssistantMessage(recent[suffixStart], format) {
+				return append(preserved, recent[suffixStart:]...), true
+			}
+		}
+		return preserved, true
 	}
 	return recent, false
+}
+
+func isAssistantMessage(message gjson.Result, format Format) bool {
+	role := message.Get("role").String()
+	if format == FormatGemini {
+		return role == "model"
+	}
+	return role == "assistant"
 }
 
 func isTextBearingUserMessage(message gjson.Result, format Format) bool {


### PR DESCRIPTION
## Summary

- preserve the newest text-bearing user turn when compaction rewrites or hard-trims a long tool loop
- apply the invariant consistently to Anthropic, OpenAI, and Gemini payloads
- remove tool results orphaned when the bounded trim pulls an older user boundary into the window

## Root cause

Emergency compaction retained the latest 12 raw messages. In long Claude Code tool loops, those messages can all be assistant tool calls and user-role tool results. The HMM policy correctly rejects that history because it has no text-bearing user boundary, so routing failed before model dispatch with a 400 and the proxy surfaced a 503.

## Validation

- `go vet ./...`
- `go test -count=1 ./...`
- WorkWeave `wv checks run --skip-cost` (18/18 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes compaction dropping the text-bearing user turn that routing needs, so long tool loops no longer fail with a 503. Previously, emergency compaction kept the latest 12 messages, which in long tool loops could be only assistant tool calls and tool-result user turns with no request text, causing routing to reject the history.

**Bug Fixes**
- Compaction now keeps the newest user message that still carries request text, for Anthropic, OpenAI, and Gemini payloads.
- The hard trim (`TrimLastNMessages`) pulls that boundary into the window when the recent tail lacks it.
- A pulled-back boundary resumes on an assistant turn so roles keep alternating.
- Tool results orphaned by the pulled-back boundary are stripped to keep the payload wire-valid.

<sup>Written for commit 9d96890774d298fb275f543f26454a89cafeb0cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weave-os/router/pull/1240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

