### PR TITLE
fix(install): resolve Codex status credentials from the provider table

### DIFF
--- a/install/codex-status.sh
+++ b/install/codex-status.sh
@@ -182,16 +182,20 @@ read_codex_endpoint() {
     # replaces a separate skip rule -- and unlike one, it also catches a comment
     # trailing another assignment, which the unanchored matches would otherwise
     # read as live config on any line preceding the real value.
-    function weave_strip_comment(line,   i, c, out, instr, esc) {
+    function weave_strip_comment(line,   i, c, out, indq, insq, esc) {
       out = ""
-      instr = 0
+      indq = 0
+      insq = 0
       esc = 0
       for (i = 1; i <= length(line); i++) {
         c = substr(line, i, 1)
         if (esc) { out = out c; esc = 0; continue }
-        if (instr && c == "\\") { out = out c; esc = 1; continue }
-        if (c == "\"") { instr = !instr; out = out c; continue }
-        if (c == "#" && !instr) break
+        # Only basic strings have escapes; a backslash in a literal string is
+        # data, so consuming the next character there would mis-track the quote.
+        if (indq && c == "\\") { out = out c; esc = 1; continue }
+        if (!insq && c == "\"") { indq = !indq; out = out c; continue }
+        if (!indq && c == "'"'"'") { insq = !insq; out = out c; continue }
+        if (c == "#" && !indq && !insq) break
         out = out c
       }
       return out

--- a/install/codex-status.sh
+++ b/install/codex-status.sh
@@ -93,11 +93,6 @@ state_root="${XDG_CACHE_HOME:-$HOME/.cache}/weave-router/codex"
 helper_dir="$(cd "$(dirname "$0")" 2>/dev/null && pwd -P)"
 disabled_marker="$helper_dir/.weave-router-disabled"
 router_badge_sentinel=$'⁣⁠⁣⁠'
-# Must stay verbatim in sync with install.sh / uninstall.sh: the endpoint read
-# below is scoped to this block so a key-shaped string elsewhere in the user's
-# config.toml is never adopted.
-codex_begin_marker="# >>> weave-router managed (do not edit between markers) >>>"
-codex_end_marker="# <<< weave-router managed <<<"
 
 emit_title() {
   local title="$1"
@@ -157,10 +152,18 @@ cost_file_for() {
 # Resolved from the helper's own location first so a project-scope install never
 # reads (or leaks) the user-scope key: the project helper lives in the same
 # .codex directory as its config, while the user-scope helper sits in ~/.weave
-# and reads ~/.codex. Values are scoped to the managed block so a key-shaped
-# string the user wrote elsewhere in the file is never adopted. awk, not a TOML
-# parser, because the Codex target deliberately does not require jq for config
-# reads.
+# and reads ~/.codex. Values are scoped to the [model_providers.weave] table so
+# a key-shaped string the user wrote elsewhere in the file is never adopted. awk,
+# not a TOML parser, because the Codex target deliberately does not require jq
+# for config reads.
+#
+# Scoped to the table rather than the managed comment markers, and matching the
+# header name quoted or bare, because Codex rewrites config.toml through a TOML
+# serializer whenever it persists its own state: comments do not survive, so the
+# markers vanish while the table remains, and the inline http_headers come back
+# as a subtable with the header name unquoted. A marker-scoped, quoted-only read
+# resolved nothing on any config Codex had touched, which silently dropped the
+# savings figure from the title with no error anywhere.
 read_codex_endpoint() {
   local config=""
   # Project/custom installs name the helper weave-status.sh and keep it next
@@ -173,19 +176,21 @@ read_codex_endpoint() {
     config="$HOME/.codex/config.toml"
   fi
   [ -n "$config" ] || return 0
-  awk -v begin="$codex_begin_marker" -v end="$codex_end_marker" '
-    $0 == begin { inblk = 1; next }
-    $0 == end   { inblk = 0; next }
-    !inblk { next }
+  awk '
+    /^[[:space:]]*\[/ {
+      in_provider = ($0 ~ /^[[:space:]]*\[[[:space:]]*model_providers[[:space:]]*\.[[:space:]]*weave[[:space:]]*(\.[^]]*)?\][[:space:]]*(#.*)?$/)
+      next
+    }
+    !in_provider { next }
     match($0, /base_url[[:space:]]*=[[:space:]]*"[^"]*"/) {
       v = substr($0, RSTART, RLENGTH)
       sub(/^.*=[[:space:]]*"/, "", v); sub(/"$/, "", v)
-      url = v
+      if (url == "") url = v
     }
-    match($0, /"X-Weave-Router-Key"[[:space:]]*=[[:space:]]*"[^"]*"/) {
+    match($0, /"?X-Weave-Router-Key"?[[:space:]]*=[[:space:]]*"[^"]*"/) {
       v = substr($0, RSTART, RLENGTH)
       sub(/^.*=[[:space:]]*"/, "", v); sub(/"$/, "", v)
-      key = v
+      if (key == "") key = v
     }
     END { if (url != "" && key != "") printf "%s\n%s\n", url, key }
   ' "$config" 2>/dev/null || true

--- a/install/codex-status.sh
+++ b/install/codex-status.sh
@@ -181,6 +181,11 @@ read_codex_endpoint() {
       in_provider = ($0 ~ /^[[:space:]]*\[[[:space:]]*model_providers[[:space:]]*\.[[:space:]]*weave[[:space:]]*(\.[^]]*)?\][[:space:]]*(#.*)?$/)
       next
     }
+    # A commented-out example is not configuration. The assignment matches below
+    # are unanchored (the key can live inside an inline http_headers table), so
+    # without this a `# base_url = "https://old"` line reads as live config --
+    # and first-match-wins would then point the fetch at a stale endpoint.
+    /^[[:space:]]*#/ { next }
     !in_provider { next }
     match($0, /base_url[[:space:]]*=[[:space:]]*"[^"]*"/) {
       v = substr($0, RSTART, RLENGTH)

--- a/install/codex-status.sh
+++ b/install/codex-status.sh
@@ -177,15 +177,30 @@ read_codex_endpoint() {
   fi
   [ -n "$config" ] || return 0
   awk '
+    # Cut a TOML comment, honouring quoted strings so a # inside a value stays.
+    # A full-line comment reduces to empty and matches nothing below, so this
+    # replaces a separate skip rule -- and unlike one, it also catches a comment
+    # trailing another assignment, which the unanchored matches would otherwise
+    # read as live config on any line preceding the real value.
+    function weave_strip_comment(line,   i, c, out, instr, esc) {
+      out = ""
+      instr = 0
+      esc = 0
+      for (i = 1; i <= length(line); i++) {
+        c = substr(line, i, 1)
+        if (esc) { out = out c; esc = 0; continue }
+        if (instr && c == "\\") { out = out c; esc = 1; continue }
+        if (c == "\"") { instr = !instr; out = out c; continue }
+        if (c == "#" && !instr) break
+        out = out c
+      }
+      return out
+    }
+    { $0 = weave_strip_comment($0) }
     /^[[:space:]]*\[/ {
       in_provider = ($0 ~ /^[[:space:]]*\[[[:space:]]*model_providers[[:space:]]*\.[[:space:]]*weave[[:space:]]*(\.[^]]*)?\][[:space:]]*(#.*)?$/)
       next
     }
-    # A commented-out example is not configuration. The assignment matches below
-    # are unanchored (the key can live inside an inline http_headers table), so
-    # without this a `# base_url = "https://old"` line reads as live config --
-    # and first-match-wins would then point the fetch at a stale endpoint.
-    /^[[:space:]]*#/ { next }
     !in_provider { next }
     match($0, /base_url[[:space:]]*=[[:space:]]*"[^"]*"/) {
       v = substr($0, RSTART, RLENGTH)

--- a/install/install.sh
+++ b/install/install.sh
@@ -3761,16 +3761,20 @@ read_codex_endpoint() {
     # replaces a separate skip rule -- and unlike one, it also catches a comment
     # trailing another assignment, which the unanchored matches would otherwise
     # read as live config on any line preceding the real value.
-    function weave_strip_comment(line,   i, c, out, instr, esc) {
+    function weave_strip_comment(line,   i, c, out, indq, insq, esc) {
       out = ""
-      instr = 0
+      indq = 0
+      insq = 0
       esc = 0
       for (i = 1; i <= length(line); i++) {
         c = substr(line, i, 1)
         if (esc) { out = out c; esc = 0; continue }
-        if (instr && c == "\\") { out = out c; esc = 1; continue }
-        if (c == "\"") { instr = !instr; out = out c; continue }
-        if (c == "#" && !instr) break
+        # Only basic strings have escapes; a backslash in a literal string is
+        # data, so consuming the next character there would mis-track the quote.
+        if (indq && c == "\\") { out = out c; esc = 1; continue }
+        if (!insq && c == "\"") { indq = !indq; out = out c; continue }
+        if (!indq && c == "'"'"'") { insq = !insq; out = out c; continue }
+        if (c == "#" && !indq && !insq) break
         out = out c
       }
       return out

--- a/install/install.sh
+++ b/install/install.sh
@@ -3756,15 +3756,30 @@ read_codex_endpoint() {
   fi
   [ -n "$config" ] || return 0
   awk '
+    # Cut a TOML comment, honouring quoted strings so a # inside a value stays.
+    # A full-line comment reduces to empty and matches nothing below, so this
+    # replaces a separate skip rule -- and unlike one, it also catches a comment
+    # trailing another assignment, which the unanchored matches would otherwise
+    # read as live config on any line preceding the real value.
+    function weave_strip_comment(line,   i, c, out, instr, esc) {
+      out = ""
+      instr = 0
+      esc = 0
+      for (i = 1; i <= length(line); i++) {
+        c = substr(line, i, 1)
+        if (esc) { out = out c; esc = 0; continue }
+        if (instr && c == "\\") { out = out c; esc = 1; continue }
+        if (c == "\"") { instr = !instr; out = out c; continue }
+        if (c == "#" && !instr) break
+        out = out c
+      }
+      return out
+    }
+    { $0 = weave_strip_comment($0) }
     /^[[:space:]]*\[/ {
       in_provider = ($0 ~ /^[[:space:]]*\[[[:space:]]*model_providers[[:space:]]*\.[[:space:]]*weave[[:space:]]*(\.[^]]*)?\][[:space:]]*(#.*)?$/)
       next
     }
-    # A commented-out example is not configuration. The assignment matches below
-    # are unanchored (the key can live inside an inline http_headers table), so
-    # without this a `# base_url = "https://old"` line reads as live config --
-    # and first-match-wins would then point the fetch at a stale endpoint.
-    /^[[:space:]]*#/ { next }
     !in_provider { next }
     match($0, /base_url[[:space:]]*=[[:space:]]*"[^"]*"/) {
       v = substr($0, RSTART, RLENGTH)

--- a/install/install.sh
+++ b/install/install.sh
@@ -3672,11 +3672,6 @@ state_root="${XDG_CACHE_HOME:-$HOME/.cache}/weave-router/codex"
 helper_dir="$(cd "$(dirname "$0")" 2>/dev/null && pwd -P)"
 disabled_marker="$helper_dir/.weave-router-disabled"
 router_badge_sentinel=$'⁣⁠⁣⁠'
-# Must stay verbatim in sync with install.sh / uninstall.sh: the endpoint read
-# below is scoped to this block so a key-shaped string elsewhere in the user's
-# config.toml is never adopted.
-codex_begin_marker="# >>> weave-router managed (do not edit between markers) >>>"
-codex_end_marker="# <<< weave-router managed <<<"
 
 emit_title() {
   local title="$1"
@@ -3736,10 +3731,18 @@ cost_file_for() {
 # Resolved from the helper's own location first so a project-scope install never
 # reads (or leaks) the user-scope key: the project helper lives in the same
 # .codex directory as its config, while the user-scope helper sits in ~/.weave
-# and reads ~/.codex. Values are scoped to the managed block so a key-shaped
-# string the user wrote elsewhere in the file is never adopted. awk, not a TOML
-# parser, because the Codex target deliberately does not require jq for config
-# reads.
+# and reads ~/.codex. Values are scoped to the [model_providers.weave] table so
+# a key-shaped string the user wrote elsewhere in the file is never adopted. awk,
+# not a TOML parser, because the Codex target deliberately does not require jq
+# for config reads.
+#
+# Scoped to the table rather than the managed comment markers, and matching the
+# header name quoted or bare, because Codex rewrites config.toml through a TOML
+# serializer whenever it persists its own state: comments do not survive, so the
+# markers vanish while the table remains, and the inline http_headers come back
+# as a subtable with the header name unquoted. A marker-scoped, quoted-only read
+# resolved nothing on any config Codex had touched, which silently dropped the
+# savings figure from the title with no error anywhere.
 read_codex_endpoint() {
   local config=""
   # Project/custom installs name the helper weave-status.sh and keep it next
@@ -3752,19 +3755,21 @@ read_codex_endpoint() {
     config="$HOME/.codex/config.toml"
   fi
   [ -n "$config" ] || return 0
-  awk -v begin="$codex_begin_marker" -v end="$codex_end_marker" '
-    $0 == begin { inblk = 1; next }
-    $0 == end   { inblk = 0; next }
-    !inblk { next }
+  awk '
+    /^[[:space:]]*\[/ {
+      in_provider = ($0 ~ /^[[:space:]]*\[[[:space:]]*model_providers[[:space:]]*\.[[:space:]]*weave[[:space:]]*(\.[^]]*)?\][[:space:]]*(#.*)?$/)
+      next
+    }
+    !in_provider { next }
     match($0, /base_url[[:space:]]*=[[:space:]]*"[^"]*"/) {
       v = substr($0, RSTART, RLENGTH)
       sub(/^.*=[[:space:]]*"/, "", v); sub(/"$/, "", v)
-      url = v
+      if (url == "") url = v
     }
-    match($0, /"X-Weave-Router-Key"[[:space:]]*=[[:space:]]*"[^"]*"/) {
+    match($0, /"?X-Weave-Router-Key"?[[:space:]]*=[[:space:]]*"[^"]*"/) {
       v = substr($0, RSTART, RLENGTH)
       sub(/^.*=[[:space:]]*"/, "", v); sub(/"$/, "", v)
-      key = v
+      if (key == "") key = v
     }
     END { if (url != "" && key != "") printf "%s\n%s\n", url, key }
   ' "$config" 2>/dev/null || true

--- a/install/install.sh
+++ b/install/install.sh
@@ -3760,6 +3760,11 @@ read_codex_endpoint() {
       in_provider = ($0 ~ /^[[:space:]]*\[[[:space:]]*model_providers[[:space:]]*\.[[:space:]]*weave[[:space:]]*(\.[^]]*)?\][[:space:]]*(#.*)?$/)
       next
     }
+    # A commented-out example is not configuration. The assignment matches below
+    # are unanchored (the key can live inside an inline http_headers table), so
+    # without this a `# base_url = "https://old"` line reads as live config --
+    # and first-match-wins would then point the fetch at a stale endpoint.
+    /^[[:space:]]*#/ { next }
     !in_provider { next }
     match($0, /base_url[[:space:]]*=[[:space:]]*"[^"]*"/) {
       v = substr($0, RSTART, RLENGTH)

--- a/install/tests/codex-status_test.sh
+++ b/install/tests/codex-status_test.sh
@@ -188,6 +188,34 @@ run_normalized_turn
   exit 1
 }
 
+# A commented-out endpoint left above the live one must not win. First match
+# wins, so treating a comment as config would point the fetch at a stale
+# endpoint and send the router key there.
+commented_home="$work/commented-home"
+mkdir -p "$commented_home/.codex"
+cat >"$commented_home/.codex/config.toml" <<TOML
+[model_providers.weave]
+# base_url = "file:///nonexistent/stale-endpoint.json"
+base_url = "file://$normalized_cost"
+
+[model_providers.weave.http_headers]
+# X-Weave-Router-Key = "rk_stale"
+X-Weave-Router-Key = "rk_test"
+TOML
+commented_cache="$work/cache-commented"
+printf '%s\n' '{"session_id":"session-5","model":"gpt-5.6-terra","last_assistant_message":"✦ **Weave Router** → claude-sonnet-5 · best pick"}' \
+  | HOME="$commented_home" XDG_CACHE_HOME="$commented_cache" \
+    WEAVE_CODEX_STATUS_TITLE_FILE="$title_file" "$helper" >/dev/null
+commented_cost_cache="$commented_cache/weave-router/codex/session-5.cost"
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  [ -f "$commented_cost_cache" ] && break
+  sleep 0.2
+done
+[ -f "$commented_cost_cache" ] || {
+  echo "a commented-out example blocked the live credentials" >&2
+  exit 1
+}
+
 # A provider whose name merely starts with "weave" is a different provider: its
 # key must never be adopted, and a config holding only that one resolves nothing.
 neighbour_home="$work/neighbour-home"
@@ -201,8 +229,15 @@ neighbour_cache="$work/cache-neighbour"
 printf '%s\n' '{"session_id":"session-4","model":"gpt-5.6-terra","last_assistant_message":"✦ **Weave Router** → claude-sonnet-5 · best pick"}' \
   | HOME="$neighbour_home" XDG_CACHE_HOME="$neighbour_cache" \
     WEAVE_CODEX_STATUS_TITLE_FILE="$title_file" "$helper" >/dev/null
-sleep 0.5
-[ ! -f "$neighbour_cache/weave-router/codex/session-4.cost" ] || {
+# Poll the full window the positive fetches get rather than sleeping once: a
+# fixed wait can expire before a wrongly-adopted fetch lands, which would pass
+# this assertion under CI load precisely when it ought to fail.
+neighbour_cost_cache="$neighbour_cache/weave-router/codex/session-4.cost"
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  [ -f "$neighbour_cost_cache" ] && break
+  sleep 0.2
+done
+[ ! -f "$neighbour_cost_cache" ] || {
   echo "adopted credentials from an unrelated provider whose name starts with weave" >&2
   exit 1
 }

--- a/install/tests/codex-status_test.sh
+++ b/install/tests/codex-status_test.sh
@@ -315,7 +315,7 @@ run_refresh_turn() {
   printf '%s\n' '{"session_id":"session-refresh","model":"gpt-5.6-terra","last_assistant_message":"✦ **Weave Router** → claude-sonnet-5 · best pick"}' \
     | HOME="$refresh_home" XDG_CACHE_HOME="$work/cache-refresh" \
       WEAVE_CODEX_STATUS_UPDATE=1 WEAVE_CODEX_STATUS_URL="file://$newer_helper" \
-      WEAVE_CODEX_STATUS_TITLE_FILE="$title_file" "$@" "$refresh_helper" >/dev/null
+      WEAVE_CODEX_STATUS_TITLE_FILE="$title_file" "$refresh_helper" >/dev/null
 }
 
 run_refresh_turn

--- a/install/tests/codex-status_test.sh
+++ b/install/tests/codex-status_test.sh
@@ -279,10 +279,6 @@ for _ in 1 2 3 4 5 6 7 8 9 10; do
   [ -f "$commented_cost_cache" ] && break
   sleep 0.2
 done
-kill "$cost_mock_pid" 2>/dev/null
-wait "$cost_mock_pid" 2>/dev/null || true
-cost_mock_pid=""
-
 [ -f "$commented_cost_cache" ] || {
   echo "a commented-out example blocked the live endpoint" >&2
   exit 1
@@ -300,11 +296,26 @@ mkdir -p "$inline_home/.codex"
 cat >"$inline_home/.codex/config.toml" <<TOML
 [model_providers.weave]
 name = "Weave Router" # base_url = "http://127.0.0.1:9/v1"
-base_url = "file://$normalized_cost"
+base_url = "http://127.0.0.1:$commented_port/v1"
 wire_api = "responses" # X-Weave-Router-Key = "rk_inline_stale"
-http_headers = { "X-Weave-Router-Key" = "rk_test" }
+# A literal string is a string: a # inside one must not end the line, or the
+# key after it in this inline table is lost and the fetch never runs.
+http_headers = { "X-App" = 'codex#1', "X-Weave-Router-Key" = "rk_test" }
 TOML
+inline_seen="$work/inline-key.txt"
+rm -f "$inline_seen"
+cp "$commented_seen" "$work/commented-key.keep" 2>/dev/null || true
 inline_cache="$work/cache-inline"
+kill "$cost_mock_pid" 2>/dev/null
+wait "$cost_mock_pid" 2>/dev/null || true
+python3 "$work/cost-mock.py" "$commented_port" "$inline_seen" &
+cost_mock_pid=$!
+for _ in $(seq 1 60); do
+  curl -fsS -o /dev/null --max-time 1 "http://127.0.0.1:$commented_port/v1/sessions/x/cost" 2>/dev/null && break
+  sleep 0.25
+done
+rm -f "$inline_seen"
+
 printf '%s\n' '{"session_id":"session-6","model":"gpt-5.6-terra","last_assistant_message":"✦ **Weave Router** → claude-sonnet-5 · best pick"}' \
   | HOME="$inline_home" XDG_CACHE_HOME="$inline_cache" \
     WEAVE_CODEX_STATUS_TITLE_FILE="$title_file" "$helper" >/dev/null
@@ -317,6 +328,13 @@ done
   echo "an inline comment on an earlier line shadowed the live base_url" >&2
   exit 1
 }
+[ "$(cat "$inline_seen" 2>/dev/null)" = "rk_test" ] || {
+  echo "the inline-commented key was forwarded instead of the live one: $(cat "$inline_seen" 2>/dev/null)" >&2
+  exit 1
+}
+kill "$cost_mock_pid" 2>/dev/null
+wait "$cost_mock_pid" 2>/dev/null || true
+cost_mock_pid=""
 
 # A provider whose name merely starts with "weave" is a different provider: its
 # key must never be adopted, and a config holding only that one resolves nothing.

--- a/install/tests/codex-status_test.sh
+++ b/install/tests/codex-status_test.sh
@@ -134,6 +134,79 @@ run_savings_turn
   exit 1
 }
 
+# ---------- credentials survive a config Codex has rewritten ----------
+#
+# Codex round-trips config.toml through a TOML serializer whenever it persists
+# its own state, which drops the managed comment markers while keeping the
+# provider table, and re-emits the inline http_headers as a subtable with the
+# header name unquoted. A marker-scoped, quoted-only read resolved nothing on
+# such a config, so the savings figure silently vanished from the title with no
+# error anywhere -- the failure looked like "the router just stopped showing
+# savings".
+normalized_home="$work/normalized-home"
+mkdir -p "$normalized_home/.codex"
+normalized_cost="$work/cost-normalized.json"
+printf '%s\n' '{"session_id":"session-3","savings_usd":1.25}' >"$normalized_cost"
+cat >"$normalized_home/.codex/config.toml" <<TOML
+model_provider = "weave"
+
+[model_providers.weave]
+base_url = "file://$normalized_cost"
+name = "Weave Router"
+requires_openai_auth = true
+wire_api = "responses"
+
+[model_providers.weave.http_headers]
+X-App = "codex"
+X-Weave-Router-Key = "rk_test"
+
+[projects."/some/repo"]
+trust_level = "trusted"
+TOML
+
+normalized_cache="$work/cache-normalized"
+run_normalized_turn() {
+  printf '%s\n' '{"session_id":"session-3","model":"gpt-5.6-terra","last_assistant_message":"✦ **Weave Router** → claude-sonnet-5 · best pick for this turn"}' \
+    | HOME="$normalized_home" XDG_CACHE_HOME="$normalized_cache" \
+      WEAVE_CODEX_STATUS_TITLE_FILE="$title_file" "$helper" >/dev/null
+}
+
+run_normalized_turn
+normalized_cost_cache="$normalized_cache/weave-router/codex/session-3.cost"
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  [ -f "$normalized_cost_cache" ] && break
+  sleep 0.2
+done
+[ -f "$normalized_cost_cache" ] || {
+  echo "credentials did not resolve from a Codex-rewritten config (no cost fetch ran)" >&2
+  exit 1
+}
+
+run_normalized_turn
+[ "$(cat "$title_file")" = "Weave Router · claude-sonnet-5 ← gpt-5.6-terra · saved \$1.25" ] || {
+  echo "savings did not reach the title from a Codex-rewritten config: $(cat "$title_file")" >&2
+  exit 1
+}
+
+# A provider whose name merely starts with "weave" is a different provider: its
+# key must never be adopted, and a config holding only that one resolves nothing.
+neighbour_home="$work/neighbour-home"
+mkdir -p "$neighbour_home/.codex"
+cat >"$neighbour_home/.codex/config.toml" <<TOML
+[model_providers.weaver]
+base_url = "file://$normalized_cost"
+X-Weave-Router-Key = "rk_not_ours"
+TOML
+neighbour_cache="$work/cache-neighbour"
+printf '%s\n' '{"session_id":"session-4","model":"gpt-5.6-terra","last_assistant_message":"✦ **Weave Router** → claude-sonnet-5 · best pick"}' \
+  | HOME="$neighbour_home" XDG_CACHE_HOME="$neighbour_cache" \
+    WEAVE_CODEX_STATUS_TITLE_FILE="$title_file" "$helper" >/dev/null
+sleep 0.5
+[ ! -f "$neighbour_cache/weave-router/codex/session-4.cost" ] || {
+  echo "adopted credentials from an unrelated provider whose name starts with weave" >&2
+  exit 1
+}
+
 # The remaining rendering cases run with no reachable config ($HOME has no
 # config.toml), so the fetch is a no-op and the seeded cache is what the turn
 # renders. That also proves an unreachable router leaves the last good value in

--- a/install/tests/codex-status_test.sh
+++ b/install/tests/codex-status_test.sh
@@ -188,15 +188,61 @@ run_normalized_turn
   exit 1
 }
 
-# A commented-out endpoint left above the live one must not win. First match
-# wins, so treating a comment as config would point the fetch at a stale
+# A commented-out endpoint or key left above the live one must not win. First
+# match wins, so treating a comment as config would point the fetch at a stale
 # endpoint and send the router key there.
+#
+# This one needs a real HTTP fixture rather than the file:// seam used above:
+# curl sends no headers to a file:// URL, so a file-based check would prove the
+# base_url comment is skipped while saying nothing about the key.
+commented_port=8809
+commented_seen="$work/commented-key.txt"
+cat >"$work/cost-mock.py" <<'MOCK'
+import pathlib, sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+SEEN = pathlib.Path(sys.argv[2])
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        SEEN.write_text(self.headers.get("X-Weave-Router-Key") or "")
+        body = b'{"savings_usd":2.50}'
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *a):
+        pass
+
+
+HTTPServer(("127.0.0.1", int(sys.argv[1])), Handler).serve_forever()
+MOCK
+python3 "$work/cost-mock.py" "$commented_port" "$commented_seen" &
+cost_mock_pid=$!
+cost_mock_ready=""
+for _ in $(seq 1 60); do
+  if curl -fsS -o /dev/null --max-time 1 "http://127.0.0.1:$commented_port/v1/sessions/x/cost" 2>/dev/null; then
+    cost_mock_ready=1
+    break
+  fi
+  sleep 0.25
+done
+[ -n "$cost_mock_ready" ] || {
+  echo "cost mock never came up on port $commented_port" >&2
+  kill "$cost_mock_pid" 2>/dev/null
+  exit 1
+}
+rm -f "$commented_seen"
+
 commented_home="$work/commented-home"
 mkdir -p "$commented_home/.codex"
 cat >"$commented_home/.codex/config.toml" <<TOML
 [model_providers.weave]
-# base_url = "file:///nonexistent/stale-endpoint.json"
-base_url = "file://$normalized_cost"
+# base_url = "http://127.0.0.1:9/v1"
+base_url = "http://127.0.0.1:$commented_port/v1"
 
 [model_providers.weave.http_headers]
 # X-Weave-Router-Key = "rk_stale"
@@ -211,8 +257,15 @@ for _ in 1 2 3 4 5 6 7 8 9 10; do
   [ -f "$commented_cost_cache" ] && break
   sleep 0.2
 done
+kill "$cost_mock_pid" 2>/dev/null
+wait "$cost_mock_pid" 2>/dev/null || true
+
 [ -f "$commented_cost_cache" ] || {
-  echo "a commented-out example blocked the live credentials" >&2
+  echo "a commented-out example blocked the live endpoint" >&2
+  exit 1
+}
+[ "$(cat "$commented_seen" 2>/dev/null)" = "rk_test" ] || {
+  echo "the commented-out key was forwarded instead of the live one: $(cat "$commented_seen" 2>/dev/null)" >&2
   exit 1
 }
 

--- a/install/tests/codex-status_test.sh
+++ b/install/tests/codex-status_test.sh
@@ -6,7 +6,26 @@ helper="$script_dir/../codex-status.sh"
 [ -x "$helper" ] || { echo "missing executable Codex status helper" >&2; exit 1; }
 
 work="$(mktemp -d)"
-trap 'rm -rf "$work"' EXIT
+cost_mock_pid=""
+cleanup() {
+  # Capture first: reaping the fixture would otherwise leave the shell exiting
+  # 143 and turn a green run red.
+  status=$?
+  if [ -n "$cost_mock_pid" ]; then
+    kill "$cost_mock_pid" 2>/dev/null
+    wait "$cost_mock_pid" 2>/dev/null || true
+  fi
+  rm -rf "$work"
+  exit "$status"
+}
+trap cleanup EXIT
+
+# One case below needs a real HTTP fixture (curl sends no headers to file://).
+# Say so up front rather than letting it surface as a readiness timeout.
+command -v python3 >/dev/null 2>&1 || {
+  echo "python3 is required for the Codex status helper tests" >&2
+  exit 1
+}
 
 # The hook self-updates from GitHub. Left on, every case below would race a
 # download that replaces the helper under test with the published copy, so the
@@ -195,7 +214,11 @@ run_normalized_turn
 # This one needs a real HTTP fixture rather than the file:// seam used above:
 # curl sends no headers to a file:// URL, so a file-based check would prove the
 # base_url comment is skipped while saying nothing about the key.
-commented_port=8809
+commented_port="$(python3 -c 'import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()')"
 commented_seen="$work/commented-key.txt"
 cat >"$work/cost-mock.py" <<'MOCK'
 import pathlib, sys
@@ -221,7 +244,7 @@ class Handler(BaseHTTPRequestHandler):
 HTTPServer(("127.0.0.1", int(sys.argv[1])), Handler).serve_forever()
 MOCK
 python3 "$work/cost-mock.py" "$commented_port" "$commented_seen" &
-cost_mock_pid=$!
+cost_mock_pid=$!  # reaped by the EXIT trap if anything below fails
 cost_mock_ready=""
 for _ in $(seq 1 60); do
   if curl -fsS -o /dev/null --max-time 1 "http://127.0.0.1:$commented_port/v1/sessions/x/cost" 2>/dev/null; then
@@ -232,7 +255,6 @@ for _ in $(seq 1 60); do
 done
 [ -n "$cost_mock_ready" ] || {
   echo "cost mock never came up on port $commented_port" >&2
-  kill "$cost_mock_pid" 2>/dev/null
   exit 1
 }
 rm -f "$commented_seen"
@@ -259,6 +281,7 @@ for _ in 1 2 3 4 5 6 7 8 9 10; do
 done
 kill "$cost_mock_pid" 2>/dev/null
 wait "$cost_mock_pid" 2>/dev/null || true
+cost_mock_pid=""
 
 [ -f "$commented_cost_cache" ] || {
   echo "a commented-out example blocked the live endpoint" >&2
@@ -266,6 +289,32 @@ wait "$cost_mock_pid" 2>/dev/null || true
 }
 [ "$(cat "$commented_seen" 2>/dev/null)" = "rk_test" ] || {
   echo "the commented-out key was forwarded instead of the live one: $(cat "$commented_seen" 2>/dev/null)" >&2
+  exit 1
+}
+
+# A comment trailing another assignment is the same hazard one line over: the
+# matches are unanchored, so a commented base_url riding on an earlier line
+# wins under first-match unless comments are stripped rather than line-skipped.
+inline_home="$work/inline-home"
+mkdir -p "$inline_home/.codex"
+cat >"$inline_home/.codex/config.toml" <<TOML
+[model_providers.weave]
+name = "Weave Router" # base_url = "http://127.0.0.1:9/v1"
+base_url = "file://$normalized_cost"
+wire_api = "responses" # X-Weave-Router-Key = "rk_inline_stale"
+http_headers = { "X-Weave-Router-Key" = "rk_test" }
+TOML
+inline_cache="$work/cache-inline"
+printf '%s\n' '{"session_id":"session-6","model":"gpt-5.6-terra","last_assistant_message":"✦ **Weave Router** → claude-sonnet-5 · best pick"}' \
+  | HOME="$inline_home" XDG_CACHE_HOME="$inline_cache" \
+    WEAVE_CODEX_STATUS_TITLE_FILE="$title_file" "$helper" >/dev/null
+inline_cost_cache="$inline_cache/weave-router/codex/session-6.cost"
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  [ -f "$inline_cost_cache" ] && break
+  sleep 0.2
+done
+[ -f "$inline_cost_cache" ] || {
+  echo "an inline comment on an earlier line shadowed the live base_url" >&2
   exit 1
 }
 


### PR DESCRIPTION
The savings figure silently disappears from the Codex terminal title on any config Codex has rewritten, with no error anywhere. Found while reading `codex-status.sh` for an unrelated change; same root cause as #1211, in a file that PR did not touch.

## Cause

`read_codex_endpoint` scoped its read to the managed comment markers **and** matched only the quoted `"X-Weave-Router-Key"` spelling:

```awk
!inblk { next }
match($0, /"X-Weave-Router-Key"[[:space:]]*=[[:space:]]*"[^"]*"/) { … }
```

Codex round-trips `config.toml` through a TOML serializer whenever it persists its own state (hook trust hashes, project trust levels). Comments do not survive that, so the markers vanish while `[model_providers.weave]` remains — re-emitted with the inline `http_headers` expanded into a subtable and the header name **unquoted**.

Both halves of the read therefore miss. `base_url` and `key` come back empty, `refresh_session_cost` returns early, the cost cache is never written, and the title falls back to model-only. To the user it looks like the router just stopped reporting savings.

## Fix

Scope to the `[model_providers.weave]` table rather than the comment markers, and accept the header name quoted or bare — the same shape as the installer readers fixed in #1211.

The table is still a precise scope, so the original reason for the marker gate (never adopting a key-shaped string the user wrote elsewhere in the file) is preserved. The match is anchored, so a neighbouring `[model_providers.weaver]` is left alone. The now-unused marker constants are removed.

## Verification

Two new cases in `install/tests/codex-status_test.sh`:

- a Codex-rewritten config (no markers, bare header in a subtable, alongside a real `[projects.*]` entry) resolves credentials, runs the cost fetch, and reaches `Weave Router · … · saved $1.25`
- a config holding only `[model_providers.weaver]` resolves nothing, so an unrelated provider's key is never adopted

Mutation-verified: restoring the quoted-only match reds the first with `credentials did not resolve from a Codex-rewritten config (no cost fetch ran)`.

Existing status tests unchanged and passing, including the marker-wrapped inline-header fixture — so both config shapes work. Heredoc re-embedded in `install.sh`; the drift test covers it.

## Note

Branched off `main`, independent of #1239 (different file). Both touch `install.sh`, but in different regions — #1239's `CODEX_DIRECTIVE_EOF` heredoc and wiring versus this one's `CODEX_STATUS_EOF` heredoc — so they should merge in either order.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex status credential reads after Codex rewrites `config.toml`, so the terminal title continues to show savings. Instead of relying on managed comment markers and quoted headers, the reader scopes values to `[model_providers.weave]`, accepts quoted or bare `X-Weave-Router-Key`, and strips TOML comments string-aware—a `#` inside a quoted value is data, and trailing comments are cut—without adopting similarly named providers.

- Tests cover rewritten and inline configs, live key forwarding over HTTP, asynchronous cost fetching, title rendering, and provider isolation.
- Mirrors the reader in embedded `install.sh`, removes the unused refresh-helper argument, and uses an ephemeral-port Python fixture with cleanup.

<sup>Written for commit a2b4e138d2573e8f5c659e6b84822781cdcf003a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weave-os/router/pull/1244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

