### PR TITLE
fix: harden model discovery and header forwarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,13 +77,19 @@ ROUTER_DEPLOYMENT_MODE=selfhosted
 # in-cluster or loopback gateway is normal. Set explicitly to override.
 # ROUTER_RESTRICT_UPSTREAM_EGRESS=false
 
+# Model discovery always rejects non-public destinations, independently of
+# ROUTER_RESTRICT_UPSTREAM_EGRESS. Self-hosted operators may allow discovery
+# for a private gateway by listing its exact origin (scheme, host, and port).
+# Comma-separate multiple origins; paths, wildcards, and CIDRs are rejected.
+# ROUTER_MODEL_DISCOVERY_PRIVATE_ORIGINS=https://gateway.internal:8443
+
 # Platform fee on BYOK turns (managed mode), as a fraction of the upstream
 # cost the customer paid their own provider. Default 0 — no fee, no byok_fee
 # ledger row. e.g. 0.05 charges 5%.
 # BYOK_FEE_RATE=0
 
-# Admin dashboard password. Defaults to "admin" when unset (logs a warning) —
-# DEV ONLY behavior. REQUIRED in any deployment exposed beyond localhost.
+# Admin dashboard password. When unset, inference remains available but
+# dashboard login and management endpoints are disabled.
 # ROUTER_ADMIN_PASSWORD=change-me
 
 # Cookie security flag for the admin dashboard. Set to `true` only when

--- a/README.md
+++ b/README.md
@@ -92,13 +92,16 @@ If you want the router (and dashboard) running on your own box:
 # 1. Drop a provider key in. OpenRouter is the recommended baseline.
 echo "OPENROUTER_API_KEY=sk-or-v1-..." >> .env.local
 
-# 2. Boot Postgres + router on :8080 and seed an rk_ key.
+# 2. Set a dashboard password. Without one, inference still runs but
+# dashboard administration is disabled.
+echo "ROUTER_ADMIN_PASSWORD=replace-with-a-strong-password" >> .env.local
+
+# 3. Boot Postgres + router on :8080 and seed an rk_ key.
 make full-setup
 ```
 
 The router is up at <http://localhost:8080>, the dashboard at
-<http://localhost:8080/ui/> (password: `admin`), and your `rk_...` key
-prints in the logs.
+<http://localhost:8080/ui/>, and your `rk_...` key prints in the logs.
 
 ```bash
 # Call it like Anthropic

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -36,6 +36,7 @@ import (
 	"weave-os/router/internal/providers/anthropic"
 	"weave-os/router/internal/providers/cortexagents"
 	googleProvider "weave-os/router/internal/providers/google"
+	providerHTTP "weave-os/router/internal/providers/httputil"
 	openaiProvider "weave-os/router/internal/providers/openai"
 	openaiCompatProvider "weave-os/router/internal/providers/openaicompat"
 	"weave-os/router/internal/proxy"
@@ -159,6 +160,11 @@ func main() {
 	}
 
 	repo := postgres.NewRepository(pool, encryptor)
+	discoveryHTTPClient, err := providerHTTP.NewModelDiscoveryClient(config.GetOr("ROUTER_MODEL_DISCOVERY_PRIVATE_ORIGINS", ""))
+	if err != nil {
+		logger.Error("Invalid model discovery private-origin configuration", "err", err)
+		panic(err)
+	}
 
 	providerMap := make(map[string]providers.Client)
 	// envKeyedProviders = providers with a real deployment-level API key.
@@ -205,7 +211,7 @@ func main() {
 	if !byokOnly {
 		anthropicKey = config.GetOr("ANTHROPIC_API_KEY", "")
 	}
-	providerMap[providers.ProviderAnthropic] = anthropic.NewClient(anthropicKey, anthropic.DefaultBaseURL)
+	providerMap[providers.ProviderAnthropic] = anthropic.NewClient(anthropicKey, anthropic.DefaultBaseURL, anthropic.WithModelListHTTPClient(discoveryHTTPClient))
 	switch {
 	case byokOnly:
 		logger.Info("Anthropic provider enabled (BYOK only)", "base_url", anthropic.DefaultBaseURL)
@@ -264,7 +270,7 @@ func main() {
 		if !byokOnly && openRouterPlatformEnabled {
 			openRouterKey = config.GetOr("OPENROUTER_API_KEY", "")
 		}
-		providerMap[providers.ProviderOpenRouter] = openaiCompatProvider.NewClient(openRouterKey, openRouterBaseURL)
+		providerMap[providers.ProviderOpenRouter] = openaiCompatProvider.NewClient(openRouterKey, openRouterBaseURL, openaiCompatProvider.WithModelListHTTPClient(discoveryHTTPClient))
 		switch {
 		case byokOnly:
 			logger.Info("OpenRouter provider enabled (BYOK only)", "base_url", openRouterBaseURL)
@@ -283,7 +289,7 @@ func main() {
 		registerDeploymentKeyedProvider(providerMap, envKeyedProviders, logger,
 			providers.ProviderFireworks, "Fireworks", "FIREWORKS_API_KEY", fireworksBaseURL, byokOnly,
 			func(key, baseURL string) providers.Client {
-				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, upstreamIDsForProvider(providers.ProviderFireworks))
+				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, upstreamIDsForProvider(providers.ProviderFireworks), openaiCompatProvider.WithModelListHTTPClient(discoveryHTTPClient))
 			})
 	}
 
@@ -294,7 +300,7 @@ func main() {
 		registerDeploymentKeyedProvider(providerMap, envKeyedProviders, logger,
 			providers.ProviderMakora, "Makora", "MAKORA_API_KEY", makoraBaseURL, byokOnly,
 			func(key, baseURL string) providers.Client {
-				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, upstreamIDsForProvider(providers.ProviderMakora))
+				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, upstreamIDsForProvider(providers.ProviderMakora), openaiCompatProvider.WithModelListHTTPClient(discoveryHTTPClient))
 			})
 	}
 
@@ -307,7 +313,7 @@ func main() {
 		registerDeploymentKeyedProvider(providerMap, envKeyedProviders, logger,
 			providers.ProviderTogether, "Together", "TOGETHER_API_KEY", togetherBaseURL, byokOnly,
 			func(key, baseURL string) providers.Client {
-				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, upstreamIDsForProvider(providers.ProviderTogether))
+				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, upstreamIDsForProvider(providers.ProviderTogether), openaiCompatProvider.WithModelListHTTPClient(discoveryHTTPClient))
 			})
 	}
 
@@ -317,7 +323,7 @@ func main() {
 		registerDeploymentKeyedProvider(providerMap, envKeyedProviders, logger,
 			providers.ProviderMiniMax, "MiniMax", "MINIMAX_API_KEY", minimaxBaseURL, byokOnly,
 			func(key, baseURL string) providers.Client {
-				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, upstreamIDsForProvider(providers.ProviderMiniMax))
+				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, upstreamIDsForProvider(providers.ProviderMiniMax), openaiCompatProvider.WithModelListHTTPClient(discoveryHTTPClient))
 			})
 	}
 
@@ -326,7 +332,7 @@ func main() {
 		registerDeploymentKeyedProvider(providerMap, envKeyedProviders, logger,
 			providers.ProviderXAI, "XAI", "XAI_API_KEY", xaiBaseURL, byokOnly,
 			func(key, baseURL string) providers.Client {
-				return openaiCompatProvider.NewClient(key, baseURL)
+				return openaiCompatProvider.NewClient(key, baseURL, openaiCompatProvider.WithModelListHTTPClient(discoveryHTTPClient))
 			})
 	}
 
@@ -335,7 +341,7 @@ func main() {
 		registerDeploymentKeyedProvider(providerMap, envKeyedProviders, logger,
 			providers.ProviderMeta, "Meta", "META_API_KEY", metaBaseURL, byokOnly,
 			func(key, baseURL string) providers.Client {
-				return openaiCompatProvider.NewClient(key, baseURL)
+				return openaiCompatProvider.NewClient(key, baseURL, openaiCompatProvider.WithModelListHTTPClient(discoveryHTTPClient))
 			})
 	}
 
@@ -346,7 +352,7 @@ func main() {
 		registerDeploymentKeyedProvider(providerMap, envKeyedProviders, logger,
 			providers.ProviderWafer, "Wafer", "WAFER_API_KEY", waferBaseURL, byokOnly,
 			func(key, baseURL string) providers.Client {
-				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, upstreamIDsForProvider(providers.ProviderWafer)).
+				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, upstreamIDsForProvider(providers.ProviderWafer), openaiCompatProvider.WithModelListHTTPClient(discoveryHTTPClient)).
 					WithProtectedHeaders(http.Header{"Wafer-ZDR": []string{"required"}})
 			})
 	}
@@ -361,7 +367,8 @@ func main() {
 		waferMessagesBaseURL := anthropic.WaferMessagesBaseURL
 		providerMap[providers.ProviderWaferAnthropic] = anthropic.NewClient(
 			waferAnthropicKey, waferMessagesBaseURL,
-			anthropic.WithAuthScheme(anthropic.AuthBearer)).
+			anthropic.WithAuthScheme(anthropic.AuthBearer),
+			anthropic.WithModelListHTTPClient(discoveryHTTPClient)).
 			WithProtectedHeaders(http.Header{"Wafer-ZDR": []string{"required"}}).
 			WithModelIDMap(upstreamIDsForProvider(providers.ProviderWaferAnthropic))
 		if waferAnthropicKey != "" {
@@ -382,7 +389,7 @@ func main() {
 		registerDeploymentKeyedProvider(providerMap, envKeyedProviders, logger,
 			providers.ProviderBedrock, "Bedrock", "AWS_BEARER_TOKEN_BEDROCK", bedrockBaseURL, byokOnly,
 			func(key, baseURL string) providers.Client {
-				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, upstreamIDsForProvider(providers.ProviderBedrock))
+				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, upstreamIDsForProvider(providers.ProviderBedrock), openaiCompatProvider.WithModelListHTTPClient(discoveryHTTPClient))
 			},
 			"region", bedrockRegion)
 	}
@@ -396,7 +403,9 @@ func main() {
 			gatewayToken = config.GetOr(providers.APIKeyEnvVar(providers.ProviderAnthropicGateway), "")
 		}
 		providerMap[providers.ProviderAnthropicGateway] = anthropic.NewClient(
-			gatewayToken, gatewayBaseURL, anthropic.WithAuthScheme(anthropic.AuthBearer))
+			gatewayToken, gatewayBaseURL,
+			anthropic.WithAuthScheme(anthropic.AuthBearer),
+			anthropic.WithModelListHTTPClient(discoveryHTTPClient))
 		if gatewayToken != "" {
 			envKeyedProviders[providers.ProviderAnthropicGateway] = struct{}{}
 			logger.Info("Anthropic gateway provider enabled", "base_url", gatewayBaseURL)
@@ -413,7 +422,7 @@ func main() {
 		if !byokOnly && gatewayBaseURL != "" {
 			gatewayToken = config.GetOr(providers.APIKeyEnvVar(providers.ProviderOpenAIGateway), "")
 		}
-		providerMap[providers.ProviderOpenAIGateway] = openaiCompatProvider.NewGatewayClient(gatewayToken, gatewayBaseURL)
+		providerMap[providers.ProviderOpenAIGateway] = openaiCompatProvider.NewGatewayClient(gatewayToken, gatewayBaseURL, openaiCompatProvider.WithModelListHTTPClient(discoveryHTTPClient))
 		if gatewayToken != "" {
 			envKeyedProviders[providers.ProviderOpenAIGateway] = struct{}{}
 			logger.Info("OpenAI gateway provider enabled", "base_url", gatewayBaseURL)
@@ -563,8 +572,7 @@ func main() {
 	if deploymentMode == server.DeploymentModeSelfHosted {
 		adminPassword := config.GetOr("ROUTER_ADMIN_PASSWORD", "")
 		if adminPassword == "" {
-			adminPassword = "admin"
-			logger.Warn("ROUTER_ADMIN_PASSWORD not set; using default 'admin'. Set ROUTER_ADMIN_PASSWORD to secure the dashboard.")
+			logger.Warn("ROUTER_ADMIN_PASSWORD not set; dashboard administration is disabled. Set ROUTER_ADMIN_PASSWORD to enable it.")
 		}
 		authSvc.WithAdminPassword(adminPassword)
 	}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -394,8 +394,9 @@ Set `DATABASE_URL` directly, or compose it from the individual vars:
 | ------------------------ | ------------ | ------- |
 | `PORT`                   | `8080`       | HTTP listen port. |
 | `ROUTER_DEPLOYMENT_MODE` | `selfhosted` | `selfhosted` mounts `/ui/*` and `/admin/v1/*`. `managed` skips both (for SaaS deployments with a separate admin UI). |
-| `ROUTER_ADMIN_PASSWORD`  | `admin`      | Dashboard password. Defaults to `admin` with a startup warning when unset — **set this for any internet-facing deployment**. |
+| `ROUTER_ADMIN_PASSWORD`  | *(none)*     | Dashboard password. When unset, inference stays available but dashboard login and management endpoints return `admin_login_disabled`. |
 | `ROUTER_RESTRICT_UPSTREAM_EGRESS` | follows `ROUTER_DEPLOYMENT_MODE` | When true, provider adapters refuse to dial an upstream that resolves outside the public internet (loopback, private, link-local, CGNAT). Defaults to true in `managed` mode and false in `selfhosted`, where pointing a provider at an in-cluster or loopback gateway is normal. While on, provider adapters also ignore `HTTP_PROXY`/`HTTPS_PROXY`, since a proxied connection makes the destination unverifiable. |
+| `ROUTER_MODEL_DISCOVERY_PRIVATE_ORIGINS` | *(none)* | Comma-separated exact origins allowed to use private addresses for model discovery (for example, `https://gateway.internal:8443`). Discovery always blocks non-public destinations otherwise and always ignores ambient proxies, regardless of `ROUTER_RESTRICT_UPSTREAM_EGRESS`. Entries may contain only scheme, host, and port; paths, wildcards, and CIDRs are rejected at startup. |
 
 ## Routing
 

--- a/internal/api/admin/internal_upstream_models.go
+++ b/internal/api/admin/internal_upstream_models.go
@@ -48,7 +48,7 @@ func InternalListUpstreamModelsHandler(authSvc *auth.Service, proxySvc *proxy.Se
 		creds := proxy.BuildCredentialsMap([]*auth.ExternalAPIKey{key})[key.Provider]
 		models, err := proxySvc.ListUpstreamModels(c.Request.Context(), key.Provider, creds)
 		if err != nil {
-			abortForListingError(c, key.Provider, key.ID, err)
+			abortForListingError(c, key.Provider, key.ID, false, err)
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"models": models})

--- a/internal/api/admin/internal_upstream_models.go
+++ b/internal/api/admin/internal_upstream_models.go
@@ -48,7 +48,7 @@ func InternalListUpstreamModelsHandler(authSvc *auth.Service, proxySvc *proxy.Se
 		creds := proxy.BuildCredentialsMap([]*auth.ExternalAPIKey{key})[key.Provider]
 		models, err := proxySvc.ListUpstreamModels(c.Request.Context(), key.Provider, creds)
 		if err != nil {
-			abortForListingError(c, key.Provider, key.ID, false, err)
+			abortForListingError(c, key.Provider, key.ID, err)
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"models": models})

--- a/internal/api/admin/keys_test.go
+++ b/internal/api/admin/keys_test.go
@@ -590,6 +590,26 @@ func TestUpsertExternalKeyHandler_RejectsReservedIdentityHeader(t *testing.T) {
 		"a rejected upsert must not take out the working key it would have replaced")
 }
 
+func TestUpsertExternalKeyHandler_RejectsCollidingHeaderDestinationsBeforeReplacement(t *testing.T) {
+	t.Setenv(providers.APIKeyEnvVar(providers.ProviderAnthropic), "")
+
+	repo := &fakeExternalAPIKeyRepo{}
+	body, err := json.Marshal(map[string]any{
+		"provider":                 providers.ProviderAnthropic,
+		"key":                      "sk-test-key",
+		"forwarded_client_headers": []string{"X-Correlation-ID"},
+		"identity_header":          "x-correlation-id",
+		"identity_header_format":   auth.IdentityFormatEmail,
+	})
+	require.NoError(t, err)
+	rec := postProviderKeyBody(upsertKeyEngine(newUpsertKeyService(repo)), body)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Zero(t, repo.created)
+	assert.Zero(t, repo.softDeletedByProvider,
+		"invalid effective configuration must leave the active key untouched")
+}
+
 func aliasUpdateEngine(svc *auth.Service, models admin.DeployedModelsSource) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	engine := gin.New()

--- a/internal/api/admin/upstream_models.go
+++ b/internal/api/admin/upstream_models.go
@@ -41,7 +41,7 @@ func DiscoverModelsHandler(proxySvc *proxy.Service) gin.HandlerFunc {
 		creds := proxy.BuildCredentialsMap([]*auth.ExternalAPIKey{key})[req.Provider]
 		models, err := proxySvc.ListUpstreamModels(c.Request.Context(), req.Provider, creds)
 		if err != nil {
-			abortForListingError(c, req.Provider, "", true, err)
+			abortForListingError(c, req.Provider, "", err)
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"models": models})
@@ -77,7 +77,7 @@ func ListUpstreamModelsHandler(authSvc *auth.Service, proxySvc *proxy.Service) g
 		creds := proxy.BuildCredentialsMap([]*auth.ExternalAPIKey{key})[key.Provider]
 		models, err := proxySvc.ListUpstreamModels(c.Request.Context(), key.Provider, creds)
 		if err != nil {
-			abortForListingError(c, key.Provider, key.ID, false, err)
+			abortForListingError(c, key.Provider, key.ID, err)
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"models": models})
@@ -85,12 +85,17 @@ func ListUpstreamModelsHandler(authSvc *auth.Service, proxySvc *proxy.Service) g
 }
 
 // abortForListingError maps listing errors without exposing endpoint details.
-func abortForListingError(c *gin.Context, provider, keyID string, unsaved bool, err error) {
+// A destination refusal answers 400 for saved and unsaved keys alike: it is a
+// rejected configuration, and reporting it as a 502 would read as an endpoint
+// outage and send an operator debugging the wrong system.
+func abortForListingError(c *gin.Context, provider, keyID string, err error) {
 	if errors.Is(err, proxy.ErrModelListingUnsupported) || errors.Is(err, proxy.ErrProviderNotConfigured) {
 		c.AbortWithStatusJSON(http.StatusNotImplemented, gin.H{"error": "This provider does not support model listing; enter aliases manually."})
 		return
 	}
-	if unsaved && errors.Is(err, providers.ErrModelDiscoveryDestination) {
+	if errors.Is(err, providers.ErrModelDiscoveryDestination) {
+		observability.FromGin(c).Warn("Upstream model listing refused a destination",
+			"external_api_key_id", keyID, "provider", provider, "err", err)
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "The model discovery destination is not allowed."})
 		return
 	}

--- a/internal/api/admin/upstream_models.go
+++ b/internal/api/admin/upstream_models.go
@@ -6,6 +6,7 @@ import (
 
 	"weave-os/router/internal/auth"
 	"weave-os/router/internal/observability"
+	"weave-os/router/internal/providers"
 	"weave-os/router/internal/proxy"
 
 	"github.com/gin-gonic/gin"
@@ -40,7 +41,7 @@ func DiscoverModelsHandler(proxySvc *proxy.Service) gin.HandlerFunc {
 		creds := proxy.BuildCredentialsMap([]*auth.ExternalAPIKey{key})[req.Provider]
 		models, err := proxySvc.ListUpstreamModels(c.Request.Context(), req.Provider, creds)
 		if err != nil {
-			abortForListingError(c, req.Provider, "", err)
+			abortForListingError(c, req.Provider, "", true, err)
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"models": models})
@@ -76,20 +77,24 @@ func ListUpstreamModelsHandler(authSvc *auth.Service, proxySvc *proxy.Service) g
 		creds := proxy.BuildCredentialsMap([]*auth.ExternalAPIKey{key})[key.Provider]
 		models, err := proxySvc.ListUpstreamModels(c.Request.Context(), key.Provider, creds)
 		if err != nil {
-			abortForListingError(c, key.Provider, key.ID, err)
+			abortForListingError(c, key.Provider, key.ID, false, err)
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"models": models})
 	}
 }
 
-// abortForListingError maps listing errors to HTTP: 501 = no surface (keep manual entry), else 502.
-func abortForListingError(c *gin.Context, provider, keyID string, err error) {
+// abortForListingError maps listing errors without exposing endpoint details.
+func abortForListingError(c *gin.Context, provider, keyID string, unsaved bool, err error) {
 	if errors.Is(err, proxy.ErrModelListingUnsupported) || errors.Is(err, proxy.ErrProviderNotConfigured) {
 		c.AbortWithStatusJSON(http.StatusNotImplemented, gin.H{"error": "This provider does not support model listing; enter aliases manually."})
 		return
 	}
+	if unsaved && errors.Is(err, providers.ErrModelDiscoveryDestination) {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "The model discovery destination is not allowed."})
+		return
+	}
 	observability.FromGin(c).Warn("Upstream model listing failed",
 		"external_api_key_id", keyID, "provider", provider, "err", err)
-	c.AbortWithStatusJSON(http.StatusBadGateway, gin.H{"error": "The endpoint did not return a model list: " + err.Error()})
+	c.AbortWithStatusJSON(http.StatusBadGateway, gin.H{"error": "The endpoint did not return a model list."})
 }

--- a/internal/api/admin/upstream_models_test.go
+++ b/internal/api/admin/upstream_models_test.go
@@ -214,3 +214,28 @@ func TestListUpstreamModelsHandler_EndpointFailureIs502(t *testing.T) {
 	assert.Equal(t, http.StatusBadGateway, rec.Code)
 	assert.NotContains(t, rec.Body.String(), upstreamSecret)
 }
+
+// A saved key pointed at a refused destination is a rejected configuration,
+// not an endpoint outage; a 502 here would send an operator to debug the
+// customer's gateway instead of their own base URL.
+func TestListUpstreamModelsHandler_BlockedDestinationIs400(t *testing.T) {
+	key := &auth.ExternalAPIKey{
+		ID:             "ext-1",
+		InstallationID: testInstallationID,
+		Provider:       providers.ProviderOpenAIGateway,
+		Plaintext:      []byte("sk-byok"),
+		BaseURL:        "https://gateway.example/v1",
+	}
+	lister := &modelListingClient{err: providers.ErrModelDiscoveryDestination}
+	engine := upstreamModelsEngine(
+		upstreamModelsAuthService([]*auth.ExternalAPIKey{key}),
+		upstreamModelsProxyService(map[string]providers.Client{providers.ProviderOpenAIGateway: lister}),
+	)
+
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/v1/provider-keys/ext-1/models", nil))
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "gateway.example")
+	assert.NotContains(t, rec.Body.String(), "sk-byok")
+}

--- a/internal/api/admin/upstream_models_test.go
+++ b/internal/api/admin/upstream_models_test.go
@@ -171,6 +171,28 @@ func TestDiscoverModelsHandler_RejectsMissingKey(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+func TestDiscoverModelsHandler_RejectsBlockedDestinationAs400(t *testing.T) {
+	lister := &modelListingClient{err: providers.ErrModelDiscoveryDestination}
+	engine := discoverModelsEngine(
+		upstreamModelsProxyService(map[string]providers.Client{providers.ProviderOpenAIGateway: lister}),
+	)
+
+	body, err := json.Marshal(map[string]string{
+		"provider": providers.ProviderOpenAIGateway,
+		"key":      "sk-unsaved",
+		"base_url": "https://gateway.example/v1",
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/admin/v1/provider-keys/discover-models", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "gateway.example")
+	assert.NotContains(t, rec.Body.String(), "sk-unsaved")
+}
+
 func TestListUpstreamModelsHandler_EndpointFailureIs502(t *testing.T) {
 	key := &auth.ExternalAPIKey{
 		ID:             "ext-1",
@@ -179,7 +201,8 @@ func TestListUpstreamModelsHandler_EndpointFailureIs502(t *testing.T) {
 		Plaintext:      []byte("sk-byok"),
 		BaseURL:        "https://cortex.example/api/v2/cortex/v1",
 	}
-	lister := &modelListingClient{err: errors.New("model listing returned status 401")}
+	const upstreamSecret = "sentinel-upstream-response-secret"
+	lister := &modelListingClient{err: errors.New("model listing returned status 401: " + upstreamSecret)}
 	engine := upstreamModelsEngine(
 		upstreamModelsAuthService([]*auth.ExternalAPIKey{key}),
 		upstreamModelsProxyService(map[string]providers.Client{providers.ProviderOpenAIGateway: lister}),
@@ -189,4 +212,5 @@ func TestListUpstreamModelsHandler_EndpointFailureIs502(t *testing.T) {
 	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/v1/provider-keys/ext-1/models", nil))
 
 	assert.Equal(t, http.StatusBadGateway, rec.Code)
+	assert.NotContains(t, rec.Body.String(), upstreamSecret)
 }

--- a/internal/auth/admin_test.go
+++ b/internal/auth/admin_test.go
@@ -142,6 +142,8 @@ func TestVerifyAdminPassword_NotConfigured(t *testing.T) {
 	err := svc.VerifyAdminPassword(adminTestPassword)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrAdminPasswordNotConfigured)
+	assert.ErrorIs(t, svc.VerifyAdminPassword("admin"), ErrAdminPasswordNotConfigured,
+		"an unset password must never revive the former shared default")
 
 	_, _, issueErr := svc.IssueAdminSession()
 	require.Error(t, issueErr)

--- a/internal/auth/external_api_key.go
+++ b/internal/auth/external_api_key.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -89,14 +90,60 @@ const (
 // maxIdentityHeaderNameLength bounds the configured field name.
 const maxIdentityHeaderNameLength = 128
 
-// headersRejectedForIdentity are request-critical headers a tenant must not redirect identity into.
-var headersRejectedForIdentity = map[string]struct{}{
-	"authorization":  {},
-	"x-api-key":      {},
-	"host":           {},
-	"content-type":   {},
-	"content-length": {},
-	"accept":         {},
+const (
+	weaveHeaderPrefix     = "x-weave-"
+	forwardedHeaderPrefix = "x-forwarded-"
+)
+
+// protectedForwardingHeaders are request-control, credential, metadata, and
+// framing fields that tenant configuration must never read or overwrite.
+var protectedForwardingHeaders = map[string]struct{}{
+	"accept":                               {},
+	"accept-encoding":                      {},
+	"anthropic-beta":                       {},
+	"anthropic-version":                    {},
+	"api-key":                              {},
+	"authentication":                       {},
+	"authentication-info":                  {},
+	"authorization":                        {},
+	"chatgpt-account-id":                   {},
+	"connection":                           {},
+	"content-encoding":                     {},
+	"content-length":                       {},
+	"content-type":                         {},
+	"cookie":                               {},
+	"forwarded":                            {},
+	"host":                                 {},
+	"keep-alive":                           {},
+	"metadata":                             {},
+	"metadata-flavor":                      {},
+	"ocp-apim-subscription-key":            {},
+	"openai-organization":                  {},
+	"openai-project":                       {},
+	"proxy-authenticate":                   {},
+	"proxy-authorization":                  {},
+	"proxy-connection":                     {},
+	"set-cookie":                           {},
+	"te":                                   {},
+	"trailer":                              {},
+	"transfer-encoding":                    {},
+	"upgrade":                              {},
+	"www-authenticate":                     {},
+	"x-access-token":                       {},
+	"x-amz-content-sha256":                 {},
+	"x-amz-date":                           {},
+	"x-amz-security-token":                 {},
+	"x-amz-target":                         {},
+	"x-api-key":                            {},
+	"x-auth-token":                         {},
+	"x-authentication":                     {},
+	"x-aws-ec2-metadata-token":             {},
+	"x-aws-ec2-metadata-token-ttl-seconds": {},
+	"x-goog-api-key":                       {},
+	"x-goog-metadata-request":              {},
+	"x-real-ip":                            {},
+	"x-original-url":                       {},
+	"x-rewrite-url":                        {},
 }
 
 // NormalizeIdentityHeader validates the header name and format; both nil clears forwarding.
@@ -119,7 +166,7 @@ func NormalizeIdentityHeader(name, format *string) (*string, *string, error) {
 	if !validHeaderName(trimmedName) {
 		return nil, nil, fmt.Errorf("%w: %q is not a valid header name", ErrInvalidIdentityHeader, trimmedName)
 	}
-	if _, rejected := headersRejectedForIdentity[strings.ToLower(trimmedName)]; rejected {
+	if !IsSafeForwardingHeader(trimmedName) {
 		return nil, nil, fmt.Errorf("%w: %q is reserved", ErrInvalidIdentityHeader, trimmedName)
 	}
 	if trimmedFormat != IdentityFormatEmail && trimmedFormat != IdentityFormatJSON {
@@ -177,16 +224,56 @@ func NormalizeBaggageHeader(raw *string) (*string, error) {
 	return &trimmed, nil
 }
 
+// ValidateForwardingHeaderConfiguration rejects collisions between the three
+// configurable destinations so runtime behavior never depends on write order.
+func ValidateForwardingHeaderConfiguration(forwarded []string, baggage, identity string) error {
+	seen := make(map[string]struct{}, len(forwarded)+2)
+	for _, name := range forwarded {
+		lowerName := strings.ToLower(name)
+		if _, duplicate := seen[lowerName]; duplicate {
+			return fmt.Errorf("%w: header destinations must be distinct", ErrInvalidForwardedHeader)
+		}
+		seen[lowerName] = struct{}{}
+	}
+	for _, name := range []string{baggage, identity} {
+		if name == "" {
+			continue
+		}
+		lowerName := strings.ToLower(name)
+		if _, collision := seen[lowerName]; collision {
+			return fmt.Errorf("%w: header destinations must be distinct", ErrInvalidForwardedHeader)
+		}
+		seen[lowerName] = struct{}{}
+	}
+	return nil
+}
+
 // validateForwardableHeader rejects malformed names and the request-critical
 // ones a caller could otherwise use to redirect its own credentials upstream.
 func validateForwardableHeader(name string) error {
-	if !validHeaderName(name) {
-		return fmt.Errorf("%w: %q is not a valid header name", ErrInvalidForwardedHeader, name)
-	}
-	if _, rejected := headersRejectedForIdentity[strings.ToLower(name)]; rejected {
+	if !IsSafeForwardingHeader(name) {
+		if !validHeaderName(name) {
+			return fmt.Errorf("%w: %q is not a valid header name", ErrInvalidForwardedHeader, name)
+		}
 		return fmt.Errorf("%w: %q is reserved", ErrInvalidForwardedHeader, name)
 	}
 	return nil
+}
+
+// IsSafeForwardingHeader reports whether name may be used as a configurable
+// forwarding, baggage, or identity destination at runtime.
+func IsSafeForwardingHeader(name string) bool {
+	if name == "" || strings.TrimSpace(name) != name || !validHeaderName(name) {
+		return false
+	}
+	lowerName := strings.ToLower(name)
+	if strings.HasPrefix(lowerName, weaveHeaderPrefix) || strings.HasPrefix(lowerName, forwardedHeaderPrefix) {
+		return false
+	}
+	if _, protected := protectedForwardingHeaders[lowerName]; protected {
+		return false
+	}
+	return true
 }
 
 // headerNameChars are the RFC 9110 token characters a field name may contain.
@@ -248,14 +335,31 @@ func NormalizeBaseURL(raw *string) (*string, error) {
 	if trimmed == "" {
 		return nil, nil
 	}
+	if strings.ContainsAny(trimmed, "?#") {
+		return nil, ErrInvalidBaseURL
+	}
 	parsed, err := url.Parse(trimmed)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %q", ErrInvalidBaseURL, trimmed)
+		return nil, ErrInvalidBaseURL
 	}
-	if (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
-		return nil, fmt.Errorf("%w: %q", ErrInvalidBaseURL, trimmed)
+	if (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" || parsed.Hostname() == "" ||
+		parsed.User != nil || parsed.Opaque != "" || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" ||
+		!validBaseURLPort(parsed) {
+		return nil, ErrInvalidBaseURL
 	}
 	return &trimmed, nil
+}
+
+func validBaseURLPort(parsed *url.URL) bool {
+	if strings.HasSuffix(parsed.Host, ":") {
+		return false
+	}
+	port := parsed.Port()
+	if port == "" {
+		return true
+	}
+	portNumber, err := strconv.Atoi(port)
+	return err == nil && portNumber >= 1 && portNumber <= 65535
 }
 
 // maxKeypairFieldLength bounds the account and user identifiers.

--- a/internal/auth/external_api_key_test.go
+++ b/internal/auth/external_api_key_test.go
@@ -34,15 +34,83 @@ func TestNormalizeBaseURL(t *testing.T) {
 
 	t.Run("rejects values that cannot address an upstream", func(t *testing.T) {
 		for name, in := range map[string]string{
-			"no scheme":       "gateway.example.com",
-			"relative path":   "/v1/messages",
-			"no host":         "https://",
-			"unsupported ftp": "ftp://gateway.example.com",
+			"no scheme":          "gateway.example.com",
+			"relative path":      "/v1/messages",
+			"no host":            "https://",
+			"unsupported ftp":    "ftp://gateway.example.com",
+			"userinfo":           "https://user:secret@gateway.example.com/v1",
+			"opaque":             "https:gateway.example.com/v1",
+			"bare query":         "https://gateway.example.com/v1?",
+			"populated query":    "https://gateway.example.com/v1?target=internal",
+			"bare fragment":      "https://gateway.example.com/v1#",
+			"populated fragment": "https://gateway.example.com/v1#hidden",
+			"empty port":         "https://gateway.example.com:",
+			"zero port":          "https://gateway.example.com:0",
+			"oversized port":     "https://gateway.example.com:65536",
+			"non-numeric port":   "https://gateway.example.com:not-a-port",
 		} {
 			_, err := auth.NormalizeBaseURL(ptr(in))
 			assert.ErrorIs(t, err, auth.ErrInvalidBaseURL, name)
+			assert.NotContains(t, err.Error(), in, name)
 		}
 	})
+
+	t.Run("accepts conventional literal addresses and custom paths", func(t *testing.T) {
+		for _, in := range []string{
+			"http://192.0.2.10:8080/custom/path",
+			"https://[2001:db8::1]/gateway/v1",
+		} {
+			got, err := auth.NormalizeBaseURL(ptr(in))
+			require.NoError(t, err, in)
+			require.NotNil(t, got, in)
+			assert.Equal(t, in, *got)
+		}
+	})
+}
+
+func TestForwardingHeaderSafetyPolicy(t *testing.T) {
+	for _, protected := range []string{
+		"Authorization",
+		"Cookie",
+		"Ocp-Apim-Subscription-Key",
+		"X-Aws-Ec2-Metadata-Token",
+		"X-Forwarded-For",
+		"x-WEAVE-router-key",
+		"Transfer-Encoding",
+	} {
+		t.Run(protected, func(t *testing.T) {
+			assert.False(t, auth.IsSafeForwardingHeader(protected))
+			_, forwardedErr := auth.NormalizeForwardedClientHeaders([]string{"  " + protected + "  "})
+			assert.ErrorIs(t, forwardedErr, auth.ErrInvalidForwardedHeader)
+			_, baggageErr := auth.NormalizeBaggageHeader(ptr("  " + protected + "  "))
+			assert.ErrorIs(t, baggageErr, auth.ErrInvalidForwardedHeader)
+			_, _, identityErr := auth.NormalizeIdentityHeader(ptr("  "+protected+"  "), ptr(auth.IdentityFormatEmail))
+			assert.ErrorIs(t, identityErr, auth.ErrInvalidIdentityHeader)
+		})
+	}
+
+	assert.True(t, auth.IsSafeForwardingHeader("X-Correlation-ID"))
+}
+
+func TestValidateForwardingHeaderConfiguration(t *testing.T) {
+	assert.NoError(t, auth.ValidateForwardingHeaderConfiguration(
+		[]string{"X-Correlation-ID"}, "X-Request-Baggage", "X-Caller-Identity",
+	))
+	for name, testCase := range map[string]struct {
+		forwarded []string
+		baggage   string
+		identity  string
+	}{
+		"forwarded duplicate": {forwarded: []string{"X-Correlation-ID", "x-correlation-id"}},
+		"baggage collision":   {forwarded: []string{"X-Correlation-ID"}, baggage: "x-correlation-id"},
+		"identity collision":  {forwarded: []string{"X-Correlation-ID"}, identity: "x-correlation-id"},
+		"baggage identity":    {baggage: "X-Metadata", identity: "x-metadata"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := auth.ValidateForwardingHeaderConfiguration(testCase.forwarded, testCase.baggage, testCase.identity)
+			assert.ErrorIs(t, err, auth.ErrInvalidForwardedHeader)
+		})
+	}
 }
 
 func ptr(s string) *string { return &s }

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -370,6 +370,17 @@ func (s *Service) UpsertExternalAPIKey(ctx context.Context, installationID strin
 	if err != nil {
 		return nil, err
 	}
+	baggageName := ""
+	if baggageHeader != nil {
+		baggageName = *baggageHeader
+	}
+	identityName := ""
+	if identityHeader != nil {
+		identityName = *identityHeader
+	}
+	if err := ValidateForwardingHeaderConfiguration(forwardedHeaders, baggageName, identityName); err != nil {
+		return nil, err
+	}
 	authType, authAccount, authUser, err := NormalizeAuthType(params.AuthType, params.AuthAccount, params.AuthUser)
 	if err != nil {
 		return nil, err

--- a/internal/providers/anthropic/client.go
+++ b/internal/providers/anthropic/client.go
@@ -46,8 +46,15 @@ func WithAuthScheme(scheme AuthScheme) Option {
 }
 
 // WithModelListHTTPClient supplies the client used only for model discovery.
+// A nil client is ignored so a misconfigured option cannot strip the
+// constructor's destination-checked default and panic on the first call.
 func WithModelListHTTPClient(client *http.Client) Option {
-	return func(c *Client) { c.modelHTTP = client }
+	return func(c *Client) {
+		if client == nil {
+			return
+		}
+		c.modelHTTP = client
+	}
 }
 
 // WithDefaultHeaders returns c with headers set on every upstream request.

--- a/internal/providers/anthropic/client.go
+++ b/internal/providers/anthropic/client.go
@@ -45,6 +45,11 @@ func WithAuthScheme(scheme AuthScheme) Option {
 	return func(c *Client) { c.authScheme = scheme }
 }
 
+// WithModelListHTTPClient supplies the client used only for model discovery.
+func WithModelListHTTPClient(client *http.Client) Option {
+	return func(c *Client) { c.modelHTTP = client }
+}
+
 // WithDefaultHeaders returns c with headers set on every upstream request.
 // Prepared and inbound per-request headers can override these values.
 func (c *Client) WithDefaultHeaders(h http.Header) *Client {
@@ -85,9 +90,10 @@ func rewriteModelField(body []byte, modelIDMap map[string]string) []byte {
 }
 
 type Client struct {
-	apiKey  string
-	baseURL string
-	http    *http.Client
+	apiKey    string
+	baseURL   string
+	http      *http.Client
+	modelHTTP *http.Client
 	// authScheme is the credential header this upstream expects; zero value
 	// (AuthAPIKeyHeader) preserves Anthropic's own behavior.
 	authScheme AuthScheme
@@ -118,9 +124,10 @@ type Client struct {
 
 func NewClient(apiKey, baseURL string, opts ...Option) *Client {
 	c := &Client{
-		apiKey:  apiKey,
-		baseURL: baseURL,
-		http:    httputil.NewClient(httputil.NewTransport(10*time.Second, 10*time.Second)),
+		apiKey:    apiKey,
+		baseURL:   baseURL,
+		http:      httputil.NewClient(httputil.NewTransport(10*time.Second, 10*time.Second)),
+		modelHTTP: httputil.NewDefaultModelDiscoveryClient(),
 	}
 	for _, opt := range opts {
 		opt(c)

--- a/internal/providers/anthropic/list_models.go
+++ b/internal/providers/anthropic/list_models.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"sort"
 
 	"github.com/tidwall/gjson"
+	"weave-os/router/internal/auth"
 	"weave-os/router/internal/providers"
 	"weave-os/router/internal/requestcontext"
 )
@@ -34,28 +34,46 @@ const maxModelListPages = 20
 func (c *Client) ListModels(ctx context.Context) ([]string, error) {
 	baseURL := requestcontext.EffectiveBaseURL(ctx, c.baseURL)
 	if baseURL == "" {
-		return nil, errors.New("no base URL configured for model listing")
+		return nil, providers.ErrModelDiscoveryDestination
 	}
+	normalizedBaseURL, err := auth.NormalizeBaseURL(&baseURL)
+	if err != nil || normalizedBaseURL == nil {
+		return nil, providers.ErrModelDiscoveryDestination
+	}
+	baseURL = *normalizedBaseURL
 	seen := make(map[string]struct{})
 	var ids []string
 	afterID := ""
 	for page := 0; page < maxModelListPages; page++ {
-		listURL := baseURL + "/v1/models?limit=1000"
-		if afterID != "" {
-			listURL += "&after_id=" + url.QueryEscape(afterID)
-		}
-		upstream, err := http.NewRequestWithContext(ctx, http.MethodGet, listURL, nil)
+		listURL, err := url.JoinPath(baseURL, "v1", "models")
 		if err != nil {
-			return nil, fmt.Errorf("build model-list request: %w", err)
+			return nil, providers.ErrModelDiscoveryDestination
+		}
+		parsedListURL, err := url.Parse(listURL)
+		if err != nil {
+			return nil, providers.ErrModelDiscoveryDestination
+		}
+		query := parsedListURL.Query()
+		query.Set("limit", "1000")
+		if afterID != "" {
+			query.Set("after_id", afterID)
+		}
+		parsedListURL.RawQuery = query.Encode()
+		upstream, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedListURL.String(), nil)
+		if err != nil {
+			return nil, providers.ErrModelDiscoveryDestination
 		}
 		upstream.Header.Set("anthropic-version", anthropicVersion)
 		c.setAuth(ctx, upstream, upstream)
 		requestcontext.ApplyWIFTokenType(ctx, upstream)
 		requestcontext.ApplyIdentityHeader(ctx, upstream)
 
-		resp, err := c.http.Do(upstream)
+		resp, err := c.modelHTTP.Do(upstream)
 		if err != nil {
-			return nil, fmt.Errorf("model-list call: %w", err)
+			if errors.Is(err, providers.ErrModelDiscoveryDestination) {
+				return nil, providers.ErrModelDiscoveryDestination
+			}
+			return nil, providers.ErrModelDiscoveryTransport
 		}
 		body, err := io.ReadAll(io.LimitReader(resp.Body, maxModelListBytes))
 		resp.Body.Close()
@@ -63,10 +81,10 @@ func (c *Client) ListModels(ctx context.Context) ([]string, error) {
 			return c.listGatewayModels(ctx, baseURL)
 		}
 		if resp.StatusCode >= 400 {
-			return nil, providers.ModelListStatusError(resp.StatusCode, body)
+			return nil, providers.NewModelListStatusError(resp.StatusCode)
 		}
 		if err != nil {
-			return nil, fmt.Errorf("read model-list response: %w", err)
+			return nil, providers.ErrModelDiscoveryTransport
 		}
 		pageIDs, err := providers.ParseModelIDs(body)
 		if err != nil {
@@ -106,9 +124,13 @@ func (c *Client) getGatewayModels(ctx context.Context, baseURL string, withEntit
 	if withEntity {
 		entity = bytes.NewReader(providers.EmptyJSONEntity)
 	}
-	upstream, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/models", entity)
+	listURL, err := url.JoinPath(baseURL, "models")
 	if err != nil {
-		return nil, 0, fmt.Errorf("build model-list request: %w", err)
+		return nil, 0, providers.ErrModelDiscoveryDestination
+	}
+	upstream, err := http.NewRequestWithContext(ctx, http.MethodGet, listURL, entity)
+	if err != nil {
+		return nil, 0, providers.ErrModelDiscoveryDestination
 	}
 	if withEntity {
 		upstream.Header.Set("Content-Type", "application/json")
@@ -119,17 +141,20 @@ func (c *Client) getGatewayModels(ctx context.Context, baseURL string, withEntit
 	requestcontext.ApplyWIFTokenType(ctx, upstream)
 	requestcontext.ApplyIdentityHeader(ctx, upstream)
 
-	resp, err := c.http.Do(upstream)
+	resp, err := c.modelHTTP.Do(upstream)
 	if err != nil {
-		return nil, 0, fmt.Errorf("model-list call: %w", err)
+		if errors.Is(err, providers.ErrModelDiscoveryDestination) {
+			return nil, 0, providers.ErrModelDiscoveryDestination
+		}
+		return nil, 0, providers.ErrModelDiscoveryTransport
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxModelListBytes))
 	if resp.StatusCode >= 400 {
-		return nil, resp.StatusCode, providers.ModelListStatusError(resp.StatusCode, body)
+		return nil, resp.StatusCode, providers.NewModelListStatusError(resp.StatusCode)
 	}
 	if err != nil {
-		return nil, resp.StatusCode, fmt.Errorf("read model-list response: %w", err)
+		return nil, resp.StatusCode, providers.ErrModelDiscoveryTransport
 	}
 	ids, err := providers.ParseModelIDs(body)
 	return ids, resp.StatusCode, err

--- a/internal/providers/anthropic/list_models_test.go
+++ b/internal/providers/anthropic/list_models_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"weave-os/router/internal/providers"
 	"weave-os/router/internal/providers/anthropic"
 	"weave-os/router/internal/providers/httputil"
 	"weave-os/router/internal/requestcontext"
@@ -140,4 +141,21 @@ func TestListModels_RetriesGatewayCatalogWithEntity(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"claude-4-sonnet"}, models)
 	assert.Equal(t, []string{"", "{}"}, attempts)
+}
+
+// A nil option value must not strip the constructor's destination-checked
+// discovery client, which would turn a misconfigured call site into a panic
+// on the first model-list request.
+func TestListModels_NilModelListClientKeepsTheCheckedDefault(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"id":"claude-haiku-4-5"}]}`))
+	}))
+	defer srv.Close()
+
+	c := anthropic.NewClient("tok", srv.URL, anthropic.WithModelListHTTPClient(nil))
+
+	// The retained default refuses this loopback destination rather than panicking.
+	_, err := c.ListModels(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, providers.ErrModelDiscoveryDestination)
 }

--- a/internal/providers/anthropic/list_models_test.go
+++ b/internal/providers/anthropic/list_models_test.go
@@ -8,11 +8,19 @@ import (
 	"testing"
 
 	"weave-os/router/internal/providers/anthropic"
+	"weave-os/router/internal/providers/httputil"
 	"weave-os/router/internal/requestcontext"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func anthropicDiscoveryClient(t *testing.T, origin string) *http.Client {
+	t.Helper()
+	client, err := httputil.NewModelDiscoveryClient(origin)
+	require.NoError(t, err)
+	return client
+}
 
 func TestListModels_GatewayBearerAuth(t *testing.T) {
 	var gotPath, gotAuth, gotVersion string
@@ -24,7 +32,7 @@ func TestListModels_GatewayBearerAuth(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := anthropic.NewClient("gw-token", srv.URL, anthropic.WithAuthScheme(anthropic.AuthBearer))
+	c := anthropic.NewClient("gw-token", srv.URL, anthropic.WithAuthScheme(anthropic.AuthBearer), anthropic.WithModelListHTTPClient(anthropicDiscoveryClient(t, srv.URL)))
 	models, err := c.ListModels(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, []string{"claude-fable-5", "claude-haiku-4-5"}, models)
@@ -41,7 +49,7 @@ func TestListModels_BYOKCredentialsOverrideBaseURL(t *testing.T) {
 	}))
 	defer byokSrv.Close()
 
-	c := anthropic.NewClient("", "", anthropic.WithAuthScheme(anthropic.AuthBearer))
+	c := anthropic.NewClient("", "", anthropic.WithAuthScheme(anthropic.AuthBearer), anthropic.WithModelListHTTPClient(anthropicDiscoveryClient(t, byokSrv.URL)))
 	ctx := context.WithValue(context.Background(), requestcontext.CredentialsContextKey{}, &requestcontext.Credentials{
 		APIKey:  []byte("byok-token"),
 		BaseURL: byokSrv.URL,
@@ -68,7 +76,7 @@ func TestListModels_WalksAllPages(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := anthropic.NewClient("tok", srv.URL, anthropic.WithAuthScheme(anthropic.AuthBearer))
+	c := anthropic.NewClient("tok", srv.URL, anthropic.WithAuthScheme(anthropic.AuthBearer), anthropic.WithModelListHTTPClient(anthropicDiscoveryClient(t, srv.URL)))
 	models, err := c.ListModels(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, []string{"claude-a", "claude-b", "claude-c"}, models)
@@ -81,7 +89,7 @@ func TestListModels_UpstreamErrorStatus(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := anthropic.NewClient("tok", srv.URL, anthropic.WithAuthScheme(anthropic.AuthBearer))
+	c := anthropic.NewClient("tok", srv.URL, anthropic.WithAuthScheme(anthropic.AuthBearer), anthropic.WithModelListHTTPClient(anthropicDiscoveryClient(t, srv.URL)))
 	_, err := c.ListModels(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "403")
@@ -101,7 +109,7 @@ func TestListModels_FallsBackToGatewayCatalogOn404(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := anthropic.NewClient("gw-token", srv.URL, anthropic.WithAuthScheme(anthropic.AuthBearer))
+	c := anthropic.NewClient("gw-token", srv.URL, anthropic.WithAuthScheme(anthropic.AuthBearer), anthropic.WithModelListHTTPClient(anthropicDiscoveryClient(t, srv.URL)))
 	models, err := c.ListModels(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, []string{"claude-haiku-4-5", "claude-opus-5"}, models)
@@ -127,7 +135,7 @@ func TestListModels_RetriesGatewayCatalogWithEntity(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := anthropic.NewClient("gw-token", srv.URL, anthropic.WithAuthScheme(anthropic.AuthBearer))
+	c := anthropic.NewClient("gw-token", srv.URL, anthropic.WithAuthScheme(anthropic.AuthBearer), anthropic.WithModelListHTTPClient(anthropicDiscoveryClient(t, srv.URL)))
 	models, err := c.ListModels(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, []string{"claude-4-sonnet"}, models)

--- a/internal/providers/anthropic/redirect_test.go
+++ b/internal/providers/anthropic/redirect_test.go
@@ -49,15 +49,22 @@ func TestProxy_RefusedRedirectFailsRetryablyWithoutTouchingWriter(t *testing.T) 
 // TestListModels_RedirectRefused: a redirecting /v1/models must fail loud
 // instead of feeding redirect boilerplate to the roster parser.
 func TestListModels_RedirectRefused(t *testing.T) {
+	var targetHit atomic.Bool
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		targetHit.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, "https://unconfigured.example"+r.URL.Path, http.StatusMovedPermanently)
+		http.Redirect(w, r, target.URL+r.URL.Path, http.StatusMovedPermanently)
 	}))
 	defer upstream.Close()
 
-	c := anthropic.NewClient("deployment-key", upstream.URL)
+	c := anthropic.NewClient("deployment-key", upstream.URL, anthropic.WithModelListHTTPClient(anthropicDiscoveryClient(t, upstream.URL)))
 	ids, err := c.ListModels(context.Background())
 
 	require.Error(t, err)
-	assert.ErrorIs(t, err, httputil.ErrRefusedRedirect)
+	assert.ErrorIs(t, err, providers.ErrModelDiscoveryTransport)
 	assert.Empty(t, ids)
+	assert.False(t, targetHit.Load(), "the redirect target must never be contacted")
 }

--- a/internal/providers/httputil/egress.go
+++ b/internal/providers/httputil/egress.go
@@ -1,18 +1,193 @@
 package httputil
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
+
+	"weave-os/router/internal/providers"
 )
 
 // ErrRestrictedDestination is the dial error when an upstream resolves outside
 // the public internet on a transport built for public destinations only.
 var ErrRestrictedDestination = errors.New("upstream destination is not publicly routable")
+
+const modelDiscoveryPrivateOriginsEnv = "ROUTER_MODEL_DISCOVERY_PRIVATE_ORIGINS"
+
+type modelDiscoveryResolver interface {
+	LookupNetIP(ctx context.Context, network, host string) ([]netip.Addr, error)
+}
+
+type modelDiscoveryPolicy struct {
+	privateOrigins map[string]struct{}
+	resolver       modelDiscoveryResolver
+	dialContext    func(context.Context, string, string) (net.Conn, error)
+}
+
+type modelDiscoveryPrivateOriginKey struct{}
+
+// ModelDiscoveryOption injects deterministic network dependencies for tests.
+type ModelDiscoveryOption func(*modelDiscoveryPolicy)
+
+// WithModelDiscoveryResolver replaces DNS resolution for a model-discovery client.
+func WithModelDiscoveryResolver(resolver modelDiscoveryResolver) ModelDiscoveryOption {
+	return func(policy *modelDiscoveryPolicy) { policy.resolver = resolver }
+}
+
+// WithModelDiscoveryDialer replaces direct IP dialing for a model-discovery client.
+func WithModelDiscoveryDialer(dialContext func(context.Context, string, string) (net.Conn, error)) ModelDiscoveryOption {
+	return func(policy *modelDiscoveryPolicy) { policy.dialContext = dialContext }
+}
+
+// NewDefaultModelDiscoveryClient returns a public-destination-only client.
+func NewDefaultModelDiscoveryClient() *http.Client {
+	client, err := NewModelDiscoveryClient("")
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
+// NewModelDiscoveryClient returns a proxy-free client that validates every
+// resolved address and dials one of those validated IPs directly.
+func NewModelDiscoveryClient(privateOrigins string, opts ...ModelDiscoveryOption) (*http.Client, error) {
+	allowedOrigins, err := parseModelDiscoveryPrivateOrigins(privateOrigins)
+	if err != nil {
+		return nil, err
+	}
+	dialer := &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}
+	policy := &modelDiscoveryPolicy{
+		privateOrigins: allowedOrigins,
+		resolver:       net.DefaultResolver,
+		dialContext:    dialer.DialContext,
+	}
+	for _, opt := range opts {
+		opt(policy)
+	}
+	transport := newTransport(10*time.Second, 10*time.Second, DefaultResponseHeaderTimeout, true)
+	transport.DialContext = policy.dial
+	transport.Proxy = nil
+	return NewClient(&modelDiscoveryRoundTripper{transport: transport, privateOrigins: allowedOrigins}), nil
+}
+
+type modelDiscoveryRoundTripper struct {
+	transport      http.RoundTripper
+	privateOrigins map[string]struct{}
+}
+
+func (t *modelDiscoveryRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	origin, err := canonicalDiscoveryOrigin(request.URL)
+	if err != nil {
+		return nil, providers.ErrModelDiscoveryDestination
+	}
+	_, privateAllowed := t.privateOrigins[origin]
+	ctx := context.WithValue(request.Context(), modelDiscoveryPrivateOriginKey{}, privateAllowed)
+	return t.transport.RoundTrip(request.Clone(ctx))
+}
+
+func (p *modelDiscoveryPolicy) dial(ctx context.Context, network, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, providers.ErrModelDiscoveryDestination
+	}
+	addresses, err := p.resolve(ctx, host)
+	if err != nil || len(addresses) == 0 {
+		return nil, providers.ErrModelDiscoveryTransport
+	}
+	privateAllowed, _ := ctx.Value(modelDiscoveryPrivateOriginKey{}).(bool)
+	for _, address := range addresses {
+		if !privateAllowed && !isPublicAddr(address) {
+			return nil, providers.ErrModelDiscoveryDestination
+		}
+	}
+	for _, address := range addresses {
+		connection, dialErr := p.dialContext(ctx, network, net.JoinHostPort(address.Unmap().String(), port))
+		if dialErr == nil {
+			return connection, nil
+		}
+	}
+	return nil, providers.ErrModelDiscoveryTransport
+}
+
+func (p *modelDiscoveryPolicy) resolve(ctx context.Context, host string) ([]netip.Addr, error) {
+	if address, err := netip.ParseAddr(host); err == nil {
+		return []netip.Addr{address}, nil
+	}
+	return p.resolver.LookupNetIP(ctx, "ip", host)
+}
+
+func isPublicAddr(address netip.Addr) bool {
+	address = address.Unmap()
+	if !address.IsValid() || address.IsLoopback() || address.IsPrivate() || address.IsLinkLocalUnicast() ||
+		address.IsLinkLocalMulticast() || address.IsMulticast() || address.IsUnspecified() {
+		return false
+	}
+	if address.Is4() {
+		bytes := address.As4()
+		if bytes[0] == 0 || (bytes[0] == 100 && bytes[1] >= 64 && bytes[1] <= 127) {
+			return false
+		}
+	}
+	return true
+}
+
+func parseModelDiscoveryPrivateOrigins(raw string) (map[string]struct{}, error) {
+	origins := make(map[string]struct{})
+	for _, configuredOrigin := range strings.Split(raw, ",") {
+		configuredOrigin = strings.TrimSpace(configuredOrigin)
+		if configuredOrigin == "" {
+			continue
+		}
+		parsed, err := url.Parse(configuredOrigin)
+		if err != nil || strings.ContainsAny(configuredOrigin, "?#") || parsed.Path != "" || parsed.RawPath != "" {
+			return nil, fmt.Errorf("invalid %s entry", modelDiscoveryPrivateOriginsEnv)
+		}
+		origin, err := canonicalDiscoveryOrigin(parsed)
+		if err != nil {
+			return nil, fmt.Errorf("invalid %s entry", modelDiscoveryPrivateOriginsEnv)
+		}
+		origins[origin] = struct{}{}
+	}
+	return origins, nil
+}
+
+func canonicalDiscoveryOrigin(parsed *url.URL) (string, error) {
+	scheme := strings.ToLower(parsed.Scheme)
+	if (scheme != "http" && scheme != "https") || parsed.Host == "" || parsed.Hostname() == "" ||
+		parsed.User != nil || parsed.Opaque != "" || parsed.Fragment != "" {
+		return "", providers.ErrModelDiscoveryDestination
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if strings.ContainsAny(host, "%*") {
+		return "", providers.ErrModelDiscoveryDestination
+	}
+	port := parsed.Port()
+	if strings.HasSuffix(parsed.Host, ":") {
+		return "", providers.ErrModelDiscoveryDestination
+	}
+	if port == "" {
+		if scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	} else {
+		portNumber, conversionErr := strconv.Atoi(port)
+		if conversionErr != nil || portNumber < 1 || portNumber > 65535 {
+			return "", providers.ErrModelDiscoveryDestination
+		}
+	}
+	return scheme + "://" + net.JoinHostPort(host, port), nil
+}
 
 // restrictUpstreamEgressEnv forces the public-destination dial policy on or
 // off regardless of deployment mode.

--- a/internal/providers/httputil/egress.go
+++ b/internal/providers/httputil/egress.go
@@ -133,7 +133,12 @@ func isPublicAddr(address netip.Addr) bool {
 	}
 	if address.Is4() {
 		bytes := address.As4()
-		if bytes[0] == 0 || (bytes[0] == 100 && bytes[1] >= 64 && bytes[1] <= 127) {
+		// None of these have a stdlib predicate: 0.0.0.0/8 is "this host on
+		// this network" (RFC 1122) and resolves to a local service on Linux,
+		// 100.64.0.0/10 is carrier-grade NAT (RFC 6598), and 240.0.0.0/4 is
+		// reserved (RFC 1112) — which also covers the 255.255.255.255
+		// broadcast address.
+		if bytes[0] == 0 || (bytes[0] == 100 && bytes[1] >= 64 && bytes[1] <= 127) || bytes[0] >= 240 {
 			return false
 		}
 	}
@@ -222,24 +227,11 @@ func restrictDestination(_, address string, _ syscall.RawConn) error {
 }
 
 func isPublicIP(ip net.IP) bool {
-	switch {
-	case ip.IsLoopback(),
-		ip.IsPrivate(),
-		ip.IsLinkLocalUnicast(),
-		ip.IsLinkLocalMulticast(),
-		ip.IsMulticast(),
-		ip.IsUnspecified():
+	// One destination policy for both dial paths: a range rejected for model
+	// discovery must not be reachable through the inference transport either.
+	address, ok := netip.AddrFromSlice(ip)
+	if !ok {
 		return false
 	}
-	ip4 := ip.To4()
-	if ip4 == nil {
-		return true
-	}
-	// Neither range has a stdlib predicate: 0.0.0.0/8 is "this host on this
-	// network" (RFC 1122) and resolves to a local service on Linux, and
-	// 100.64.0.0/10 is carrier-grade NAT (RFC 6598).
-	if ip4[0] == 0 {
-		return false
-	}
-	return !(ip4[0] == 100 && ip4[1] >= 64 && ip4[1] <= 127)
+	return isPublicAddr(address)
 }

--- a/internal/providers/httputil/egress_test.go
+++ b/internal/providers/httputil/egress_test.go
@@ -62,6 +62,8 @@ func TestRestrictDestinationClassifiesAddresses(t *testing.T) {
 		{"[fe80::1]:443", false},
 		{"0.0.0.0:443", false},
 		{"224.0.0.1:443", false},
+		{"240.0.0.1:443", false},
+		{"255.255.255.255:443", false},
 	} {
 		err := restrictDestination("tcp", tc.address, nil)
 		if tc.allowed {
@@ -124,6 +126,9 @@ func TestModelDiscoveryAddressClassification(t *testing.T) {
 		{address: "ff02::1"},
 		{address: "::ffff:127.0.0.1"},
 		{address: "::ffff:169.254.169.254"},
+		{address: "240.0.0.1"},
+		{address: "255.255.255.255"},
+		{address: "::ffff:240.0.0.1"},
 	} {
 		address := netip.MustParseAddr(testCase.address)
 		assert.Equal(t, testCase.public, isPublicAddr(address), testCase.address)
@@ -285,7 +290,9 @@ func TestModelDiscoveryIgnoresAmbientProxyConfiguration(t *testing.T) {
 	t.Setenv("HTTP_PROXY", proxyServer.URL)
 	t.Setenv("HTTPS_PROXY", proxyServer.URL)
 	t.Setenv("NO_PROXY", "")
-	t.Setenv(restrictUpstreamEgressEnv, "false")
+	// No egress-mode override here on purpose: NewModelDiscoveryClient sets
+	// transport.Proxy = nil unconditionally, so discovery ignores an ambient
+	// proxy in every deployment mode.
 
 	sink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/providers/httputil/egress_test.go
+++ b/internal/providers/httputil/egress_test.go
@@ -1,14 +1,28 @@
 package httputil
 
 import (
+	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
+	"net/url"
+	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"weave-os/router/internal/providers"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type modelDiscoveryResolverFunc func(context.Context, string, string) ([]netip.Addr, error)
+
+func (f modelDiscoveryResolverFunc) LookupNetIP(ctx context.Context, network, host string) ([]netip.Addr, error) {
+	return f(ctx, network, host)
+}
 
 func TestRestrictedTransportRefusesANonPublicDestination(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -85,4 +99,258 @@ func TestRestrictedTransportIgnoresAnEnvironmentProxy(t *testing.T) {
 
 	unrestricted := newTransport(time.Second, time.Second, time.Second, false)
 	assert.NotNil(t, unrestricted.Proxy, "an unrestricted transport still honors the environment proxy")
+}
+
+func TestModelDiscoveryAddressClassification(t *testing.T) {
+	for _, testCase := range []struct {
+		address string
+		public  bool
+	}{
+		{address: "8.8.8.8", public: true},
+		{address: "2606:4700:4700::1111", public: true},
+		{address: "127.0.0.1"},
+		{address: "10.1.2.3"},
+		{address: "172.16.0.1"},
+		{address: "192.168.1.1"},
+		{address: "169.254.169.254"},
+		{address: "224.0.0.1"},
+		{address: "0.0.0.0"},
+		{address: "0.1.2.3"},
+		{address: "100.64.0.1"},
+		{address: "::"},
+		{address: "::1"},
+		{address: "fd00::1"},
+		{address: "fe80::1"},
+		{address: "ff02::1"},
+		{address: "::ffff:127.0.0.1"},
+		{address: "::ffff:169.254.169.254"},
+	} {
+		address := netip.MustParseAddr(testCase.address)
+		assert.Equal(t, testCase.public, isPublicAddr(address), testCase.address)
+	}
+}
+
+func TestModelDiscoveryRejectsRestrictedAndMixedDNSAnswersBeforeDial(t *testing.T) {
+	var sinkRequests atomic.Int32
+	sink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		sinkRequests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer sink.Close()
+	target := mustServerAddress(t, sink.URL)
+
+	for name, addresses := range map[string][]netip.Addr{
+		"loopback":          {netip.MustParseAddr("127.0.0.1")},
+		"private":           {netip.MustParseAddr("10.1.2.3")},
+		"link local":        {netip.MustParseAddr("169.254.169.254")},
+		"multicast":         {netip.MustParseAddr("224.0.0.1")},
+		"unspecified":       {netip.MustParseAddr("0.0.0.0")},
+		"zero network":      {netip.MustParseAddr("0.1.2.3")},
+		"carrier grade NAT": {netip.MustParseAddr("100.64.0.1")},
+		"mapped loopback":   {netip.MustParseAddr("::ffff:127.0.0.1")},
+		"mixed answers":     {netip.MustParseAddr("203.0.113.10"), netip.MustParseAddr("127.0.0.1")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var dialCalls atomic.Int32
+			client, err := NewModelDiscoveryClient("",
+				WithModelDiscoveryResolver(modelDiscoveryResolverFunc(func(context.Context, string, string) ([]netip.Addr, error) {
+					return addresses, nil
+				})),
+				WithModelDiscoveryDialer(func(ctx context.Context, network, _ string) (net.Conn, error) {
+					dialCalls.Add(1)
+					return (&net.Dialer{}).DialContext(ctx, network, target)
+				}),
+			)
+			require.NoError(t, err)
+
+			response, requestErr := client.Get("http://models.example:" + serverPort(t, target) + "/models")
+			if response != nil {
+				response.Body.Close()
+			}
+			require.Error(t, requestErr)
+			assert.ErrorIs(t, requestErr, providers.ErrModelDiscoveryDestination)
+			assert.Zero(t, dialCalls.Load(), "a rejected answer must not reach the dialer")
+			assert.Zero(t, sinkRequests.Load(), "a rejected answer must not reach the controlled sink")
+		})
+	}
+}
+
+func TestModelDiscoveryDialsValidatedAddressWithoutChangingTheRequestOrigin(t *testing.T) {
+	var receivedHost string
+	sink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		receivedHost = request.Host
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer sink.Close()
+	target := mustServerAddress(t, sink.URL)
+	port := serverPort(t, target)
+	client, err := NewModelDiscoveryClient("",
+		WithModelDiscoveryResolver(modelDiscoveryResolverFunc(func(_ context.Context, _, host string) ([]netip.Addr, error) {
+			assert.Equal(t, "models.example", host)
+			return []netip.Addr{netip.MustParseAddr("203.0.113.10")}, nil
+		})),
+		WithModelDiscoveryDialer(func(ctx context.Context, network, address string) (net.Conn, error) {
+			assert.Equal(t, net.JoinHostPort("203.0.113.10", port), address)
+			return (&net.Dialer{}).DialContext(ctx, network, target)
+		}),
+	)
+	require.NoError(t, err)
+
+	response, err := client.Get("http://models.example:" + port + "/models")
+	require.NoError(t, err)
+	response.Body.Close()
+	assert.Equal(t, "models.example:"+port, receivedHost)
+}
+
+func TestModelDiscoveryPrivateOriginExceptionIsExact(t *testing.T) {
+	sink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer sink.Close()
+	target := mustServerAddress(t, sink.URL)
+	port := serverPort(t, target)
+	origin := "http://models.internal:" + port
+	var dialCalls atomic.Int32
+	client, err := NewModelDiscoveryClient(origin,
+		WithModelDiscoveryResolver(modelDiscoveryResolverFunc(func(context.Context, string, string) ([]netip.Addr, error) {
+			return []netip.Addr{netip.MustParseAddr("127.0.0.1")}, nil
+		})),
+		WithModelDiscoveryDialer(func(ctx context.Context, network, _ string) (net.Conn, error) {
+			dialCalls.Add(1)
+			return (&net.Dialer{}).DialContext(ctx, network, target)
+		}),
+	)
+	require.NoError(t, err)
+
+	response, err := client.Get(origin + "/gateway/models?limit=1000")
+	require.NoError(t, err)
+	response.Body.Close()
+	assert.Equal(t, int32(1), dialCalls.Load())
+
+	otherPort := strconv.Itoa(mustPortNumber(t, port) + 1)
+	response, err = client.Get("http://models.internal:" + otherPort + "/models")
+	if response != nil {
+		response.Body.Close()
+	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, providers.ErrModelDiscoveryDestination)
+	assert.Equal(t, int32(1), dialCalls.Load(), "a different origin must not inherit the exception")
+}
+
+func TestModelDiscoveryRevalidatesDNSOnEachNewConnection(t *testing.T) {
+	var sinkRequests atomic.Int32
+	sink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		sinkRequests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer sink.Close()
+	target := mustServerAddress(t, sink.URL)
+	var lookups atomic.Int32
+	client, err := NewModelDiscoveryClient("",
+		WithModelDiscoveryResolver(modelDiscoveryResolverFunc(func(context.Context, string, string) ([]netip.Addr, error) {
+			if lookups.Add(1) == 1 {
+				return []netip.Addr{netip.MustParseAddr("203.0.113.10")}, nil
+			}
+			return []netip.Addr{netip.MustParseAddr("127.0.0.1")}, nil
+		})),
+		WithModelDiscoveryDialer(func(ctx context.Context, network, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, network, target)
+		}),
+	)
+	require.NoError(t, err)
+	requestURL := "http://models.example:" + serverPort(t, target) + "/models"
+
+	firstRequest, err := http.NewRequest(http.MethodGet, requestURL, nil)
+	require.NoError(t, err)
+	firstRequest.Close = true
+	response, err := client.Do(firstRequest)
+	require.NoError(t, err)
+	response.Body.Close()
+	response, err = client.Get(requestURL)
+	if response != nil {
+		response.Body.Close()
+	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, providers.ErrModelDiscoveryDestination)
+	assert.Equal(t, int32(1), sinkRequests.Load())
+}
+
+func TestModelDiscoveryIgnoresAmbientProxyConfiguration(t *testing.T) {
+	var proxyRequests atomic.Int32
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		proxyRequests.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer proxyServer.Close()
+	t.Setenv("HTTP_PROXY", proxyServer.URL)
+	t.Setenv("HTTPS_PROXY", proxyServer.URL)
+	t.Setenv("NO_PROXY", "")
+	t.Setenv(restrictUpstreamEgressEnv, "false")
+
+	sink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer sink.Close()
+	target := mustServerAddress(t, sink.URL)
+	client, err := NewModelDiscoveryClient("",
+		WithModelDiscoveryResolver(modelDiscoveryResolverFunc(func(context.Context, string, string) ([]netip.Addr, error) {
+			return []netip.Addr{netip.MustParseAddr("203.0.113.10")}, nil
+		})),
+		WithModelDiscoveryDialer(func(ctx context.Context, network, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, network, target)
+		}),
+	)
+	require.NoError(t, err)
+
+	response, err := client.Get("http://models.example:" + serverPort(t, target) + "/models")
+	require.NoError(t, err)
+	response.Body.Close()
+	assert.Zero(t, proxyRequests.Load())
+}
+
+func TestModelDiscoveryPrivateOriginConfigurationValidation(t *testing.T) {
+	for name, configured := range map[string]string{
+		"path":              "https://gateway.internal/models",
+		"query":             "https://gateway.internal?mode=list",
+		"fragment":          "https://gateway.internal#models",
+		"wildcard":          "https://*.internal",
+		"CIDR":              "https://10.0.0.0/8",
+		"userinfo":          "https://user@gateway.internal",
+		"empty port":        "https://gateway.internal:",
+		"zero port":         "https://gateway.internal:0",
+		"out of range port": "https://gateway.internal:65536",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewModelDiscoveryClient(configured)
+			assert.Error(t, err)
+			assert.NotContains(t, err.Error(), configured)
+		})
+	}
+
+	httpsURL, err := url.Parse("https://gateway.internal/path")
+	require.NoError(t, err)
+	origin, err := canonicalDiscoveryOrigin(httpsURL)
+	require.NoError(t, err)
+	assert.Equal(t, "https://gateway.internal:443", origin)
+}
+
+func mustServerAddress(t *testing.T, rawURL string) string {
+	t.Helper()
+	parsed, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	return parsed.Host
+}
+
+func serverPort(t *testing.T, address string) string {
+	t.Helper()
+	_, port, err := net.SplitHostPort(address)
+	require.NoError(t, err)
+	return port
+}
+
+func mustPortNumber(t *testing.T, port string) int {
+	t.Helper()
+	portNumber, err := strconv.Atoi(port)
+	require.NoError(t, err)
+	return portNumber
 }

--- a/internal/providers/model_list_parse.go
+++ b/internal/providers/model_list_parse.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/tidwall/gjson"
 )
@@ -13,30 +12,28 @@ import (
 // the OpenAI/Anthropic list shape nor a gateway's bare model array.
 var ErrUnknownModelListShape = errors.New("model listing response has no recognizable model list")
 
-// maxModelListErrorBytes caps how much of a rejected model-list body is quoted
-// back in the error.
-const maxModelListErrorBytes = 400
+// ModelListFailureCategory is the non-sensitive class of a model-list failure.
+type ModelListFailureCategory string
 
-// ModelListStatusError describes a rejected model-list response, quoting a
-// truncated, single-line excerpt of the upstream body. Gateways explain
-// themselves there (Snowflake Cortex answers 400 with a JSON "message"), and
-// without it a status code alone is undiagnosable in production.
-func ModelListStatusError(status int, body []byte) error {
-	detail := gjson.GetBytes(body, "message").String()
-	if detail == "" {
-		detail = gjson.GetBytes(body, "error.message").String()
-	}
-	if detail == "" {
-		detail = string(body)
-	}
-	detail = strings.TrimSpace(strings.Join(strings.Fields(detail), " "))
-	if len(detail) > maxModelListErrorBytes {
-		detail = detail[:maxModelListErrorBytes] + "…"
-	}
-	if detail == "" {
-		return fmt.Errorf("model listing returned status %d", status)
-	}
-	return fmt.Errorf("model listing returned status %d: %s", status, detail)
+const (
+	// ModelListFailureUpstreamStatus means the endpoint rejected the request.
+	ModelListFailureUpstreamStatus ModelListFailureCategory = "upstream_status"
+)
+
+// ModelListHTTPStatusError describes an upstream rejection without retaining
+// response content that may contain credentials or private endpoint details.
+type ModelListHTTPStatusError struct {
+	Status   int
+	Category ModelListFailureCategory
+}
+
+func (e *ModelListHTTPStatusError) Error() string {
+	return fmt.Sprintf("model listing failed with status %d (%s)", e.Status, e.Category)
+}
+
+// NewModelListStatusError returns a safe typed upstream-status failure.
+func NewModelListStatusError(status int) error {
+	return &ModelListHTTPStatusError{Status: status, Category: ModelListFailureUpstreamStatus}
 }
 
 // ParseModelIDs extracts sorted, deduplicated model IDs from a model-list body.

--- a/internal/providers/model_list_parse_test.go
+++ b/internal/providers/model_list_parse_test.go
@@ -29,10 +29,13 @@ func TestParseModelIDs_RejectsUnknownShape(t *testing.T) {
 	assert.ErrorIs(t, err, providers.ErrUnknownModelListShape)
 }
 
-func TestModelListStatusError_QuotesUpstreamExplanation(t *testing.T) {
-	err := providers.ModelListStatusError(400, []byte(`{"message":"invalid\n token type","code":"390318"}`))
-	assert.EqualError(t, err, "model listing returned status 400: invalid token type")
+func TestModelListStatusError_DoesNotExposeUpstreamExplanation(t *testing.T) {
+	err := providers.NewModelListStatusError(400)
+	assert.EqualError(t, err, "model listing failed with status 400 (upstream_status)")
+	assert.NotContains(t, err.Error(), "invalid token type")
 
-	err = providers.ModelListStatusError(500, []byte(""))
-	assert.EqualError(t, err, "model listing returned status 500")
+	var statusErr *providers.ModelListHTTPStatusError
+	require.ErrorAs(t, err, &statusErr)
+	assert.Equal(t, 400, statusErr.Status)
+	assert.Equal(t, providers.ModelListFailureUpstreamStatus, statusErr.Category)
 }

--- a/internal/providers/model_lister.go
+++ b/internal/providers/model_lister.go
@@ -1,6 +1,17 @@
 package providers
 
-import "context"
+import (
+	"context"
+	"errors"
+)
+
+// ErrModelDiscoveryDestination is returned when model discovery targets an
+// address outside its configured destination policy.
+var ErrModelDiscoveryDestination = errors.New("model discovery destination is not allowed")
+
+// ErrModelDiscoveryTransport is returned when a protected model-discovery
+// request cannot reach its endpoint without exposing network details.
+var ErrModelDiscoveryTransport = errors.New("model discovery endpoint could not be reached")
 
 // ModelLister is implemented by provider adapters that expose a model-listing endpoint.
 // Request-context BYOK credentials win over the deployment-level key, mirroring inference.

--- a/internal/providers/openaicompat/azure_internal_test.go
+++ b/internal/providers/openaicompat/azure_internal_test.go
@@ -40,8 +40,7 @@ func TestListModels_AzureEndpointStoredWithOpenAIStyleV1(t *testing.T) {
 	require.NoError(t, err)
 
 	rt := &hostRewriter{target: target}
-	c := NewGatewayClient("k", "https://zllama-dev.openai.azure.com/v1")
-	c.http = &http.Client{Transport: rt}
+	c := NewGatewayClient("k", "https://zllama-dev.openai.azure.com/v1", WithModelListHTTPClient(&http.Client{Transport: rt}))
 
 	ids, err := c.ListModels(context.Background())
 	require.NoError(t, err)

--- a/internal/providers/openaicompat/client.go
+++ b/internal/providers/openaicompat/client.go
@@ -115,8 +115,15 @@ type Client struct {
 type Option func(*Client)
 
 // WithModelListHTTPClient supplies the client used only for model discovery.
+// A nil client is ignored so a misconfigured option cannot strip the
+// constructor's destination-checked default and panic on the first call.
 func WithModelListHTTPClient(client *http.Client) Option {
-	return func(c *Client) { c.modelHTTP = client }
+	return func(c *Client) {
+		if client == nil {
+			return
+		}
+		c.modelHTTP = client
+	}
 }
 
 func NewClient(apiKey, baseURL string, opts ...Option) *Client {

--- a/internal/providers/openaicompat/client.go
+++ b/internal/providers/openaicompat/client.go
@@ -76,9 +76,10 @@ func BedrockMantleBaseURL(region string) string {
 }
 
 type Client struct {
-	apiKey  string
-	baseURL string
-	http    *http.Client
+	apiKey    string
+	baseURL   string
+	http      *http.Client
+	modelHTTP *http.Client
 	// grokHTTP carries the wider time-to-first-byte guard used for Grok
 	// models; see grokResponseHeaderTimeout.
 	grokHTTP *http.Client
@@ -110,35 +111,48 @@ type Client struct {
 	versionMemo providers.GatewayVersionMemo
 }
 
-func NewClient(apiKey, baseURL string) *Client {
-	return NewClientWithModelIDMap(apiKey, baseURL, nil)
+// Option configures a Client at construction.
+type Option func(*Client)
+
+// WithModelListHTTPClient supplies the client used only for model discovery.
+func WithModelListHTTPClient(client *http.Client) Option {
+	return func(c *Client) { c.modelHTTP = client }
+}
+
+func NewClient(apiKey, baseURL string, opts ...Option) *Client {
+	return NewClientWithModelIDMap(apiKey, baseURL, nil, opts...)
 }
 
 // NewClientWithModelIDMap builds a client that rewrites the body's top-level
 // "model" field before forwarding when the requested model has a mapping.
 // Pass nil to disable rewriting.
-func NewClientWithModelIDMap(apiKey, baseURL string, modelIDMap map[string]string) *Client {
+func NewClientWithModelIDMap(apiKey, baseURL string, modelIDMap map[string]string, opts ...Option) *Client {
 	if baseURL == "" {
 		baseURL = DefaultBaseURL
 	}
-	return newClient(apiKey, baseURL, modelIDMap)
+	return newClient(apiKey, baseURL, modelIDMap, opts...)
 }
 
 // NewGatewayClient builds a client for a customer-supplied OpenAI-spec endpoint.
 // Unlike NewClient, no default base URL is applied: an unconfigured gateway must
 // fail rather than silently dispatch the tenant's token to OpenRouter.
-func NewGatewayClient(apiKey, baseURL string) *Client {
-	return newClient(apiKey, baseURL, nil)
+func NewGatewayClient(apiKey, baseURL string, opts ...Option) *Client {
+	return newClient(apiKey, baseURL, nil, opts...)
 }
 
-func newClient(apiKey, baseURL string, modelIDMap map[string]string) *Client {
-	return &Client{
+func newClient(apiKey, baseURL string, modelIDMap map[string]string, opts ...Option) *Client {
+	client := &Client{
 		apiKey:     apiKey,
 		baseURL:    strings.TrimRight(baseURL, "/"),
 		http:       httputil.NewClient(httputil.NewTransport(5*time.Second, 5*time.Second)),
 		grokHTTP:   httputil.NewClient(httputil.NewTransportWithResponseHeaderTimeout(5*time.Second, 5*time.Second, grokResponseHeaderTimeout)),
+		modelHTTP:  httputil.NewDefaultModelDiscoveryClient(),
 		modelIDMap: modelIDMap,
 	}
+	for _, opt := range opts {
+		opt(client)
+	}
+	return client
 }
 
 // httpFor picks the HTTP client for a routed model: Grok models get the

--- a/internal/providers/openaicompat/cortex_catalog_test.go
+++ b/internal/providers/openaicompat/cortex_catalog_test.go
@@ -8,7 +8,10 @@ import (
 	"testing"
 
 	"weave-os/router/internal/providers/anthropic"
+	"weave-os/router/internal/providers/httputil"
 	"weave-os/router/internal/providers/openaicompat"
+
+	"github.com/stretchr/testify/require"
 )
 
 // cortex replays Snowflake Cortex's observed catalog responses: 415 without a
@@ -49,7 +52,9 @@ func TestCortexSimOpenAI(t *testing.T) {
 	hits := 0
 	srv := httptest.NewServer(cortex(t, &hits))
 	defer srv.Close()
-	models, err := openaicompat.NewGatewayClient("tok", srv.URL+"/api/v2/cortex").ListModels(context.Background())
+	discoveryClient, err := httputil.NewModelDiscoveryClient(srv.URL)
+	require.NoError(t, err)
+	models, err := openaicompat.NewGatewayClient("tok", srv.URL+"/api/v2/cortex", openaicompat.WithModelListHTTPClient(discoveryClient)).ListModels(context.Background())
 	if err != nil || len(models) != 2 || hits != 1 {
 		t.Fatalf("openai_gateway: models=%v err=%v hits=%d", models, err, hits)
 	}
@@ -59,7 +64,9 @@ func TestCortexSimAnthropic(t *testing.T) {
 	hits := 0
 	srv := httptest.NewServer(cortex(t, &hits))
 	defer srv.Close()
-	models, err := anthropic.NewClient("tok", srv.URL+"/api/v2/cortex", anthropic.WithAuthScheme(anthropic.AuthBearer)).ListModels(context.Background())
+	discoveryClient, err := httputil.NewModelDiscoveryClient(srv.URL)
+	require.NoError(t, err)
+	models, err := anthropic.NewClient("tok", srv.URL+"/api/v2/cortex", anthropic.WithAuthScheme(anthropic.AuthBearer), anthropic.WithModelListHTTPClient(discoveryClient)).ListModels(context.Background())
 	if err != nil || len(models) != 2 || hits != 1 {
 		t.Fatalf("anthropic_gateway: models=%v err=%v hits=%d", models, err, hits)
 	}

--- a/internal/providers/openaicompat/list_models.go
+++ b/internal/providers/openaicompat/list_models.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
+	"weave-os/router/internal/auth"
 	"weave-os/router/internal/providers"
 	"weave-os/router/internal/requestcontext"
 )
@@ -22,32 +23,55 @@ const maxModelListBytes = 1 << 20
 func (c *Client) ListModels(ctx context.Context) ([]string, error) {
 	baseURL := c.effectiveBaseURL(ctx)
 	if baseURL == "" {
-		return nil, errors.New("no base URL configured for model listing")
+		return nil, providers.ErrModelDiscoveryDestination
+	}
+	normalizedBaseURL, err := auth.NormalizeBaseURL(&baseURL)
+	if err != nil || normalizedBaseURL == nil {
+		return nil, providers.ErrModelDiscoveryDestination
+	}
+	baseURL = *normalizedBaseURL
+	listURLs, err := modelListURLs(baseURL)
+	if err != nil {
+		return nil, providers.ErrModelDiscoveryDestination
 	}
 	var (
-		ids []string
-		err error
+		ids     []string
+		listErr error
 	)
-	for _, listURL := range modelListURLs(baseURL) {
+	for _, listURL := range listURLs {
 		var status int
-		ids, status, err = c.listModelsAt(ctx, listURL)
+		ids, status, listErr = c.listModelsAt(ctx, listURL)
 		if status != http.StatusNotFound {
-			return ids, err
+			return ids, listErr
 		}
 	}
-	return ids, err
+	return ids, listErr
 }
 
 // modelListURLs returns catalog URLs to try for baseURL, likeliest first.
 // For gateways that mount their catalog above /v1 (e.g. Snowflake Cortex:
 // /api/v2/cortex/models vs /api/v2/cortex/v1/chat/completions), also
 // includes one segment up.
-func modelListURLs(baseURL string) []string {
-	urls := []string{baseURL + "/models"}
-	if root, trimmed := strings.CutSuffix(baseURL, "/v1"); trimmed {
-		urls = append(urls, root+"/models")
+func modelListURLs(baseURL string) ([]string, error) {
+	primary, err := url.JoinPath(baseURL, "models")
+	if err != nil {
+		return nil, err
 	}
-	return urls
+	urls := []string{primary}
+	parsedBaseURL, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	if strings.HasSuffix(parsedBaseURL.Path, "/v1") {
+		parsedBaseURL.Path = strings.TrimSuffix(parsedBaseURL.Path, "/v1")
+		parsedBaseURL.RawPath = ""
+		fallback, joinErr := url.JoinPath(parsedBaseURL.String(), "models")
+		if joinErr != nil {
+			return nil, joinErr
+		}
+		urls = append(urls, fallback)
+	}
+	return urls, nil
 }
 
 // listModelsAt reads one model-list URL, also reporting the upstream status so
@@ -68,7 +92,7 @@ func (c *Client) getModelList(ctx context.Context, listURL string, withEntity bo
 	}
 	upstream, err := http.NewRequestWithContext(ctx, http.MethodGet, listURL, entity)
 	if err != nil {
-		return nil, 0, fmt.Errorf("build model-list request: %w", err)
+		return nil, 0, providers.ErrModelDiscoveryDestination
 	}
 	if withEntity {
 		upstream.Header.Set("Content-Type", "application/json")
@@ -78,17 +102,20 @@ func (c *Client) getModelList(ctx context.Context, listURL string, withEntity bo
 	requestcontext.ApplyWIFTokenType(ctx, upstream)
 	requestcontext.ApplyIdentityHeader(ctx, upstream)
 
-	resp, err := c.http.Do(upstream)
+	resp, err := c.modelHTTP.Do(upstream)
 	if err != nil {
-		return nil, 0, fmt.Errorf("model-list call: %w", err)
+		if errors.Is(err, providers.ErrModelDiscoveryDestination) {
+			return nil, 0, providers.ErrModelDiscoveryDestination
+		}
+		return nil, 0, providers.ErrModelDiscoveryTransport
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxModelListBytes))
 	if resp.StatusCode >= 400 {
-		return nil, resp.StatusCode, providers.ModelListStatusError(resp.StatusCode, body)
+		return nil, resp.StatusCode, providers.NewModelListStatusError(resp.StatusCode)
 	}
 	if err != nil {
-		return nil, resp.StatusCode, fmt.Errorf("read model-list response: %w", err)
+		return nil, resp.StatusCode, providers.ErrModelDiscoveryTransport
 	}
 	ids, err := providers.ParseModelIDs(body)
 	return ids, resp.StatusCode, err

--- a/internal/providers/openaicompat/list_models_test.go
+++ b/internal/providers/openaicompat/list_models_test.go
@@ -7,12 +7,20 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"weave-os/router/internal/providers/httputil"
 	"weave-os/router/internal/providers/openaicompat"
 	"weave-os/router/internal/requestcontext"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func openAICompatibleDiscoveryClient(t *testing.T, origin string) *http.Client {
+	t.Helper()
+	client, err := httputil.NewModelDiscoveryClient(origin)
+	require.NoError(t, err)
+	return client
+}
 
 func TestListModels_ReturnsSortedDedupedIDs(t *testing.T) {
 	var gotPath, gotAuth string
@@ -24,7 +32,7 @@ func TestListModels_ReturnsSortedDedupedIDs(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := openaicompat.NewGatewayClient("deploy-token", srv.URL)
+	c := openaicompat.NewGatewayClient("deploy-token", srv.URL, openaicompat.WithModelListHTTPClient(openAICompatibleDiscoveryClient(t, srv.URL)))
 	models, err := c.ListModels(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, []string{"claude-fable-5", "llama3.1-70b"}, models)
@@ -40,7 +48,7 @@ func TestListModels_BYOKCredentialsOverrideBaseURLAndKey(t *testing.T) {
 	}))
 	defer byokSrv.Close()
 
-	c := openaicompat.NewGatewayClient("deploy-token", "http://127.0.0.1:1/unreachable")
+	c := openaicompat.NewGatewayClient("deploy-token", "http://127.0.0.1:1/unreachable", openaicompat.WithModelListHTTPClient(openAICompatibleDiscoveryClient(t, byokSrv.URL)))
 	ctx := context.WithValue(context.Background(), requestcontext.CredentialsContextKey{}, &requestcontext.Credentials{
 		APIKey:  []byte("byok-token"),
 		BaseURL: byokSrv.URL,
@@ -57,7 +65,7 @@ func TestListModels_UpstreamErrorStatus(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := openaicompat.NewGatewayClient("bad-token", srv.URL)
+	c := openaicompat.NewGatewayClient("bad-token", srv.URL, openaicompat.WithModelListHTTPClient(openAICompatibleDiscoveryClient(t, srv.URL)))
 	_, err := c.ListModels(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "401")
@@ -75,7 +83,7 @@ func TestListModels_MalformedBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := openaicompat.NewGatewayClient("token", srv.URL)
+	c := openaicompat.NewGatewayClient("token", srv.URL, openaicompat.WithModelListHTTPClient(openAICompatibleDiscoveryClient(t, srv.URL)))
 	_, err := c.ListModels(context.Background())
 	require.Error(t, err)
 }
@@ -94,7 +102,7 @@ func TestListModels_FallsBackAboveV1On404(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := openaicompat.NewGatewayClient("gw-token", srv.URL+"/api/v2/cortex/v1")
+	c := openaicompat.NewGatewayClient("gw-token", srv.URL+"/api/v2/cortex/v1", openaicompat.WithModelListHTTPClient(openAICompatibleDiscoveryClient(t, srv.URL)))
 	models, err := c.ListModels(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, []string{"claude-opus-5", "openai-gpt-5.2"}, models)
@@ -116,7 +124,7 @@ func TestListModels_RetriesWithEntityWhenGatewayDemandsOne(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := openaicompat.NewGatewayClient("token", srv.URL)
+	c := openaicompat.NewGatewayClient("token", srv.URL, openaicompat.WithModelListHTTPClient(openAICompatibleDiscoveryClient(t, srv.URL)))
 	models, err := c.ListModels(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, []string{"claude-4-sonnet", "openai-gpt-5"}, models)

--- a/internal/providers/openaicompat/list_models_test.go
+++ b/internal/providers/openaicompat/list_models_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"weave-os/router/internal/providers"
 	"weave-os/router/internal/providers/httputil"
 	"weave-os/router/internal/providers/openaicompat"
 	"weave-os/router/internal/requestcontext"
@@ -129,4 +130,21 @@ func TestListModels_RetriesWithEntityWhenGatewayDemandsOne(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"claude-4-sonnet", "openai-gpt-5"}, models)
 	assert.Equal(t, []string{"", "{}"}, attempts)
+}
+
+// A nil option value must not strip the constructor's destination-checked
+// discovery client, which would turn a misconfigured call site into a panic
+// on the first model-list request.
+func TestListModels_NilModelListClientKeepsTheCheckedDefault(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"id":"cortex-model"}]}`))
+	}))
+	defer srv.Close()
+
+	c := openaicompat.NewGatewayClient("tok", srv.URL, openaicompat.WithModelListHTTPClient(nil))
+
+	// The retained default refuses this loopback destination rather than panicking.
+	_, err := c.ListModels(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, providers.ErrModelDiscoveryDestination)
 }

--- a/internal/providers/openaicompat/redirect_test.go
+++ b/internal/providers/openaicompat/redirect_test.go
@@ -79,11 +79,11 @@ func TestPassthrough_RefusedRedirectRelaysNothing(t *testing.T) {
 func TestListModels_RedirectRefused(t *testing.T) {
 	upstream, targetHit := redirectFixture(t)
 
-	c := openaicompat.NewClient("test-key", upstream.URL+"/v1")
+	c := openaicompat.NewClient("test-key", upstream.URL+"/v1", openaicompat.WithModelListHTTPClient(openAICompatibleDiscoveryClient(t, upstream.URL)))
 	ids, err := c.ListModels(context.Background())
 
 	require.Error(t, err)
-	assert.ErrorIs(t, err, httputil.ErrRefusedRedirect)
+	assert.ErrorIs(t, err, providers.ErrModelDiscoveryTransport)
 	assert.Empty(t, ids)
 	assert.False(t, targetHit.Load(), "the redirect target must never be contacted")
 }

--- a/internal/proxy/credentials.go
+++ b/internal/proxy/credentials.go
@@ -82,7 +82,7 @@ func BuildCredentialsMap(keys []*auth.ExternalAPIKey) map[string]*Credentials {
 
 			IdentityHeader:         key.IdentityHeader,
 			IdentityHeaderFormat:   key.IdentityHeaderFormat,
-			ForwardedClientHeaders: key.ForwardedClientHeaders,
+			ForwardedClientHeaders: append([]string(nil), key.ForwardedClientHeaders...),
 			BaggageHeader:          key.BaggageHeader,
 			AuthType:               key.AuthType,
 		}

--- a/internal/requestcontext/forwarding.go
+++ b/internal/requestcontext/forwarding.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"weave-os/router/internal/auth"
 )
@@ -43,9 +44,13 @@ func WithForwardedHeaderSnapshot(ctx context.Context, keys []*auth.ExternalAPIKe
 			continue
 		}
 		for _, name := range key.ForwardedClientHeaders {
-			capture(name)
+			if safeExternalKeyHeaderDestination(key, name) {
+				capture(name)
+			}
 		}
-		capture(key.BaggageHeader)
+		if safeExternalKeyHeaderDestination(key, key.BaggageHeader) {
+			capture(key.BaggageHeader)
+		}
 	}
 	if snapshot == nil {
 		return ctx
@@ -67,11 +72,14 @@ func ApplyForwardedClientHeaders(ctx context.Context, upstream *http.Request, in
 		return
 	}
 	for _, name := range creds.ForwardedClientHeaders {
+		if !safeCredentialHeaderDestination(creds, name) || headerFieldExists(upstream.Header, name) {
+			continue
+		}
 		if v := forwardedValue(ctx, inbound, name); v != "" {
 			upstream.Header.Set(name, v)
 		}
 	}
-	if creds.BaggageHeader == "" {
+	if !safeCredentialHeaderDestination(creds, creds.BaggageHeader) || headerFieldExists(upstream.Header, creds.BaggageHeader) {
 		return
 	}
 	baggage := forwardedValue(ctx, inbound, creds.BaggageHeader)
@@ -84,6 +92,9 @@ func ApplyForwardedClientHeaders(ctx context.Context, upstream *http.Request, in
 // ingress snapshot, or (for X-Claude-Code-Session-Id only) the resolved
 // identity — covering clients that embed the id in the body, not a header.
 func forwardedValue(ctx context.Context, inbound http.Header, name string) string {
+	if !auth.IsSafeForwardingHeader(name) {
+		return ""
+	}
 	if v := inbound.Get(name); v != "" {
 		return v
 	}
@@ -94,6 +105,45 @@ func forwardedValue(ctx context.Context, inbound http.Header, name string) strin
 		return ClientIdentityFrom(ctx).SessionID
 	}
 	return ""
+}
+
+func safeExternalKeyHeaderDestination(key *auth.ExternalAPIKey, name string) bool {
+	if key == nil || !auth.IsSafeForwardingHeader(name) {
+		return false
+	}
+	return headerDestinationCount(name, key.ForwardedClientHeaders, key.BaggageHeader, key.IdentityHeader) == 1
+}
+
+func safeCredentialHeaderDestination(creds *Credentials, name string) bool {
+	if creds == nil || !auth.IsSafeForwardingHeader(name) {
+		return false
+	}
+	return headerDestinationCount(name, creds.ForwardedClientHeaders, creds.BaggageHeader, creds.IdentityHeader) == 1
+}
+
+func headerDestinationCount(name string, forwarded []string, baggage, identity string) int {
+	count := 0
+	for _, candidate := range forwarded {
+		if strings.EqualFold(name, candidate) {
+			count++
+		}
+	}
+	if strings.EqualFold(name, baggage) {
+		count++
+	}
+	if strings.EqualFold(name, identity) {
+		count++
+	}
+	return count
+}
+
+func headerFieldExists(headers http.Header, name string) bool {
+	for existingName := range headers {
+		if strings.EqualFold(existingName, name) {
+			return true
+		}
+	}
+	return false
 }
 
 // MergeBaggageEmail injects the router-resolved email as on-behalf-of, overwriting any

--- a/internal/requestcontext/header_forwarding_test.go
+++ b/internal/requestcontext/header_forwarding_test.go
@@ -1,12 +1,14 @@
 package requestcontext_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"weave-os/router/internal/auth"
+	"weave-os/router/internal/proxy"
 	"weave-os/router/internal/requestcontext"
 
 	"github.com/stretchr/testify/assert"
@@ -165,4 +167,75 @@ func TestApplyForwardedClientHeaders(t *testing.T) {
 		requestcontext.ApplyForwardedClientHeaders(ctx, upstream, http.Header{})
 		assert.Empty(t, upstream.Header.Get("X-SNOWFLAKE-APPLICATION"))
 	})
+}
+
+func TestForwardingRuntimeGuardsRejectUnsafeLegacyConfiguration(t *testing.T) {
+	identity := proxy.ClientIdentity{Email: "engineer@example.com"}
+	inbound := http.Header{
+		"Authorization":      []string{"Bearer inbound-secret"},
+		"X-Weave-Router-Key": []string{"router-secret"},
+		"Cookie":             []string{"session=secret"},
+	}
+	legacyKey := &auth.ExternalAPIKey{
+		ForwardedClientHeaders: []string{"Authorization"},
+		BaggageHeader:          "X-Weave-Router-Key",
+		IdentityHeader:         "Cookie",
+	}
+
+	ctx := proxy.WithForwardedHeaderSnapshot(context.Background(), []*auth.ExternalAPIKey{legacyKey}, inbound)
+	snapshot, _ := ctx.Value(proxy.ForwardedHeaderSnapshotContextKey{}).(http.Header)
+	assert.Empty(t, snapshot, "protected values must not be retained in a request snapshot")
+
+	creds := &proxy.Credentials{
+		ForwardedClientHeaders: legacyKey.ForwardedClientHeaders,
+		BaggageHeader:          legacyKey.BaggageHeader,
+		IdentityHeader:         legacyKey.IdentityHeader,
+		IdentityHeaderFormat:   auth.IdentityFormatEmail,
+	}
+	ctx = identityCtx(creds, identity)
+	upstream := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	proxy.ApplyIdentityHeader(ctx, upstream)
+	proxy.ApplyForwardedClientHeaders(ctx, upstream, inbound)
+	assert.Empty(t, upstream.Header, "protected values must not be emitted by runtime-only credentials")
+}
+
+func TestForwardingRuntimeGuardsRejectBaggageOnlyCredentialRelay(t *testing.T) {
+	for name, identity := range map[string]proxy.ClientIdentity{
+		"without resolved email": {},
+		"with resolved email":    {Email: "engineer@example.com"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			creds := &proxy.Credentials{BaggageHeader: "Authorization"}
+			ctx := identityCtx(creds, identity)
+			upstream := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+			proxy.ApplyForwardedClientHeaders(ctx, upstream, http.Header{"Authorization": []string{"Bearer inbound-secret"}})
+			assert.Empty(t, upstream.Header.Get("Authorization"))
+		})
+	}
+}
+
+func TestForwardingRuntimeGuardsPreserveUpstreamEstablishedHeaders(t *testing.T) {
+	creds := &proxy.Credentials{ForwardedClientHeaders: []string{"X-Correlation-ID"}}
+	ctx := identityCtx(creds, proxy.ClientIdentity{})
+	upstream := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	upstream.Header.Set("X-Correlation-ID", "provider-value")
+
+	proxy.ApplyForwardedClientHeaders(ctx, upstream, http.Header{"X-Correlation-ID": []string{"client-value"}})
+
+	assert.Equal(t, "provider-value", upstream.Header.Get("X-Correlation-ID"))
+}
+
+func TestForwardingRuntimeGuardsRejectCollidingLegacyDestinations(t *testing.T) {
+	creds := &proxy.Credentials{
+		ForwardedClientHeaders: []string{"X-Correlation-ID"},
+		IdentityHeader:         "x-correlation-id",
+		IdentityHeaderFormat:   auth.IdentityFormatEmail,
+	}
+	ctx := identityCtx(creds, proxy.ClientIdentity{Email: "engineer@example.com"})
+	upstream := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	proxy.ApplyIdentityHeader(ctx, upstream)
+	proxy.ApplyForwardedClientHeaders(ctx, upstream, http.Header{"X-Correlation-ID": []string{"client-value"}})
+
+	assert.Empty(t, upstream.Header.Get("X-Correlation-ID"))
 }

--- a/internal/requestcontext/identity.go
+++ b/internal/requestcontext/identity.go
@@ -51,7 +51,7 @@ type identityBag struct {
 // must be called after prep.Headers are copied so it wins over a client-supplied value.
 func ApplyIdentityHeader(ctx context.Context, upstream *http.Request) {
 	creds := CredentialsFromContext(ctx)
-	if creds == nil || creds.IdentityHeader == "" {
+	if creds == nil || !safeCredentialHeaderDestination(creds, creds.IdentityHeader) {
 		return
 	}
 	value := IdentityHeaderValue(creds.IdentityHeaderFormat, ClientIdentityFrom(ctx))


### PR DESCRIPTION
## Summary
- reject model-discovery SSRF targets at dial time, refuse redirects/proxies, and support exact self-hosted private-origin exceptions
- normalize and redact model-list failures without leaking upstream response content
- fail closed for the default admin password and protect credential/header forwarding, including legacy stored rows
- add regression coverage for DNS rebinding, mixed DNS answers, redirects, proxy bypass, URL parsing, and header relay

## Validation
- `make check` (Go policy, vet, build, and all Go tests pass; existing statusline shell suite has two unrelated stamp/timing failures)
- focused provider, auth, request-context, admin, proxy, and egress tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Harden model discovery and header forwarding to prevent SSRF and credential leaks.

**Model discovery**
- Rejects non-public destinations, redirects, and proxies at dial time.
- Supports exact private origins via `ROUTER_MODEL_DISCOVERY_PRIVATE_ORIGINS`.
- Redacts model-list failures; upstream response content is never included in errors.
- Blocked discovery destinations return 400, so they read as rejected configuration rather than endpoint outages.

**Header forwarding and admin**
- Blocks credential, control, and metadata headers as forwarding destinations.
- Rejects colliding header destinations; runtime guards ignore unsafe legacy configurations.
- Admin dashboard login is disabled when `ROUTER_ADMIN_PASSWORD` is unset.

<sup>Written for commit 2ba6e7d31d6eef2a272e833153ebaa249f9846d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weave-os/router/pull/1247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

