### PR TITLE
fix(proxy): enable semantic response cache for self-hosted installations using installation ID

### DIFF
--- a/internal/proxy/cache_tenant_key_internal_test.go
+++ b/internal/proxy/cache_tenant_key_internal_test.go
@@ -1,0 +1,115 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"weave-os/router/internal/providers"
+	"weave-os/router/internal/router"
+	"weave-os/router/internal/router/cache"
+	"weave-os/router/internal/router/policy"
+)
+
+func TestCacheTenantKey(t *testing.T) {
+	instID := uuid.New()
+
+	t.Run("external ID takes priority when present", func(t *testing.T) {
+		assert.Equal(t, "org_12345", cacheTenantKey(instID, "org_12345"))
+	})
+
+	t.Run("installation ID used for self-hosted when external ID is empty", func(t *testing.T) {
+		assert.Equal(t, instID.String(), cacheTenantKey(instID, ""))
+	})
+
+	t.Run("empty string when both are absent", func(t *testing.T) {
+		assert.Empty(t, cacheTenantKey(uuid.Nil, ""))
+	})
+}
+
+func TestSemanticCache_SelfHostedInstallationHit(t *testing.T) {
+	instID := uuid.New()
+	embedding := []float32{1, 0}
+
+	for _, tc := range []struct {
+		name   string
+		format cache.Format
+		body   string
+		invoke func(*Service, context.Context, []byte, http.ResponseWriter, *http.Request) error
+	}{
+		{
+			name:   "messages_anthropic",
+			format: cache.FormatAnthropic,
+			body:   `{"model":"claude-opus-4-8","max_tokens":4096,"messages":[{"role":"user","content":"explain semantic caching"}]}`,
+			invoke: (*Service).ProxyMessages,
+		},
+		{
+			name:   "chat_openai",
+			format: cache.FormatOpenAI,
+			body:   `{"model":"gpt-5","messages":[{"role":"user","content":"explain semantic caching"}]}`,
+			invoke: (*Service).ProxyOpenAIChatCompletion,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			semanticCache := cache.New(cache.DefaultConfig())
+			cachedBody := `{"cached_response":true,"format":"` + string(tc.format) + `"}`
+			semanticCache.Store(
+				instID.String(),
+				tc.format,
+				embedding,
+				1,
+				cache.CachedResponse{StatusCode: http.StatusOK, Body: []byte(cachedBody)},
+				"",
+				0,
+			)
+
+			// Router returns matching metadata with cluster 1 and embedding
+			decision := router.Decision{
+				Provider: providers.ProviderAnthropic,
+				Model:    "claude-haiku-4-5",
+				Metadata: &router.RoutingMetadata{
+					Strategy:   string(router.StrategyHMMEmbedding),
+					Embedding:  embedding,
+					ClusterIDs: []int{1},
+				},
+			}
+			routerMock := &authoritativeTestRouter{decision: decision}
+
+			svc := NewService(routerMock, nil, nil, false, semanticCache, newStubPinStore(), false, providers.ProviderAnthropic, "claude-opus-4-8", nil).
+				WithPolicyStrategy(policy.StrategySpec{
+					Strategy: router.StrategyHMMEmbedding,
+					Router:   routerMock,
+					Capabilities: policy.Capabilities{
+						SchemaVersion: policy.SchemaVersionV1,
+					},
+				})
+
+			// Context has InstallationIDContextKey but NO ExternalIDContextKey (self-hosted mode)
+			ctx := context.Background()
+			ctx = context.WithValue(ctx, InstallationIDContextKey{}, instID.String())
+			ctx = context.WithValue(ctx, APIKeyIDContextKey{}, "test-api-key")
+
+			recorder := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+			err := tc.invoke(svc, ctx, []byte(tc.body), recorder, req)
+			require.NoError(t, err, "self-hosted request must successfully hit semantic cache without provider dispatch")
+			assert.Equal(t, http.StatusOK, recorder.Code)
+			assert.JSONEq(t, cachedBody, recorder.Body.String())
+
+			// A different installation ID must miss the cache and attempt provider dispatch (failing with ErrProviderNotConfigured)
+			otherCtx := context.Background()
+			otherCtx = context.WithValue(otherCtx, InstallationIDContextKey{}, uuid.NewString())
+			otherCtx = context.WithValue(otherCtx, APIKeyIDContextKey{}, "test-api-key")
+
+			otherRecorder := httptest.NewRecorder()
+			otherErr := tc.invoke(svc, otherCtx, []byte(tc.body), otherRecorder, req)
+			require.ErrorIs(t, otherErr, ErrProviderNotConfigured, "different installation ID must miss cache and attempt provider dispatch")
+		})
+	}
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2497,6 +2497,19 @@ func (s *Service) semanticCacheAllowed(ctx context.Context) bool {
 	return !s.authoritativePerTurnSelection(ctx)
 }
 
+// cacheTenantKey derives the cache isolation key for a request. Multi-tenant
+// cloud deployments isolate by external organization ID, while self-hosted
+// and single-tenant deployments isolate by the installation ID.
+func cacheTenantKey(installationID uuid.UUID, externalID string) string {
+	if externalID != "" {
+		return externalID
+	}
+	if installationID != uuid.Nil {
+		return installationID.String()
+	}
+	return ""
+}
+
 // PolicyStrategyAvailable reports whether a strategy has a live router;
 // registration stays visible when a sidecar is absent so callers see the gap.
 func (s *Service) PolicyStrategyAvailable(strategy router.Strategy) bool {
@@ -3544,9 +3557,10 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// Subscription-state conditional model lists are likewise absent from the
 	// cache key, so never cache a request after one has been selected. Plan-aware
 	// exclusions are also absent from the key and must bypass the cache.
-	cacheEligible := routeRes.EscalationOrdinal == 0 && !clientRecoveryApplied && s.semanticCacheAllowed(ctx) && s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !compactionHandoverRan && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0 && !subscriptionConditionalModelsConfigured(ctx) && len(subscriptionPlanAwareExcludedModelsFromContext(ctx)) == 0 && !requestAllowedModelsPresent(ctx)
+	tenantKey := cacheTenantKey(installationID, externalID)
+	cacheEligible := routeRes.EscalationOrdinal == 0 && !clientRecoveryApplied && s.semanticCacheAllowed(ctx) && s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && tenantKey != "" && !bypassEval && !compactionHandoverRan && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0 && !subscriptionConditionalModelsConfigured(ctx) && len(subscriptionPlanAwareExcludedModelsFromContext(ctx)) == 0 && !requestAllowedModelsPresent(ctx)
 	if cacheEligible {
-		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatAnthropic, decision.Metadata.Embedding, decision.Metadata.ClusterIDs, decision.Metadata.ClusterRouterVersion, decision.Metadata.EffectiveKnobsHash); hit {
+		if resp, hit := s.semanticCache.Lookup(tenantKey, cache.FormatAnthropic, decision.Metadata.Embedding, decision.Metadata.ClusterIDs, decision.Metadata.ClusterRouterVersion, decision.Metadata.EffectiveKnobsHash); hit {
 			s.writeCachedResponse(w, resp, decision)
 			otel.Record(ctx, otel.Span{
 				Name:  "router.cache_hit",
@@ -4448,7 +4462,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 				Headers:    cloneCacheHeaders(w.Header()),
 				Body:       body,
 			}
-			s.semanticCache.Store(externalID, cache.FormatAnthropic, decision.Metadata.Embedding, decision.Metadata.ClusterIDs[0], storeResp, decision.Metadata.ClusterRouterVersion, decision.Metadata.EffectiveKnobsHash)
+			s.semanticCache.Store(tenantKey, cache.FormatAnthropic, decision.Metadata.Embedding, decision.Metadata.ClusterIDs[0], storeResp, decision.Metadata.ClusterRouterVersion, decision.Metadata.EffectiveKnobsHash)
 		}
 	}
 
@@ -6217,9 +6231,10 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// See the ProxyMessages cache-eligibility note: subsidized, subscription-state-
 	// conditional, and plan-aware requests bypass the semantic cache because the
 	// key does not capture headroom-dependent model eligibility.
-	cacheEligible := routeRes.EscalationOrdinal == 0 && s.semanticCacheAllowed(ctx) && s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !responsesPassthrough && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0 && !subscriptionConditionalModelsConfigured(ctx) && len(subscriptionPlanAwareExcludedModelsFromContext(ctx)) == 0 && !requestAllowedModelsPresent(ctx)
+	tenantKey := cacheTenantKey(installationID, externalID)
+	cacheEligible := routeRes.EscalationOrdinal == 0 && s.semanticCacheAllowed(ctx) && s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && tenantKey != "" && !bypassEval && !responsesPassthrough && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0 && !subscriptionConditionalModelsConfigured(ctx) && len(subscriptionPlanAwareExcludedModelsFromContext(ctx)) == 0 && !requestAllowedModelsPresent(ctx)
 	if cacheEligible {
-		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatOpenAI, decision.Metadata.Embedding, decision.Metadata.ClusterIDs, decision.Metadata.ClusterRouterVersion, decision.Metadata.EffectiveKnobsHash); hit {
+		if resp, hit := s.semanticCache.Lookup(tenantKey, cache.FormatOpenAI, decision.Metadata.Embedding, decision.Metadata.ClusterIDs, decision.Metadata.ClusterRouterVersion, decision.Metadata.EffectiveKnobsHash); hit {
 			s.writeCachedResponse(w, resp, decision)
 			otel.Record(ctx, otel.Span{
 				Name:  "router.cache_hit",
@@ -7094,7 +7109,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 				Headers:    cloneCacheHeaders(w.Header()),
 				Body:       body,
 			}
-			s.semanticCache.Store(externalID, cache.FormatOpenAI, decision.Metadata.Embedding, decision.Metadata.ClusterIDs[0], storeResp, decision.Metadata.ClusterRouterVersion, decision.Metadata.EffectiveKnobsHash)
+			s.semanticCache.Store(tenantKey, cache.FormatOpenAI, decision.Metadata.Embedding, decision.Metadata.ClusterIDs[0], storeResp, decision.Metadata.ClusterRouterVersion, decision.Metadata.EffectiveKnobsHash)
 		}
 	}
 


### PR DESCRIPTION
﻿## Description

The semantic response cache in `internal/proxy` was 100% disabled in self-hosted and single-tenant deployments because `cacheEligible` hard-required `externalID != ""`. In self-hosted mode there is no Stripe organization ID, so `externalID` is empty. However, every installation has a permanent UUID (`installationID`), and `internal/router/cache` was explicitly designed and documented around isolating cache entries per `installationID`.

## Changes

- Added `cacheTenantKey(installationID uuid.UUID, externalID string) string` helper in `internal/proxy/service.go`. It prioritizes `externalID` when present (multi-tenant cloud orgs) and falls back to `installationID.String()` for self-hosted/single-tenant installations.
- Updated `ProxyMessages` and `ProxyOpenAIChatCompletion` cache eligibility checks, lookups, and stores to use `tenantKey`.
- Added unit tests in `internal/proxy/cache_tenant_key_internal_test.go` covering `TestCacheTenantKey` priority and `TestSemanticCache_SelfHostedInstallationHit` verifying semantic cache hits and tenant isolation for both Anthropic and OpenAI formats without external IDs.

## Verification

- `go test -v ./internal/proxy -run "TestCacheTenantKey|TestSemanticCache_SelfHostedInstallationHit"` (passed)
- `go test ./internal/router/policy ./internal/architecture` (passed)
- `go build ./...` (passed)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the semantic response cache for self-hosted and single-tenant installations, where it was previously always bypassed because cache eligibility required an external Stripe organization ID. The cache key now falls back to the installation UUID when the external ID is empty, isolating cached responses per installation for both Anthropic Messages and OpenAI Chat Completions proxy paths, with tests covering key priority and self-hosted cache hits and tenant isolation.

<sup>Written for commit 832a9475088b5126390e4bf8537baa45765eb1e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weave-os/router/pull/1266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

