### PR TITLE
fix: preserve classifier user text under the text budget

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,10 @@ jobs:
 
   test:
     name: Test
-    # The branch ruleset requires only this check, so gating it on the
-    # boundary job makes the architecture and generated-policy checks required.
-    needs: inference-boundary
+    # The branch ruleset requires this check, so gating it on the
+    # prerequisite jobs makes architecture and classifier contract checks required.
+    needs: [inference-boundary, test-hmm-sidecar]
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -48,6 +49,10 @@ jobs:
           --health-retries 30
 
     steps:
+      - name: Require inference and sidecar gates
+        if: needs.inference-boundary.result != 'success' || needs.test-hmm-sidecar.result != 'success'
+        run: exit 1
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -175,6 +180,17 @@ jobs:
         working-directory: sidecars/hmm
         run: poetry install --no-interaction
 
+      - name: Set up Go for the serving contract
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Verify Go to bundled Python contract
+        run: |
+          HMM_CONTRACT_PYTHON="$(poetry -C sidecars/hmm env info --path)/bin/python" \
+            go test ./internal/policyclient -run TestBundledPythonAcceptsGoClassificationEvidence -count=1
+
       - name: Check formatting
         working-directory: sidecars/hmm
         run: poetry run black --check hmm_sidecar scripts tests
@@ -204,7 +220,7 @@ jobs:
           trap 'docker rm --force router-hmm-sidecar-test >/dev/null 2>&1 || true' EXIT
           docker run --detach --name router-hmm-sidecar-test \
             --publish 8093:8093 router-hmm-sidecar:test
-          for attempt in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             curl --fail http://127.0.0.1:8093/livez && exit 0
             sleep 1
           done

--- a/internal/policyclient/boundary_test.go
+++ b/internal/policyclient/boundary_test.go
@@ -1,0 +1,81 @@
+package policyclient
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+
+	"weave-os/router/internal/router"
+)
+
+func TestRouteMessagesPreserveTaskAtEveryPosition(t *testing.T) {
+	for _, count := range []int{95, 96, 97, 193} {
+		for position := 0; position < count; position++ {
+			t.Run(fmt.Sprintf("messages_%d_boundary_%d", count, position), func(t *testing.T) {
+				messages := make([]router.ConversationMessage, count)
+				for i := range messages {
+					messages[i] = router.ConversationMessage{Role: "assistant", Text: strings.Repeat("context", 500)}
+				}
+				messages[position] = router.ConversationMessage{Role: "user", Text: "Fix the actual task 界🙂"}
+				got := routeMessages(messages)
+				assert.Equal(t, "Fix the actual task 界🙂", latestUserText(got))
+				assert.LessOrEqual(t, len(got), 96)
+				bytes := 0
+				for _, message := range got {
+					bytes += len(message.Text)
+					assert.LessOrEqual(t, len(message.Text), 3000)
+					assert.True(t, utf8.ValidString(message.Text), "invalid UTF-8 at boundary %d", position)
+				}
+				assert.LessOrEqual(t, bytes, 48000)
+			})
+		}
+	}
+}
+
+func TestClipRouteTextPreservesUTF8(t *testing.T) {
+	for _, test := range []struct {
+		text  string
+		limit int
+		want  string
+	}{
+		{"界🙂x", 1, ""},
+		{"界🙂x", 3, "界"},
+		{"界🙂x", 6, "界"},
+		{"界🙂x", 7, "界🙂"},
+		{" a界 z ", 3, "a"},
+	} {
+		assert.Equal(t, test.want, clipRouteText(test.text, test.limit))
+	}
+}
+
+func TestRouteMessagesDoNotInventUserText(t *testing.T) {
+	messages := []router.ConversationMessage{
+		{Role: "system", Text: "not the task"},
+		{Role: "user", Text: "  "},
+		{Role: "assistant", Text: "assistant context"},
+		{Role: "user", ToolResults: []router.ConversationToolResult{{ToolUseID: "call", Text: "not a user instruction"}}},
+	}
+	assert.Empty(t, latestUserText(routeMessages(messages)))
+	messages[3].Text = "Actual mixed-content task"
+	assert.Equal(t, "Actual mixed-content task", latestUserText(routeMessages(messages)))
+}
+
+func FuzzRouteMessagesPreserveBoundary(f *testing.F) {
+	f.Add(uint8(37), "Restore the task 界🙂")
+	f.Add(uint8(0), "x")
+	f.Fuzz(func(t *testing.T, index uint8, task string) {
+		if !utf8.ValidString(task) || strings.TrimSpace(task) == "" {
+			t.Skip()
+		}
+		messages := make([]router.ConversationMessage, 97)
+		for i := range messages {
+			messages[i] = router.ConversationMessage{Role: "assistant", Text: strings.Repeat("a", 3000)}
+		}
+		messages[int(index)%len(messages)] = router.ConversationMessage{Role: "user", Text: task}
+		want := clipRouteText(task, 3000)
+		assert.Equal(t, want, latestUserText(routeMessages(messages)))
+	})
+}

--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -1050,12 +1050,11 @@ func convertRouteMessages(messages []router.ConversationMessage, limits routeMes
 		return nil
 	}
 	messages = routeMessageWindow(messages, limits.maxMessages)
-	// The oldest message is converted last, so the text budget reserves room for
-	// it: otherwise the pulled-back user boundary arrives with empty text and is
-	// dropped, which is the same wire shape the window guard exists to prevent.
+	// Reserve the task before newer assistant text consumes the shared budget.
+	latestUserTextIndex := userTextIndex(messages)
 	boundaryReserve := 0
-	if boundary := userTextIndex(messages); boundary == 0 && limits.maxTotalTextChars > 0 {
-		boundaryReserve = len(clipRouteText(messages[0].Text, limits.maxTextChars))
+	if latestUserTextIndex >= 0 && limits.maxTotalTextChars > 0 {
+		boundaryReserve = len(clipRouteText(clipRouteText(messages[latestUserTextIndex].Text, limits.maxTextChars), limits.maxTotalTextChars))
 	}
 	reversed := make([]routeMessage, 0, len(messages))
 	totalText := 0
@@ -1068,7 +1067,7 @@ func convertRouteMessages(messages []router.ConversationMessage, limits routeMes
 		text := clipRouteText(message.Text, limits.maxTextChars)
 		if limits.maxTotalTextChars > 0 {
 			budget := limits.maxTotalTextChars
-			if i > 0 {
+			if i > latestUserTextIndex {
 				budget -= boundaryReserve
 			}
 			if remaining := budget - totalText; remaining < len(text) {
@@ -1153,6 +1152,9 @@ func clipRouteText(text string, limit int) string {
 	text = strings.TrimSpace(text)
 	if limit <= 0 || len(text) <= limit {
 		return text
+	}
+	for limit > 0 && !utf8.RuneStart(text[limit]) {
+		limit--
 	}
 	return strings.TrimSpace(text[:limit])
 }

--- a/internal/policyclient/python_contract_test.go
+++ b/internal/policyclient/python_contract_test.go
@@ -1,0 +1,55 @@
+package policyclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"weave-os/router/internal/router"
+	"weave-os/router/internal/router/policy"
+)
+
+// CI supplies the actual bundled sidecar environment; ordinary Go-only builds
+// can run without Python. HMM_CONTRACT_EXPORT also exports these synthetic
+// wire fixtures for the separately owned managed raw-V5 contract gate.
+func TestBundledPythonAcceptsGoClassificationEvidence(t *testing.T) {
+	python := os.Getenv("HMM_CONTRACT_PYTHON")
+	if python == "" {
+		t.Skip("set HMM_CONTRACT_PYTHON to the bundled sidecar Python")
+	}
+	var requests []json.RawMessage
+	for position := 0; position < 97; position++ {
+		messages := make([]router.ConversationMessage, 97)
+		for i := range messages {
+			messages[i] = router.ConversationMessage{Role: "assistant", Text: strings.Repeat("context", 500)}
+		}
+		messages[position] = router.ConversationMessage{Role: "user", Text: "Inspect the synthetic regression"}
+		body, err := marshalRouteRequest(policy.Query{Strategy: router.StrategyHMM, SchemaVersion: policy.SchemaVersionV3, ConversationMessages: messages})
+		require.NoError(t, err)
+		requests = append(requests, body)
+	}
+	wire, err := json.Marshal(requests)
+	require.NoError(t, err)
+	if path := os.Getenv("HMM_CONTRACT_EXPORT"); path != "" {
+		require.NoError(t, os.WriteFile(path, wire, 0600))
+	}
+	program := `import json, sys
+from hmm_sidecar.features import conversation_sequence
+payloads = json.load(sys.stdin)
+for payload in payloads:
+    users = [turn.text for turn in conversation_sequence(payload) if turn.kind == "user"]
+    assert users and "Inspect the synthetic regression" in users[-1], users
+    assert "[missing prompt text]" not in users[-1]
+print(len(payloads))`
+	command := exec.Command(python, "-c", program)
+	command.Env = append(os.Environ(), "PYTHONPATH="+filepath.Join("..", "..", "sidecars", "hmm"))
+	command.Stdin = bytes.NewReader(wire)
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, "%s", output)
+	require.Equal(t, "97", strings.TrimSpace(string(output)))
+}


### PR DESCRIPTION
The classifier converts newer messages first under a shared text budget. It reserved space for the user's task only when that message was at position zero, so long assistant output could erase a task already inside the retained window.

Reserve the latest user text at every position and clip on UTF-8 boundaries while preserving the existing message and byte limits. This is independent of the compaction fix in #1240 and does not change classifier failure recovery.

Validation: the extracted regressions fail against main and pass with the fix. The full Go suite passed 5,854 tests with five optional skips. Coverage includes every position across 95/96/97/193-message histories, multibyte clipping, tool-only input and fuzz seeds. The Go-to-bundled-Python contract verifies that the preserved task reaches the actual feature builder; its CI gate is required.

Split from #1246. Classifier recovery is independently covered by #1249; both PRs target main.
