### PR TITLE
Fix Anthropic system output_config demotion

### DIFF
--- a/internal/translate/AGENTS.md
+++ b/internal/translate/AGENTS.md
@@ -47,7 +47,7 @@ Anthropic-only fields (`thinking`, `cache_control`, `metadata`, Anthropic beta h
 
 ## Prefix-stable system handling (load-bearing)
 
-Anthropic 400s on `role:"system"` inside `messages`, so `hoistAnthropicSystemMessages` clears them — but only the **leading** run is hoisted into `system`. A mid-conversation system message is demoted to `user` **in place**. Hoisting it instead would move its text in front of the whole history, so a client that emits a system reminder per turn (Claude Code) shifts the cached prefix on every turn and re-writes the entire prompt; prod traffic showed ~890k cache-creation tokens per turn against a flat 17.5k read.
+Anthropic 400s on `role:"system"` inside `messages`, so `hoistAnthropicSystemMessages` clears them — but only the **leading** run is hoisted into `system`. Any system-scoped `output_config` is hoisted to the request-level field (without overwriting an explicit request-level value), while a mid-conversation system message is demoted to `user` **in place** after its message-scoped `output_config` is removed. Hoisting it instead would move its text in front of the whole history, so a client that emits a system reminder per turn (Claude Code) shifts the cached prefix on every turn and re-writes the entire prompt; prod traffic showed ~890k cache-creation tokens per turn against a flat 17.5k read.
 
 ## `<think>` content-channel extraction (gated)
 

--- a/internal/translate/CLAUDE.md
+++ b/internal/translate/CLAUDE.md
@@ -47,7 +47,7 @@ Anthropic-only fields (`thinking`, `cache_control`, `metadata`, Anthropic beta h
 
 ## Prefix-stable system handling (load-bearing)
 
-Anthropic 400s on `role:"system"` inside `messages`, so `hoistAnthropicSystemMessages` clears them — but only the **leading** run is hoisted into `system`. A mid-conversation system message is demoted to `user` **in place**. Hoisting it instead would move its text in front of the whole history, so a client that emits a system reminder per turn (Claude Code) shifts the cached prefix on every turn and re-writes the entire prompt; prod traffic showed ~890k cache-creation tokens per turn against a flat 17.5k read.
+Anthropic 400s on `role:"system"` inside `messages`, so `hoistAnthropicSystemMessages` clears them — but only the **leading** run is hoisted into `system`. Any system-scoped `output_config` is hoisted to the request-level field (without overwriting an explicit request-level value), while a mid-conversation system message is demoted to `user` **in place** after its message-scoped `output_config` is removed. Hoisting it instead would move its text in front of the whole history, so a client that emits a system reminder per turn (Claude Code) shifts the cached prefix on every turn and re-writes the entire prompt; prod traffic showed ~890k cache-creation tokens per turn against a flat 17.5k read.
 
 ## `<think>` content-channel extraction (gated)
 

--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -736,7 +736,9 @@ func (e *RequestEnvelope) buildAnthropicFromAnthropic(opts EmitOptions) ([]byte,
 // hoistAnthropicSystemMessages clears role:"system" entries from "messages"
 // (Anthropic's API 400s on them after a mid-session model switch). Only the
 // leading run is hoisted; mid-conversation ones are rewritten as user messages
-// in place to keep the cached prefix stable. No-op if none present.
+// in place to keep the cached prefix stable. Message-scoped output_config is
+// moved to the request-level field before demotion so role-specific options are
+// not left on a user message.
 func hoistAnthropicSystemMessages(body []byte) ([]byte, error) {
 	msgs := gjson.GetBytes(body, "messages")
 	if !msgs.IsArray() {
@@ -745,26 +747,50 @@ func hoistAnthropicSystemMessages(body []byte) ([]byte, error) {
 
 	var hoisted []string // text from the leading system run, in order
 	var kept []string    // raw message objects, system entries demoted to user
+	var hoistedOutputConfig string
 	leading := true
+	leadingSystemFound := false
 	rewritten := false
 	for _, msg := range msgs.Array() {
 		isSystem := msg.Get("role").String() == "system"
 		switch {
 		case isSystem && leading:
+			leadingSystemFound = true
 			hoisted = append(hoisted, anthropicSystemTexts(msg.Get("content"))...)
+			if config := msg.Get("output_config"); config.Exists() && config.Type != gjson.Null && hoistedOutputConfig == "" {
+				hoistedOutputConfig = config.Raw
+			}
 		case isSystem:
-			demoted, err := sjson.Set(msg.Raw, "role", "user")
+			demoted := []byte(msg.Raw)
+			if config := msg.Get("output_config"); config.Exists() {
+				var err error
+				demoted, err = sjson.DeleteBytes(demoted, "output_config")
+				if err != nil {
+					return nil, fmt.Errorf("remove demoted system output config: %w", err)
+				}
+				if config.Type != gjson.Null && hoistedOutputConfig == "" {
+					hoistedOutputConfig = config.Raw
+				}
+			}
+			demoted, err := sjson.SetBytes(demoted, "role", "user")
 			if err != nil {
 				return nil, fmt.Errorf("demote system message: %w", err)
 			}
-			kept = append(kept, demoted)
+			kept = append(kept, string(demoted))
 			rewritten = true
 		default:
 			leading = false
 			kept = append(kept, msg.Raw)
 		}
 	}
-	if len(hoisted) == 0 && !rewritten {
+	if hoistedOutputConfig != "" && !gjson.GetBytes(body, "output_config").Exists() {
+		var err error
+		body, err = sjson.SetRawBytes(body, "output_config", []byte(hoistedOutputConfig))
+		if err != nil {
+			return nil, fmt.Errorf("hoist system output config: %w", err)
+		}
+	}
+	if !leadingSystemFound && !rewritten {
 		return body, nil
 	}
 	if len(hoisted) == 0 {

--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -783,7 +783,8 @@ func hoistAnthropicSystemMessages(body []byte) ([]byte, error) {
 			kept = append(kept, msg.Raw)
 		}
 	}
-	if hoistedOutputConfig != "" && !gjson.GetBytes(body, "output_config").Exists() {
+	requestOutputConfig := gjson.GetBytes(body, "output_config")
+	if hoistedOutputConfig != "" && (!requestOutputConfig.Exists() || requestOutputConfig.Type == gjson.Null) {
 		var err error
 		body, err = sjson.SetRawBytes(body, "output_config", []byte(hoistedOutputConfig))
 		if err != nil {

--- a/internal/translate/emit_same_format_test.go
+++ b/internal/translate/emit_same_format_test.go
@@ -650,6 +650,23 @@ func TestAnthropicSameFormat_SystemOutputConfigDoesNotOverwriteTopLevelConfig(t 
 	assert.NotContains(t, demoted, "output_config")
 }
 
+func TestAnthropicSameFormat_NullTopLevelOutputConfigDoesNotBlockHoist(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-20250514","output_config":null,"messages":[{"role":"user","content":"hi"},{"role":"system","content":"set effort","output_config":{"effort":"high"}}],"max_tokens":1024}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-opus-4-7",
+		Capabilities: router.Lookup("claude-opus-4-7"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+
+	outputConfig, _ := out["output_config"].(map[string]any)
+	require.NotNil(t, outputConfig)
+	assert.Equal(t, "high", outputConfig["effort"])
+	msgs, _ := out["messages"].([]any)
+	require.Len(t, msgs, 2)
+	demoted, _ := msgs[1].(map[string]any)
+	assert.NotContains(t, demoted, "output_config")
+}
+
 func TestAnthropicSameFormat_LeadingSystemOutputConfigHoisted(t *testing.T) {
 	body := []byte(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"system","content":"set effort","output_config":{"effort":"high"}},{"role":"user","content":"hi"}],"max_tokens":1024}`)
 	opts := translate.EmitOptions{

--- a/internal/translate/emit_same_format_test.go
+++ b/internal/translate/emit_same_format_test.go
@@ -597,6 +597,74 @@ func TestAnthropicSameFormat_MidConversationSystemMessageDemotedInPlace(t *testi
 	}
 }
 
+func TestAnthropicSameFormat_MidConversationSystemOutputConfigHoistedBeforeDemotion(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"},{"role":"system","content":"set effort","output_config":{"effort":"high"}}],"max_tokens":1024}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-opus-4-7",
+		Capabilities: router.Lookup("claude-opus-4-7"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+
+	outputConfig, _ := out["output_config"].(map[string]any)
+	require.NotNil(t, outputConfig)
+	assert.Equal(t, "high", outputConfig["effort"])
+
+	msgs, _ := out["messages"].([]any)
+	require.Len(t, msgs, 2)
+	demoted, _ := msgs[1].(map[string]any)
+	assert.Equal(t, "user", demoted["role"])
+	assert.NotContains(t, demoted, "output_config", "role-scoped config must not remain on the demoted message")
+}
+
+func TestAnthropicSameFormat_DemotedSystemNullOutputConfigRemoved(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"},{"role":"system","content":"reminder","output_config":null}],"max_tokens":1024}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-opus-4-7",
+		Capabilities: router.Lookup("claude-opus-4-7"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+
+	assert.NotContains(t, out, "output_config")
+	msgs, _ := out["messages"].([]any)
+	require.Len(t, msgs, 2)
+	demoted, _ := msgs[1].(map[string]any)
+	assert.Equal(t, "user", demoted["role"])
+	assert.NotContains(t, demoted, "output_config", "even null role-scoped fields must not remain on a user message")
+}
+
+func TestAnthropicSameFormat_SystemOutputConfigDoesNotOverwriteTopLevelConfig(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-20250514","output_config":{"effort":"low"},"messages":[{"role":"user","content":"hi"},{"role":"system","content":"set effort","output_config":{"effort":"high"}}],"max_tokens":1024}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-opus-4-7",
+		Capabilities: router.Lookup("claude-opus-4-7"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+
+	outputConfig, _ := out["output_config"].(map[string]any)
+	require.NotNil(t, outputConfig)
+	assert.Equal(t, "low", outputConfig["effort"], "an explicit request-level option remains authoritative")
+
+	msgs, _ := out["messages"].([]any)
+	require.Len(t, msgs, 2)
+	demoted, _ := msgs[1].(map[string]any)
+	assert.NotContains(t, demoted, "output_config")
+}
+
+func TestAnthropicSameFormat_LeadingSystemOutputConfigHoisted(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"system","content":"set effort","output_config":{"effort":"high"}},{"role":"user","content":"hi"}],"max_tokens":1024}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-opus-4-7",
+		Capabilities: router.Lookup("claude-opus-4-7"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+
+	outputConfig, _ := out["output_config"].(map[string]any)
+	require.NotNil(t, outputConfig)
+	assert.Equal(t, "high", outputConfig["effort"])
+	msgs, _ := out["messages"].([]any)
+	require.Len(t, msgs, 1, "leading system message is still hoisted out of the message array")
+}
+
 func TestAnthropicSameFormat_NewSystemMessageLeavesEarlierTurnsInPlace(t *testing.T) {
 	// The cache-affecting property: a system reminder arriving on a later turn
 	// must not shift any earlier message, or the whole cached prefix moves.


### PR DESCRIPTION
## Summary
- hoist message-scoped `output_config` to the request level before demoting Anthropic system messages
- preserve an explicit request-level `output_config` and remove the field from demoted user messages
- add regression coverage for mid-conversation, leading, precedence, and null-field cases

## Validation
- `go test ./...`
- `go vet ./...`
- `wv router typecheck`
- `wv router test`
- `make check-agent-guides`
- `make check-docs`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Anthropic system message demotion so `output_config` is no longer left on demoted user messages and is hoisted to the request level when present.

- Hoists message-scoped `output_config` to the request-level field without overwriting an explicit request-level value; a null request-level value is treated as absent and doesn't block hoisting.
- Removes `output_config` from mid-conversation system messages demoted to `user`, including null values.
- Adds regression tests for mid-conversation, leading, precedence, and null-field cases.
- Updates the Anthropic translation docs to describe the hoisting and removal behavior.

<sup>Written for commit 785d43eb4af8161da0be40a5f81bd16a55028e70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weave-os/router/pull/1241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

