### PR TITLE
Show positive shadow escalations without changing routing

### DIFF
--- a/internal/proxy/escalation.go
+++ b/internal/proxy/escalation.go
@@ -206,6 +206,7 @@ func escalationRoutingApplied(decision router.Decision) bool {
 
 func (s *Service) finishEscalation(ctx context.Context, turn *escalationTurn, res *turnLoopResult, routeErr error) error {
 	if turn.replay {
+		res.EscalationShadowMarked = !turn.active && turn.checkpoint.Prediction != nil && turn.checkpoint.Prediction.Escalate
 		res.EscalationScope = turn.scope
 		res.EscalationOrdinal = turn.checkpoint.Ordinal
 		res.escalationActivation = turn.activation
@@ -227,6 +228,7 @@ func (s *Service) finishEscalation(ctx context.Context, turn *escalationTurn, re
 		s.invalidateEscalation(ctx, turn.scope, turn.boundary, turn.token)
 		return err
 	}
+	res.EscalationShadowMarked = !turn.active && turn.checkpoint.Prediction != nil && turn.checkpoint.Prediction.Escalate
 	res.EscalationScope = turn.scope
 	res.EscalationOrdinal = turn.session.Ordinal
 	res.escalationActivation = turn.activation

--- a/internal/proxy/escalation_internal_test.go
+++ b/internal/proxy/escalation_internal_test.go
@@ -175,7 +175,24 @@ func TestEscalationShadowCheckpointsDoNotChangeRoutingOrEstablishFloor(t *testin
 		require.Equal(t, ordinal%5 == 0, turn.EscalationShadowMarked)
 		if ordinal%5 == 0 {
 			require.Contains(t, routingMarkerFor(turn), markerReasonShadowEscalation)
+			replayed, replayErr := svc.runTurnLoop(ctx, env, features, "shadow-key", installation, "", http.Header{}, router.Request{RequestedModel: features.Model})
+			require.NoError(t, replayErr)
+			require.Equal(t, int64(ordinal), replayed.EscalationOrdinal)
+			require.Equal(t, turn.Decision.Model, replayed.Decision.Model)
+			require.Contains(t, routingMarkerFor(replayed), markerReasonShadowEscalation)
+			require.False(t, escalationRoutingApplied(replayed.Decision))
+			require.Empty(t, store.sessions[replayed.EscalationScope].Floor)
+			require.Len(t, observer.requests, ordinal, "replay must load the committed checkpoint without scoring again")
 		}
+	}
+	for _, disabledInstallation := range []uuid.UUID{installation, uuid.New()} {
+		env := escalationTestEnvelope(t, 12)
+		features := env.RoutingFeatures(false)
+		disabled, err := svc.runTurnLoop(escalationTestContext(false, false), env, features, "shadow-key", disabledInstallation, "", http.Header{}, router.Request{RequestedModel: features.Model})
+		require.NoError(t, err)
+		require.Zero(t, disabled.EscalationOrdinal)
+		require.False(t, disabled.EscalationShadowMarked)
+		require.False(t, escalationRoutingApplied(disabled.Decision))
 	}
 	require.Len(t, observer.requests, 11)
 	positiveCheckpoints := 0
@@ -387,14 +404,11 @@ func TestEscalationShadowMarkerRequiresCommittedPositiveShadowCheckpoint(t *test
 		name       string
 		active     bool
 		prediction *escalation.Prediction
-		replay     bool
 		failCommit bool
 		wantMarked bool
 	}{
 		{name: "positive shadow", prediction: &escalation.Prediction{Escalate: true}, wantMarked: true},
-		{name: "replayed shadow", prediction: &escalation.Prediction{Escalate: true}, replay: true, wantMarked: true},
 		{name: "active promotion", active: true, prediction: &escalation.Prediction{Escalate: true}},
-		{name: "replayed active", active: true, prediction: &escalation.Prediction{Escalate: true}, replay: true},
 		{name: "negative shadow", prediction: &escalation.Prediction{}},
 		{name: "between checkpoints"},
 		{name: "uncommitted shadow", prediction: &escalation.Prediction{Escalate: true}, failCommit: true},
@@ -403,7 +417,7 @@ func TestEscalationShadowMarkerRequiresCommittedPositiveShadowCheckpoint(t *test
 			store := newEscalationTestStore()
 			store.failCommit = tc.failCommit
 			svc := (&Service{}).WithEscalation(store, nil)
-			turn := &escalationTurn{active: tc.active, replay: tc.replay, checkpoint: escalation.Checkpoint{Ordinal: 5, Prediction: tc.prediction}}
+			turn := &escalationTurn{active: tc.active, checkpoint: escalation.Checkpoint{Ordinal: 5, Prediction: tc.prediction}}
 			var routed turnLoopResult
 			err := svc.finishEscalation(context.Background(), turn, &routed, nil)
 			if tc.failCommit {

--- a/internal/proxy/escalation_internal_test.go
+++ b/internal/proxy/escalation_internal_test.go
@@ -152,6 +152,45 @@ func TestEscalationCadenceReplayFloorAndGates(t *testing.T) {
 	forced.ForceModel = "claude-opus-4-8"
 	require.Nil(t, svc.beginEscalation(ctx, escalationTestEnvelope(t, 7), forced, &res, "test-key"))
 }
+func TestEscalationShadowCheckpointsDoNotChangeRoutingOrEstablishFloor(t *testing.T) {
+	store := newEscalationTestStore()
+	observer := &escalationTestObserver{}
+	ctx := flags.WithOverrides(router.WithStrategy(context.Background(), router.StrategyHMMEmbedding), flags.Overrides{Bools: map[flags.Key]bool{
+		flags.KeyEscalationXGBoostShadowEnabled: true,
+		flags.KeyPlannerEnabled:                 false,
+	}})
+	installation := uuid.New()
+	svc := NewService(nil, nil, nil, false, nil, newStubPinStore(), false, providers.ProviderAnthropic, "claude-opus-4-8", nil).
+		WithEscalation(store, observer).
+		WithPolicyStrategy(policy.StrategySpec{Strategy: router.StrategyHMMEmbedding, Router: escalationDispatchRouter{}, Capabilities: policy.Capabilities{SchemaVersion: policy.SchemaVersionV1, AuthoritativePerTurnSelection: true}})
+	for ordinal := 1; ordinal <= 11; ordinal++ {
+		env := escalationTestEnvelope(t, ordinal)
+		features := env.RoutingFeatures(false)
+		turn, err := svc.runTurnLoop(ctx, env, features, "shadow-key", installation, "", http.Header{}, router.Request{RequestedModel: features.Model})
+		require.NoError(t, err)
+		require.Equal(t, int64(ordinal), turn.EscalationOrdinal)
+		require.Equal(t, "claude-haiku-4-5", turn.Decision.Model)
+		require.False(t, escalationRoutingApplied(turn.Decision))
+		require.Empty(t, store.sessions[turn.EscalationScope].Floor)
+		require.Equal(t, ordinal%5 == 0, turn.EscalationShadowMarked)
+		if ordinal%5 == 0 {
+			require.Contains(t, routingMarkerFor(turn), markerReasonShadowEscalation)
+		}
+	}
+	require.Len(t, observer.requests, 11)
+	positiveCheckpoints := 0
+	for _, checkpoints := range store.checkpoints {
+		for _, checkpoint := range checkpoints {
+			if checkpoint.Prediction != nil {
+				require.True(t, checkpoint.Prediction.Escalate)
+				require.Contains(t, []int64{5, 10}, checkpoint.Ordinal)
+				positiveCheckpoints++
+			}
+		}
+	}
+	require.Equal(t, 2, positiveCheckpoints)
+}
+
 func TestEscalationObservationFailureResetsFeaturesRetainsFloor(t *testing.T) {
 	store := newEscalationTestStore()
 	observer := &escalationTestObserver{}
@@ -339,6 +378,40 @@ func TestEscalationCommitFailureDoesNotRepeatUnconstrainedSelection(t *testing.T
 			require.Equal(t, "claude-opus-4-8", res.Decision.Model)
 			require.Zero(t, res.EscalationOrdinal)
 			require.Len(t, classifier.requests, 1, "failed observational commits cannot repeat ordinary routing and its side effects")
+		})
+	}
+}
+
+func TestEscalationShadowMarkerRequiresCommittedPositiveShadowCheckpoint(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		active     bool
+		prediction *escalation.Prediction
+		replay     bool
+		failCommit bool
+		wantMarked bool
+	}{
+		{name: "positive shadow", prediction: &escalation.Prediction{Escalate: true}, wantMarked: true},
+		{name: "replayed shadow", prediction: &escalation.Prediction{Escalate: true}, replay: true, wantMarked: true},
+		{name: "active promotion", active: true, prediction: &escalation.Prediction{Escalate: true}},
+		{name: "replayed active", active: true, prediction: &escalation.Prediction{Escalate: true}, replay: true},
+		{name: "negative shadow", prediction: &escalation.Prediction{}},
+		{name: "between checkpoints"},
+		{name: "uncommitted shadow", prediction: &escalation.Prediction{Escalate: true}, failCommit: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newEscalationTestStore()
+			store.failCommit = tc.failCommit
+			svc := (&Service{}).WithEscalation(store, nil)
+			turn := &escalationTurn{active: tc.active, replay: tc.replay, checkpoint: escalation.Checkpoint{Ordinal: 5, Prediction: tc.prediction}}
+			var routed turnLoopResult
+			err := svc.finishEscalation(context.Background(), turn, &routed, nil)
+			if tc.failCommit {
+				require.ErrorIs(t, err, escalation.ErrLeaseLost)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.wantMarked, routed.EscalationShadowMarked)
 		})
 	}
 }

--- a/internal/proxy/marker_internal_test.go
+++ b/internal/proxy/marker_internal_test.go
@@ -1,10 +1,12 @@
 package proxy
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"weave-os/router/internal/router"
 	"weave-os/router/internal/router/planner"
@@ -445,4 +447,29 @@ func TestRoutingMarkerFor_SuppressesEffortOnlyChange(t *testing.T) {
 		PriorServedModel: "gpt-5.6-luna:xhigh",
 	}
 	assert.Empty(t, routingMarkerFor(res), "changing effort must not repeat the model-choice marker")
+}
+
+func TestRoutingMarkerFor_ShadowEscalationShowsWithoutModelSwitchAndStripsOnEcho(t *testing.T) {
+	decision := router.Decision{Model: "claude-haiku-4-5"}
+	turn := turnLoopResult{Decision: decision, PriorServedModel: decision.Model, EscalationShadowMarked: true}
+	marker := routingMarkerFor(turn)
+	require.Equal(t, routingMarkerPrefix+decision.Model+" · "+markerReasonShadowEscalation+"\n\n", marker)
+
+	for _, content := range []any{
+		marker + "The answer.",
+		[]map[string]string{{"type": "text", "text": marker + "The answer."}},
+	} {
+		body, err := json.Marshal(map[string]any{"messages": []any{map[string]any{"role": "assistant", "content": content}}})
+		require.NoError(t, err)
+		cleaned, err := translate.StripRoutingMarkerFromMessages(body)
+		require.NoError(t, err)
+		require.NotContains(t, string(cleaned), markerReasonShadowEscalation)
+		require.Contains(t, string(cleaned), "The answer.")
+	}
+
+	turn.EscalationShadowMarked = false
+	require.Empty(t, routingMarkerFor(turn))
+	turn.EscalationShadowMarked = true
+	turn.SuggestionMode = true
+	require.Empty(t, routingMarkerFor(turn))
 }

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -622,7 +622,8 @@ func suppressMarkerIfRequested(ctx context.Context, h http.Header, marker string
 }
 
 // routingMarkerFor builds the "brand → model · note" snippet emitted when the
-// selected serving model changes (and on the first routed turn).
+// selected serving model changes, on the first routed turn, or when a shadow
+// escalation is marked without affecting selection.
 func routingMarkerFor(res turnLoopResult) string {
 	decision := res.Decision
 	if decision.Model == "" {
@@ -648,6 +649,10 @@ func routingMarkerFor(res turnLoopResult) string {
 	// letting it read as a first turn.
 	if res.HardPinned {
 		return ""
+	}
+	// A shadow checkpoint is news even when ordinary routing keeps the same model.
+	if res.EscalationShadowMarked {
+		return routingMarkerPrefix + decision.Model + " · " + markerReasonShadowEscalation + "\n\n"
 	}
 	// Same model as last turn: the user already knows. Empty prior model means
 	// the first turn of this session (or role), which still shows. Effort changes
@@ -708,6 +713,7 @@ func sanitizeSidecarDisplayMarker(raw string) string {
 // the marker wording; tests assert the mapping against these constants rather
 // than re-spelling the literals.
 const (
+	markerReasonShadowEscalation  = "escalation marked — shadow mode; no action taken"
 	markerReasonUserForced        = "pinned by force-model"
 	markerReasonLoopEscalated     = "escalated due to loop"
 	markerReasonStruggleEscalated = "picked a different model to break a grind"

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -160,10 +160,11 @@ func (s *Service) plannerTokensFor(env *translate.RequestEnvelope, feats transla
 
 // turnLoopResult bundles the routing decision and pin/planner state.
 type turnLoopResult struct {
-	EscalationScope       [32]byte
-	EscalationOrdinal     int64
-	escalationActivation  [32]byte
-	escalationObservation translate.EscalationObservation
+	EscalationShadowMarked bool
+	EscalationScope        [32]byte
+	EscalationOrdinal      int64
+	escalationActivation   [32]byte
+	escalationObservation  translate.EscalationObservation
 
 	Decision       router.Decision
 	SessionKey     [sessionpin.SessionKeyLen]byte


### PR DESCRIPTION
Positive XGB shadow checkpoints now display `escalation marked — shadow mode; no action taken` in the existing terminal routing badge, even when the selected model stays the same. The badge retains the selected model and appears only for committed positive shadow decisions, including request replays.

Shadow scoring still passes no routing constraint and establishes no escalation floor. Active decisions, negative predictions, intermediate turns, and failed commits do not receive the shadow label. Existing marker visibility settings and ingress stripping remain in effect.

Validation: proxy and translation package tests pass; race-enabled escalation and routing-marker tests pass. Added coverage for eleven shadow turns with positive checkpoints at turns 5 and 10, replay/commit behavior, and marker echo removal.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Positive XGB shadow checkpoints are no longer invisible in the routing badge. They now show `escalation marked — shadow mode; no action taken` even when the selected model stays the same, without changing routing or establishing an escalation floor.

- The badge appears only for committed positive shadow decisions, including replays.
- Active decisions, negative predictions, intermediate turns, and failed commits remain unlabeled.
- Existing marker visibility controls and ingress stripping still apply.
- Adds coverage for checkpoint cadence, replay and commit behavior, marker echo removal, and flag-off isolation.

<sup>Written for commit 0f4e3c7937afc13690087d42f112e5f63155375a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weave-os/router/pull/1242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

