### PR TITLE
fix(proxy): record billing debits on streaming client cancellations with consumed tokens

### DIFF
--- a/internal/proxy/byok_billing_internal_test.go
+++ b/internal/proxy/byok_billing_internal_test.go
@@ -45,3 +45,28 @@ func TestByokServedForProvider(t *testing.T) {
 	assert.False(t, byokServedForProvider(context.Background(), providers.ProviderAnthropic),
 		"no BYOK rows on the request means no fee billing")
 }
+
+func TestShouldBillInference(t *testing.T) {
+	// Normal successful turns must always bill.
+	assert.True(t, shouldBillInference(nil, 100, 200))
+	assert.True(t, shouldBillInference(nil, 0, 0))
+
+	// Client aborts / stream disconnects with tokens consumed must bill.
+	assert.True(t, shouldBillInference(context.Canceled, 50, 150),
+		"canceled client context after token consumption must still be debited")
+	assert.True(t, shouldBillInference(context.DeadlineExceeded, 100, 0),
+		"client timeout after prompt tokens processed must still be debited")
+
+	// Client aborts before any tokens consumed must NOT bill.
+	assert.False(t, shouldBillInference(context.Canceled, 0, 0),
+		"client cancellation with zero tokens consumed must not bill")
+
+	// Upstream errors (4xx / 5xx) must NOT bill the customer.
+	statusErr := &providers.UpstreamStatusError{Status: 500}
+	assert.False(t, shouldBillInference(statusErr, 100, 100),
+		"upstream 500 must never debit customer")
+
+	bufferedErr := &providers.UpstreamErrorResponse{Status: 429}
+	assert.False(t, shouldBillInference(bufferedErr, 100, 100),
+		"upstream 429 must never debit customer")
+}

--- a/internal/proxy/byok_billing_internal_test.go
+++ b/internal/proxy/byok_billing_internal_test.go
@@ -48,25 +48,31 @@ func TestByokServedForProvider(t *testing.T) {
 
 func TestShouldBillInference(t *testing.T) {
 	// Normal successful turns must always bill.
-	assert.True(t, shouldBillInference(nil, 100, 200))
-	assert.True(t, shouldBillInference(nil, 0, 0))
+	assert.True(t, shouldBillInference(nil, 100, 200, 0, 0))
+	assert.True(t, shouldBillInference(nil, 0, 0, 0, 0))
 
 	// Client aborts / stream disconnects with tokens consumed must bill.
-	assert.True(t, shouldBillInference(context.Canceled, 50, 150),
+	assert.True(t, shouldBillInference(context.Canceled, 50, 150, 0, 0),
 		"canceled client context after token consumption must still be debited")
-	assert.True(t, shouldBillInference(context.DeadlineExceeded, 100, 0),
+	assert.True(t, shouldBillInference(context.DeadlineExceeded, 100, 0, 0, 0),
 		"client timeout after prompt tokens processed must still be debited")
 
+	// Client aborts with cache-only usage (Anthropic cacheRead / cacheCreation) must bill.
+	assert.True(t, shouldBillInference(context.Canceled, 0, 0, 1000, 0),
+		"client cancellation after cache creation must still be debited")
+	assert.True(t, shouldBillInference(context.Canceled, 0, 0, 0, 5000),
+		"client cancellation with cache-read-only usage must still be debited")
+
 	// Client aborts before any tokens consumed must NOT bill.
-	assert.False(t, shouldBillInference(context.Canceled, 0, 0),
+	assert.False(t, shouldBillInference(context.Canceled, 0, 0, 0, 0),
 		"client cancellation with zero tokens consumed must not bill")
 
 	// Upstream errors (4xx / 5xx) must NOT bill the customer.
 	statusErr := &providers.UpstreamStatusError{Status: 500}
-	assert.False(t, shouldBillInference(statusErr, 100, 100),
+	assert.False(t, shouldBillInference(statusErr, 100, 100, 500, 500),
 		"upstream 500 must never debit customer")
 
 	bufferedErr := &providers.UpstreamErrorResponse{Status: 429}
-	assert.False(t, shouldBillInference(bufferedErr, 100, 100),
+	assert.False(t, shouldBillInference(bufferedErr, 100, 100, 500, 500),
 		"upstream 429 must never debit customer")
 }

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -456,11 +456,11 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		s.fireTelemetry(telemetryParams)
 	}
 
-	if shouldBillInference(proxyErr, in, out) {
+	if shouldBillInference(proxyErr, in, out, cacheCreation, cacheRead) {
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
-		if compRes.Summarized {
-			s.billCompactionSummary(ctx, requestID, externalID, compRes.SummaryUsage)
-		}
+	}
+	if compRes.Summarized {
+		s.billCompactionSummary(ctx, requestID, externalID, compRes.SummaryUsage)
 	}
 
 	// Two-strike provider disable: see ProxyMessages. Gemini rarely produces a

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -456,7 +456,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		s.fireTelemetry(telemetryParams)
 	}
 
-	if proxyErr == nil {
+	if shouldBillInference(proxyErr, in, out) {
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
 		if compRes.Summarized {
 			s.billCompactionSummary(ctx, requestID, externalID, compRes.SummaryUsage)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -4656,8 +4656,10 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	// No-op when billing is unwired (selfhosted); only reached on a real
 	// upstream call since the cache-hit branch above already returned.
-	if shouldBillInference(proxyErr, in, out) && !agentShadowMode {
+	if shouldBillInference(proxyErr, in, out, cacheCreation, cacheRead) && !agentShadowMode {
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
+	}
+	if !agentShadowMode {
 		if compRes.Summarized {
 			s.billCompactionSummary(ctx, requestID, externalID, compRes.SummaryUsage)
 		}
@@ -5725,16 +5727,16 @@ func (s *Service) fireTelemetry(p InsertTelemetryParams) {
 // shouldBillInference reports whether inference tokens were consumed and must
 // be debited. When proxyErr is nil, billing proceeds normally. When proxyErr is
 // non-nil (e.g. client disconnect, context cancellation, or stream drop),
-// billing is still recorded if tokens were actually processed (in > 0 || out > 0)
-// and the error is not an upstream rejection (upstream status < 400).
-func shouldBillInference(proxyErr error, in, out int) bool {
+// billing is still recorded if tokens were actually processed (fresh, generated,
+// or cached) and the error is not an upstream rejection (upstream status < 400).
+func shouldBillInference(proxyErr error, in, out, cacheCreation, cacheRead int) bool {
 	if proxyErr == nil {
 		return true
 	}
 	if upstreamStatus(proxyErr) >= 400 {
 		return false
 	}
-	return in > 0 || out > 0
+	return in > 0 || out > 0 || cacheCreation > 0 || cacheRead > 0
 }
 
 // emitBilling debits the customer for one upstream call and, on switch turns
@@ -7195,11 +7197,11 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	s.recordTurnUsage(ctx, routeRes, finalProvider, decision.ServedIdentity(), in, out, cacheCreation, cacheRead)
 
-	if shouldBillInference(proxyErr, in, out) {
+	if shouldBillInference(proxyErr, in, out, cacheCreation, cacheRead) {
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
-		if compResOAI.Summarized {
-			s.billCompactionSummary(ctx, requestID, externalID, compResOAI.SummaryUsage)
-		}
+	}
+	if compResOAI.Summarized {
+		s.billCompactionSummary(ctx, requestID, externalID, compResOAI.SummaryUsage)
 	}
 
 	// See ProxyMessages for the two-strike eviction rationale.

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -4656,7 +4656,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	// No-op when billing is unwired (selfhosted); only reached on a real
 	// upstream call since the cache-hit branch above already returned.
-	if proxyErr == nil && !agentShadowMode {
+	if shouldBillInference(proxyErr, in, out) && !agentShadowMode {
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
 		if compRes.Summarized {
 			s.billCompactionSummary(ctx, requestID, externalID, compRes.SummaryUsage)
@@ -5720,6 +5720,21 @@ func (s *Service) fireTelemetry(p InsertTelemetryParams) {
 			log.Debug("Telemetry insert failed", "err", err)
 		}
 	})
+}
+
+// shouldBillInference reports whether inference tokens were consumed and must
+// be debited. When proxyErr is nil, billing proceeds normally. When proxyErr is
+// non-nil (e.g. client disconnect, context cancellation, or stream drop),
+// billing is still recorded if tokens were actually processed (in > 0 || out > 0)
+// and the error is not an upstream rejection (upstream status < 400).
+func shouldBillInference(proxyErr error, in, out int) bool {
+	if proxyErr == nil {
+		return true
+	}
+	if upstreamStatus(proxyErr) >= 400 {
+		return false
+	}
+	return in > 0 || out > 0
 }
 
 // emitBilling debits the customer for one upstream call and, on switch turns
@@ -7180,7 +7195,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	s.recordTurnUsage(ctx, routeRes, finalProvider, decision.ServedIdentity(), in, out, cacheCreation, cacheRead)
 
-	if proxyErr == nil {
+	if shouldBillInference(proxyErr, in, out) {
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
 		if compResOAI.Summarized {
 			s.billCompactionSummary(ctx, requestID, externalID, compResOAI.SummaryUsage)


### PR DESCRIPTION
﻿## Description

In `ProxyMessages`, `ProxyOpenAIChatCompletion`, and `ProxyGemini`, billing debits were guarded strictly by `if proxyErr == nil`. When streaming clients disconnected early or canceled requests during an in-flight response (e.g., `context.Canceled`, `client disconnected`, `write: broken pipe`), `proxyErr` was non-nil, causing the router to completely discard the billing debit even though upstream providers generated hundreds or thousands of billable tokens.

## Changes

- Added `shouldBillInference(proxyErr error, inTokens, outTokens int) bool` in `internal/proxy/service.go`.
- Ensured billing debits proceed when tokens were consumed (`inTokens > 0 || outTokens > 0`) and the failure was not an upstream HTTP rejection (`upstreamStatus(proxyErr) < 400`).
- Applied `shouldBillInference` consistently across `ProxyMessages`, `ProxyOpenAIChatCompletion`, and `ProxyGemini`.
- Added unit tests in `internal/proxy/byok_billing_internal_test.go` (`TestShouldBillInference`) asserting behavior across nil errors, context cancellations with consumed tokens, broken pipes, and upstream 4xx/5xx errors.

## Verification

- `go test -v ./internal/proxy -run TestShouldBillInference` (passed)
- `go test ./internal/router/policy ./internal/architecture` (passed)
- `go build ./...` (passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes billing debits being skipped when streaming clients disconnect or cancel after tokens were consumed, so providers are correctly debited for billable tokens even when the request ends with an error.

- Records debits when any tokens (fresh, generated, or Anthropic cache) were consumed and the error is not an upstream HTTP rejection (status < 400).
- Decouples compaction summary billing from the main inference outcome so completed summarizer calls are debited even if the client cancels early.
- Applies the new billing check consistently across `ProxyMessages`, `ProxyOpenAIChatCompletion`, and `ProxyGemini`.
- Upstream 4xx/5xx errors and cancellations with zero tokens consumed still do not bill.
- Adds unit tests covering nil errors, context cancellations, broken pipes, cache-only usage, and upstream status errors.

<sup>Written for commit a3aef16318b49693c21d02842e2c1056c49d9d87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weave-os/router/pull/1265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

