### PR TITLE
fix(translate): emit parallel tool call blocks in deterministic sequential order

### DIFF
--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -409,8 +409,9 @@ type AnthropicSSETranslator struct {
 	// DeepSeek-v4 et al emit a bare "\n\n" between reasoning and tool_calls;
 	// opening a text block for it would render as an empty block. Flushed once
 	// real text arrives, or dropped if only whitespace ever comes.
-	pendingText strings.Builder
-	toolBlocks  map[int]int
+	pendingText    strings.Builder
+	toolBlocks     map[int]int
+	toolBlockOrder []int
 	// suppressedTools holds tool_call indices refused for carrying no function
 	// name (see emitDelta); later argument fragments reuse the index and must
 	// be dropped too.
@@ -1166,6 +1167,7 @@ func (t *AnthropicSSETranslator) emitDelta(delta gjson.Result) error {
 			}
 			blockIdx = t.blockIdx
 			t.toolBlocks[idx] = blockIdx
+			t.toolBlockOrder = append(t.toolBlockOrder, blockIdx)
 			t.toolNames[blockIdx] = name
 			t.toolUseEmitted = true
 			t.toolUseCount++
@@ -1408,7 +1410,7 @@ func (t *AnthropicSSETranslator) finishStream() error {
 		}
 		t.thinkingOpen = false
 	}
-	for _, blockIdx := range t.toolBlocks {
+	for _, blockIdx := range t.toolBlockOrder {
 		if err := t.emitValidatedToolArgsDelta(blockIdx); err != nil {
 			return err
 		}
@@ -1417,6 +1419,7 @@ func (t *AnthropicSSETranslator) finishStream() error {
 		}
 	}
 	t.toolBlocks = map[int]int{}
+	t.toolBlockOrder = nil
 
 	// Upstream error seen after Prelude committed: surface it as an `error`
 	// event, not a clean end_turn (which agent harnesses would silently accept

--- a/internal/translate/translate_test.go
+++ b/internal/translate/translate_test.go
@@ -584,11 +584,19 @@ func TestAnthropicSSETranslator_StreamingParallelToolCallsDeterministicOrder(t *
 		start0 := strings.Index(body, `"type":"content_block_start","index":0`)
 		start1 := strings.Index(body, `"type":"content_block_start","index":1`)
 		start2 := strings.Index(body, `"type":"content_block_start","index":2`)
+		require.True(t, start0 != -1 && start1 != -1 && start2 != -1, "all start events must be present")
 		require.True(t, start0 < start1 && start1 < start2, "starts must be in order: 0 < 1 < 2")
+
+		delta0 := strings.Index(body, `"type":"content_block_delta","index":0`)
+		delta1 := strings.Index(body, `"type":"content_block_delta","index":1`)
+		delta2 := strings.Index(body, `"type":"content_block_delta","index":2`)
+		require.True(t, delta0 != -1 && delta1 != -1 && delta2 != -1, "all delta events must be present")
+		require.True(t, delta0 < delta1 && delta1 < delta2, "deltas must be in order: 0 < 1 < 2")
 
 		stop0 := strings.Index(body, `"type":"content_block_stop","index":0`)
 		stop1 := strings.Index(body, `"type":"content_block_stop","index":1`)
 		stop2 := strings.Index(body, `"type":"content_block_stop","index":2`)
+		require.True(t, stop0 != -1 && stop1 != -1 && stop2 != -1, "all stop events must be present")
 		require.True(t, stop0 < stop1 && stop1 < stop2, "stops must be in deterministic order: 0 < 1 < 2 (trial %d)", trial)
 	}
 }

--- a/internal/translate/translate_test.go
+++ b/internal/translate/translate_test.go
@@ -556,6 +556,43 @@ func TestAnthropicSSETranslator_StreamingToolUse(t *testing.T) {
 	assert.Contains(t, body, "event: message_stop")
 }
 
+func TestAnthropicSSETranslator_StreamingParallelToolCallsDeterministicOrder(t *testing.T) {
+	for trial := 0; trial < 10; trial++ {
+		rec := httptest.NewRecorder()
+		translator := translate.NewAnthropicSSETranslator(rec, "gpt-4o", nil)
+
+		translator.Header().Set("Content-Type", "text/event-stream")
+		translator.WriteHeader(http.StatusOK)
+
+		events := []string{
+			"data: {\"id\":\"chatcmpl-p\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":null,\"tool_calls\":[{\"index\":0,\"id\":\"call_a\",\"type\":\"function\",\"function\":{\"name\":\"tool_a\",\"arguments\":\"\"}},{\"index\":1,\"id\":\"call_b\",\"type\":\"function\",\"function\":{\"name\":\"tool_b\",\"arguments\":\"\"}},{\"index\":2,\"id\":\"call_c\",\"type\":\"function\",\"function\":{\"name\":\"tool_c\",\"arguments\":\"\"}}]},\"finish_reason\":null}]}\n\n",
+			"data: {\"id\":\"chatcmpl-p\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"arg\\\":\\\"a\\\"}\"}},{\"index\":1,\"function\":{\"arguments\":\"{\\\"arg\\\":\\\"b\\\"}\"}},{\"index\":2,\"function\":{\"arguments\":\"{\\\"arg\\\":\\\"c\\\"}\"}}]},\"finish_reason\":null}]}\n\n",
+			"data: {\"id\":\"chatcmpl-p\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":20,\"completion_tokens\":15,\"total_tokens\":35}}\n\n",
+			"data: [DONE]\n\n",
+		}
+
+		for _, event := range events {
+			_, err := translator.Write([]byte(event))
+			require.NoError(t, err)
+		}
+
+		require.NoError(t, translator.Finalize())
+
+		body := rec.Body.String()
+		// Check that content_block_start, content_block_delta, and content_block_stop
+		// for indices 0, 1, 2 appear in strict monotonic index order.
+		start0 := strings.Index(body, `"type":"content_block_start","index":0`)
+		start1 := strings.Index(body, `"type":"content_block_start","index":1`)
+		start2 := strings.Index(body, `"type":"content_block_start","index":2`)
+		require.True(t, start0 < start1 && start1 < start2, "starts must be in order: 0 < 1 < 2")
+
+		stop0 := strings.Index(body, `"type":"content_block_stop","index":0`)
+		stop1 := strings.Index(body, `"type":"content_block_stop","index":1`)
+		stop2 := strings.Index(body, `"type":"content_block_stop","index":2`)
+		require.True(t, stop0 < stop1 && stop1 < stop2, "stops must be in deterministic order: 0 < 1 < 2 (trial %d)", trial)
+	}
+}
+
 // Any response with tool_use blocks must report stop_reason="tool_use" even if
 // the upstream finish_reason says otherwise. Some OpenAI-compat serves (e.g.
 // GLM-5.1 on DeepInfra) close tool-emitting turns with "stop" or "", which


### PR DESCRIPTION
﻿## Description

In `AnthropicSSETranslator.finishStream()`, open parallel tool call blocks were closed by iterating over `for _, blockIdx := range t.toolBlocks` where `t.toolBlocks` is a Go `map[int]int`. Because Go randomizes map iteration order, parallel tool call finish events (`content_block_stop`) and subsequent deltas were emitted non-deterministically across runs, causing out-of-order block termination and sporadic failures in strict SSE client parsers.

## Changes

- Added `toolBlockOrder []int` slice to `AnthropicSSETranslator` in `internal/translate/stream.go` to record the exact arrival order of parallel tool call blocks.
- Updated `finishStream()` to iterate through `toolBlockOrder` sequentially instead of over map keys.
- Added non-tautological test `TestAnthropicSSETranslator_StreamingParallelToolCallsDeterministicOrder` in `internal/translate/translate_test.go` asserting strict sequential order `[0, 1, 2]` across multiple randomized trials.

## Verification

- `go test -v ./internal/translate -run TestAnthropicSSETranslator_StreamingParallelToolCallsDeterministicOrder` (passed)
- `go test ./internal/translate` (passed)
- `go test ./internal/router/policy ./internal/architecture` (passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes non-deterministic emission of parallel tool call blocks in `AnthropicSSETranslator.finishStream()`, which caused sporadic SSE client parsing failures.

The translator now records tool block arrival order in a slice instead of relying on Go's randomized map iteration, so `content_block_start`, `content_block_delta`, and `content_block_stop` events are emitted in deterministic sequential order. Adds a test that runs 10 randomized trials asserting strict index order `[0, 1, 2]` across all event types.

<sup>Written for commit b1eee6eb56a108fbc7d327d17e44ea5918435f92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weave-os/router/pull/1264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

