### PR TITLE
fix(codex): print the client's own directive sigil, and answer router-session without inference

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -296,8 +296,8 @@ replacement when the bytes are unchanged. The `WEAVE_STATUSLINE_*` variables
 above are accepted as fallbacks for users who configure both clients together.
 
 **Prompt directives are answered by the router.** `$fm`/`$force-model`,
-`$ufm`/`$unforce-model` and `$rf`/`$router-feedback` reach the router; the local
-toggles and `$router-session` do not, and are covered below. Codex sends a
+`$ufm`/`$unforce-model`, `$rf`/`$router-feedback` and `$router-session` reach
+the router; the local toggles do not, and are covered below. Codex sends a
 `$name` invocation as two user messages: the text the user typed, then a second message
 carrying the invoked skill's `SKILL.md`. The router reads the directive out of
 the first one, applies it, and answers with a synthetic response — the same
@@ -309,12 +309,17 @@ why a `$rf - too slow` verdict now survives: nothing paraphrases it.
 router could see the directive behind the skill block. It is retired, and an
 upgrade removes both the hook and its helper.
 
-Two groups stay skill-driven because they are not router state. The local
-toggles (`$router-on`/`$router-off`/`$router-status`/`$router-models`/
-`$disable-routing`) mutate config on disk. `$router-session` prints a
-client-local id, so it never reaches the router and still costs a model turn;
-its script needs `CODEX_SESSION_ID`, and Codex prints the same id in its own
-session banner.
+One group stays skill-driven because it is not router state: the local toggles
+(`$router-on`/`$router-off`/`$router-status`/`$router-models`/
+`$disable-routing`) mutate config on disk, which the router cannot do.
+
+`$router-session` used to be in that group and no longer is. It reported
+`$CODEX_SESSION_ID` from a script, which cost a model turn plus a tool exec and
+failed outright wherever that variable was unset. The router already receives
+the id as `Session-Id` on every request and stores it for analytics joins, so
+it now answers the directive itself — no inference, and the id is by
+construction the one telemetry recorded rather than a client-side guess at it.
+The skill and its script remain installed as a fallback for older routers.
 
 **Codex status integration.** Codex 0.150+ supports lifecycle hooks. The installer enables hooks and adds managed `SessionStart` and `Stop` handlers. They maintain a small local state file and set the terminal title to `Weave Router · <routed-model> ← <requested-model>` when the router provides a routed-model marker. On ordinary turns where the model is unchanged, the title remains the last known routed model; before the first routed response it shows `Weave Router · active`. The hooks intentionally emit no status messages: Codex renders hook output in the conversation, which makes a persistent router indicator noisy and easy to confuse with model output. It is not a replacement for Codex's requested-model line: that line continues to show the model selected in Codex configuration, while the Weave status identifies the model that actually served. Existing user and project hooks remain outside the managed block and are preserved on reinstall/uninstall.
 

--- a/internal/proxy/client_identity.go
+++ b/internal/proxy/client_identity.go
@@ -172,6 +172,23 @@ const (
 	ClientAppOpencode   = "opencode"
 )
 
+// directivePrefix returns the sigil a client's user has to type to reach the
+// router. Codex reserves a leading "/" for its own built-ins: it answers
+// "Unrecognized command" and never forwards the line, so a hint naming the
+// slash form there sends the user down a dead end. Every other client passes
+// "/" through untouched.
+//
+// Ingress accepts both spellings from every client regardless (see
+// translate.parseForceModelCommand) -- this only decides which one we print
+// back. Unknown clients get "/", the form the docs and every non-Codex client
+// use.
+func directivePrefix(clientApp string) string {
+	if clientApp == ClientAppCodex {
+		return "$"
+	}
+	return "/"
+}
+
 // clientAppAliases maps the raw X-App values some clients send to their
 // canonical client_app. Claude Code sends "cli", which would otherwise store
 // verbatim and miss the dashboard's label map.

--- a/internal/proxy/directive_prefix_internal_test.go
+++ b/internal/proxy/directive_prefix_internal_test.go
@@ -1,0 +1,119 @@
+package proxy
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"weave-os/router/internal/providers"
+	"weave-os/router/internal/translate"
+)
+
+// codexCtx stands in for a request that arrived with `X-App: codex`.
+func codexCtx(sessionID string) context.Context {
+	return context.WithValue(context.Background(), ClientIdentityContextKey{},
+		ClientIdentity{ClientApp: ClientAppCodex, SessionID: sessionID})
+}
+
+// The reported bug: Codex users were told "Use /unforce-model to clear", and
+// Codex answers "Unrecognized command '/unforce-model'" because it never
+// forwards a leading slash. The ack must name the form that actually works.
+func TestForceModelCommand_CodexAckNamesTheDollarForm(t *testing.T) {
+	store := &recordingPinStore{}
+	svc := NewService(nil, nil, nil, false, nil, store, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", nil).
+		WithDeploymentKeyedProviders(keyed(providers.ProviderAnthropic))
+
+	env := forceCommandEnv(t)
+	rec := httptest.NewRecorder()
+	require.NoError(t, svc.handleForceModelCommand(codexCtx("sess-1"), rec, env,
+		translate.ForceModelResult{Model: "opus"},
+		uuid.New(), DeriveSessionKey(env, "key-1"), DeriveSessionKey(env, "key-1"), 10))
+
+	body := rec.Body.String()
+	require.Contains(t, body, "force-model applied")
+	assert.Contains(t, body, "$unforce-model")
+	assert.NotContains(t, body, "/unforce-model")
+}
+
+// Claude Code expands and forwards slash commands, so it must keep them.
+func TestForceModelCommand_ClaudeCodeAckKeepsTheSlashForm(t *testing.T) {
+	store := &recordingPinStore{}
+	svc := NewService(nil, nil, nil, false, nil, store, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", nil).
+		WithDeploymentKeyedProviders(keyed(providers.ProviderAnthropic))
+
+	env := forceCommandEnv(t)
+	rec := httptest.NewRecorder()
+	ctx := context.WithValue(context.Background(), ClientIdentityContextKey{},
+		ClientIdentity{ClientApp: ClientAppClaudeCode})
+	require.NoError(t, svc.handleForceModelCommand(ctx, rec, env,
+		translate.ForceModelResult{Model: "opus"},
+		uuid.New(), DeriveSessionKey(env, "key-1"), DeriveSessionKey(env, "key-1"), 10))
+
+	assert.Contains(t, rec.Body.String(), "/unforce-model")
+}
+
+// router-session used to reach no handler at all, so it fell through to a
+// routed turn: the model read the skill, shelled out to emit.sh, and echoed
+// the result. It must answer from the router's own identity instead, with no
+// upstream and no pin store touched.
+func TestRouterSessionCommand_AnswersSyntheticallyFromRequestIdentity(t *testing.T) {
+	store := &recordingPinStore{}
+	svc := NewService(nil, nil, nil, false, nil, store, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", nil)
+
+	env := forceCommandEnv(t)
+	rec := httptest.NewRecorder()
+	require.NoError(t, svc.handleRouterSessionCommand(
+		codexCtx("01a08ca1-6f83-7233-9e53-bc6c07d2a805"), rec, env, 10))
+
+	assert.Contains(t, rec.Body.String(), "01a08ca1-6f83-7233-9e53-bc6c07d2a805")
+	assert.Empty(t, store.upserts, "reporting the session id must not touch routing state")
+}
+
+// Codex answers "Unrecognized command '/unforce-model'" and never forwards the
+// line, so a hint printed to a Codex user has to name the $ form. Every other
+// client sends "/" through.
+func TestDirectivePrefix(t *testing.T) {
+	assert.Equal(t, "$", directivePrefix(ClientAppCodex))
+
+	for _, app := range []string{
+		ClientAppClaudeCode,
+		ClientAppCursor,
+		ClientAppGeminiCLI,
+		ClientAppOpencode,
+		"",
+		"something-unknown",
+	} {
+		assert.Equal(t, "/", directivePrefix(app), "expected slash for %q", app)
+	}
+}
+
+func TestRouterSessionMessage_NamesTheIDAndTheClientsOwnSigil(t *testing.T) {
+	codex := routerSessionMessage("01a08ca1-6f83-7233", ClientAppCodex, translate.FormatOpenAI)
+	assert.Contains(t, codex, "01a08ca1-6f83-7233")
+	assert.Contains(t, codex, "$router-feedback")
+	assert.NotContains(t, codex, "/router-feedback")
+
+	claude := routerSessionMessage("sess-abc", ClientAppClaudeCode, translate.FormatAnthropic)
+	assert.Contains(t, claude, "sess-abc")
+	assert.Contains(t, claude, "/router-feedback")
+	// Anthropic-format acks are formatted as routing markers so
+	// StripRoutingMarkerFromMessages removes them from later requests.
+	assert.Contains(t, claude, routingMarkerPrefix)
+}
+
+// Naming a substitute id would send support at the wrong session, so an
+// absent id has to read as absent.
+func TestRouterSessionMessage_MissingIDSaysSoRatherThanGuessing(t *testing.T) {
+	for _, format := range []translate.Format{translate.FormatOpenAI, translate.FormatAnthropic} {
+		msg := routerSessionMessage("", ClientAppCodex, format)
+		assert.Contains(t, msg, "no session id")
+		assert.NotContains(t, msg, "session id: ")
+	}
+}

--- a/internal/proxy/dispatch_error.go
+++ b/internal/proxy/dispatch_error.go
@@ -120,9 +120,11 @@ func ClassifyDispatchError(err error) (DispatchErrorClass, bool) {
 		// Ahead of the sentinel cases so the reason reaches the caller: a bare
 		// "forced model is excluded" doesn't say which model or why.
 		return DispatchErrorClass{
-			Kind:       DispatchErrorForcedModelExcluded,
-			Status:     http.StatusBadRequest,
-			Message:    forcedExcluded.Reason + ". Clear the force (/unforce-model) or pick a model from a permitted provider.",
+			Kind:   DispatchErrorForcedModelExcluded,
+			Status: http.StatusBadRequest,
+			// Sigil-free on purpose: this classifier has no request context to
+			// read the client from, and Codex never accepts the "/" form.
+			Message:    forcedExcluded.Reason + ". Clear it with the unforce-model directive, or pick a model from a permitted provider.",
 			LogLevel:   "warn",
 			LogMessage: "Rejected request: forced model is excluded on this installation",
 		}, true

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -634,9 +634,10 @@ func (s *Service) applyForceModelCommand(
 	if effortLevel != "" {
 		shownModel = canonicalModel + ":" + effortLevel
 	}
-	msg = fmt.Sprintf("✦ **Weave Router** → force-model applied: %s (%s) · Use /unforce-model to clear\n\n", shownModel, binding)
+	clear := directivePrefix(ClientIdentityFrom(ctx).ClientApp) + "unforce-model"
+	msg = fmt.Sprintf("✦ **Weave Router** → force-model applied: %s (%s) · Use %s to clear\n\n", shownModel, binding, clear)
 	if env.SourceFormat() == translate.FormatOpenAI {
-		msg = fmt.Sprintf("Weave Router: force-model applied: %s (%s). Use /unforce-model to clear.", shownModel, binding)
+		msg = fmt.Sprintf("Weave Router: force-model applied: %s (%s). Use %s to clear.", shownModel, binding, clear)
 	}
 	log.Debug("/force-model: session pin set",
 		"input_model", cmd.Model,

--- a/internal/proxy/force_model_exclusions_internal_test.go
+++ b/internal/proxy/force_model_exclusions_internal_test.go
@@ -416,7 +416,10 @@ func TestClassifyDispatchError_ForcedModelExcluded(t *testing.T) {
 	assert.True(t, cls.Kind.IsClientError(),
 		"an excluded force is a client-input problem, not an upstream failure")
 	assert.Contains(t, cls.Message, "claude-opus-5")
-	assert.Contains(t, cls.Message, "/unforce-model")
+	// Sigil-free: this classifier has no request context to tell a Codex
+	// caller (which needs "$") from a Claude Code one (which needs "/").
+	assert.Contains(t, cls.Message, "unforce-model")
+	assert.NotContains(t, cls.Message, "/unforce-model")
 }
 
 // Desugaring only covers routableUniverse; claude-opus-4-8 is passthrough-only

--- a/internal/proxy/router_feedback.go
+++ b/internal/proxy/router_feedback.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -87,9 +88,10 @@ func (s *Service) handleRouterFeedbackCommand(
 	if rating == "" && feedback == "" {
 		// No verdict and no note. Message is formatted as a routing marker so
 		// StripRoutingMarkerFromMessages strips it from later requests.
-		msg := "✦ **Weave Router** → Router-feedback needs a verdict or a note, e.g. /rf+ or /rf- too slow.\n\n"
+		rf := directivePrefix(ClientIdentityFrom(ctx).ClientApp) + "rf"
+		msg := fmt.Sprintf("✦ **Weave Router** → Router-feedback needs a verdict or a note, e.g. %s+ or %s- too slow.\n\n", rf, rf)
 		if env.SourceFormat() == translate.FormatOpenAI {
-			msg = "Weave Router: router-feedback needs a verdict or a note, e.g. /rf+ or /rf- too slow."
+			msg = fmt.Sprintf("Weave Router: router-feedback needs a verdict or a note, e.g. %s+ or %s- too slow.", rf, rf)
 		}
 		if synthetic {
 			return writeSyntheticCommandResponse(w, env, msg, inputTokens)
@@ -107,9 +109,10 @@ func (s *Service) handleRouterFeedbackCommand(
 		if err != nil {
 			log.Error("/router-feedback: sequence lookup failed", "sequence", cmd.Sequence, "err", err)
 			if errors.Is(err, sql.ErrNoRows) {
-				msg := "✦ **Weave Router** → No turn found at that sequence number. Try `/rf` without a number for the last turn.\n\n"
+				rf := directivePrefix(ClientIdentityFrom(ctx).ClientApp) + "rf"
+				msg := fmt.Sprintf("✦ **Weave Router** → No turn found at that sequence number. Try `%s` without a number for the last turn.\n\n", rf)
 				if env.SourceFormat() == translate.FormatOpenAI {
-					msg = "Weave Router: No turn found at that sequence number. Try `/rf` without a number for the last turn."
+					msg = fmt.Sprintf("Weave Router: No turn found at that sequence number. Try `%s` without a number for the last turn.", rf)
 				}
 				if synthetic {
 					return writeSyntheticCommandResponse(w, env, msg, inputTokens)

--- a/internal/proxy/router_session.go
+++ b/internal/proxy/router_session.go
@@ -1,0 +1,59 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"weave-os/router/internal/observability"
+	"weave-os/router/internal/translate"
+)
+
+// handleRouterSessionCommand answers a router-session directive synthetically,
+// with no upstream call.
+//
+// The id reported is ClientIdentity.SessionID -- the same value the router
+// stores on telemetry and keys session cost lookups by -- so it is the id that
+// actually resolves in the dashboard. Reading it here rather than in a client
+// skill also removes the model turn the skill needed: the directive now costs
+// zero inference, like force-model and router-feedback.
+func (s *Service) handleRouterSessionCommand(
+	ctx context.Context,
+	w http.ResponseWriter,
+	env *translate.RequestEnvelope,
+	inputTokens int,
+) error {
+	log := observability.FromContext(ctx)
+	identity := ClientIdentityFrom(ctx)
+	msg := routerSessionMessage(identity.SessionID, identity.ClientApp, env.SourceFormat())
+
+	log.Debug("/router-session: answered from request identity",
+		"has_session_id", identity.SessionID != "",
+		"client_app", identity.ClientApp,
+	)
+
+	if env.SourceFormat() == translate.FormatOpenAI {
+		return writeSyntheticOpenAIResponse(w, env, msg, inputTokens)
+	}
+	return writeSyntheticAnthropicResponse(w, env, msg, inputTokens)
+}
+
+// routerSessionMessage renders the ack in the marker style each surface uses:
+// OpenAI-format clients (Codex) get plain text, Anthropic-format clients get
+// the ✦ marker the rest of the router's synthetic replies use there.
+func routerSessionMessage(sessionID, clientApp string, format translate.Format) string {
+	if sessionID == "" {
+		// No session header means nothing here is correlated, so naming a
+		// substitute id would point support at the wrong session. Say so.
+		const detail = "no session id on this request. This client did not send one, so its turns are not correlated in router telemetry."
+		if format == translate.FormatOpenAI {
+			return "Weave Router: " + detail
+		}
+		return "✦ **Weave Router** → " + detail + "\n\n"
+	}
+	hint := directivePrefix(clientApp) + "router-feedback"
+	if format == translate.FormatOpenAI {
+		return fmt.Sprintf("Weave Router: session id: %s. Quote it in support requests; %s attaches feedback to this session.", sessionID, hint)
+	}
+	return fmt.Sprintf("✦ **Weave Router** → session id: `%s` · quote it in support requests; `%s` attaches feedback to this session\n\n", sessionID, hint)
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3160,6 +3160,14 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			requestBodyChanged = true
 		}
 	}
+	if !agentShadowMode && env.ExtractRouterSessionCommand() {
+		log.Info("ProxyMessages router-session command")
+		if err := s.handleRouterSessionCommand(ctx, w, env, feats.Tokens); err != nil {
+			return err
+		}
+		s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
+		return nil
+	}
 
 	// Sanitize after command extraction: a skill can encode its command as a
 	// plain user string after an assistant tool_use, and sanitizing first would
@@ -6006,6 +6014,14 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			return nil
 		}
 		requestBodyChanged = true
+	}
+	if env.ExtractRouterSessionCommand() {
+		log.Info("ProxyOpenAIChatCompletion router-session command")
+		if err := s.handleRouterSessionCommand(ctx, w, env, feats.Tokens); err != nil {
+			return err
+		}
+		s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
+		return nil
 	}
 
 	// Sanitize after command extraction: a skill can encode its command as a

--- a/internal/translate/router_session.go
+++ b/internal/translate/router_session.go
@@ -1,0 +1,64 @@
+package translate
+
+import "strings"
+
+// routerSessionTokens are the spellings of the router-session directive.
+// Codex reserves `/…` for its own built-ins and exposes the directive as a
+// `$name` skill, so both sigils are accepted here for the same reason
+// parseForceModelCommand accepts both.
+var routerSessionTokens = [...]string{
+	"/router-session",
+	"$router-session",
+}
+
+// ExtractRouterSessionCommand reports whether the trailing user message opens
+// with a router-session directive, stripping it so no upstream ever sees it.
+//
+// The router is the authority on the answer: the id this returns is the one it
+// recorded for the session, so it cannot disagree with what telemetry stored.
+// The client-side skill this supersedes read $CODEX_SESSION_ID and reported
+// whatever that held, which is a different value (or an error) whenever the
+// environment does not export one -- and cost a model turn plus a tool exec to
+// produce it.
+//
+// Tool-result turns are deliberately excluded (extractLeadingCommand drops
+// them): an agent asking for the session id mid-turn wants it in context, not
+// a synthetic response that ends the turn.
+func (env *RequestEnvelope) ExtractRouterSessionCommand() bool {
+	return env.extractLeadingCommand(parseRouterSessionCommand)
+}
+
+// parseRouterSessionCommand matches the directive on the first non-empty line
+// and returns the text with that line removed. Restricted to the leading line
+// for the same reason as the other directives: pasted transcripts must not be
+// able to fire one. The directive takes no arguments, so a line carrying
+// anything after the token is left alone as ordinary prompt text.
+func parseRouterSessionCommand(text string) (found bool, stripped string) {
+	prefixEnd := leadingInjectedPrefixEnd(text)
+	prefix := text[:prefixEnd]
+	body := text[prefixEnd:]
+
+	lines := strings.Split(body, "\n")
+	cmdIdx := -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		for _, tok := range routerSessionTokens {
+			if trimmed == tok {
+				cmdIdx = i
+				break
+			}
+		}
+		break
+	}
+	if cmdIdx < 0 {
+		return false, text
+	}
+
+	remaining := make([]string, 0, len(lines)-1)
+	remaining = append(remaining, lines[:cmdIdx]...)
+	remaining = append(remaining, lines[cmdIdx+1:]...)
+	return true, strings.TrimSpace(prefix + strings.Join(remaining, "\n"))
+}

--- a/internal/translate/router_session_test.go
+++ b/internal/translate/router_session_test.go
@@ -1,0 +1,53 @@
+package translate_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractRouterSessionCommand_BothSigils(t *testing.T) {
+	for _, directive := range []string{"/router-session", "$router-session"} {
+		t.Run(directive, func(t *testing.T) {
+			env := codexEnvelope(t, codexUserItem(directive))
+			require.True(t, env.ExtractRouterSessionCommand(), "expected %q to be recognized", directive)
+		})
+	}
+}
+
+// The whole point of the directive is that it never reaches a model, so the
+// Codex skill blob that trails the typed text must not hide it -- the same
+// regression #1257 fixed for $fm and $rf.
+func TestExtractRouterSessionCommand_CodexSkillBlobFollowsDirective(t *testing.T) {
+	env := codexEnvelope(t,
+		codexUserItem("$router-session"),
+		codexUserItem("<skill>\nname: router-session\nPrint the session id.\n</skill>"),
+	)
+	require.True(t, env.ExtractRouterSessionCommand())
+}
+
+// A skill block that follows an assistant turn is a real turn, not an
+// attachment; treating it as one would re-fire a directive from an older turn.
+func TestExtractRouterSessionCommand_SkillBlobAfterAssistantIsNotADirective(t *testing.T) {
+	env := codexEnvelope(t,
+		codexUserItem("$router-session"),
+		codexAssistantItem("Weave Router: session id: abc-123."),
+		codexUserItem("<skill>\nname: router-session\n</skill>"),
+	)
+	assert.False(t, env.ExtractRouterSessionCommand())
+}
+
+func TestExtractRouterSessionCommand_IgnoresNonLeadingAndArgumentForms(t *testing.T) {
+	for name, text := range map[string]string{
+		"not on the leading line": "here is a transcript\n$router-session",
+		"pasted with a prefix":    "see `$router-session` for the id",
+		"carries an argument":     "$router-session please",
+		"different directive":     "$router-status",
+	} {
+		t.Run(name, func(t *testing.T) {
+			env := codexEnvelope(t, codexUserItem(text))
+			assert.False(t, env.ExtractRouterSessionCommand(), "should not match %q", text)
+		})
+	}
+}


### PR DESCRIPTION
Two Codex directive bugs, both caught in a live session.

## 1. We printed a sigil Codex rejects

`$fm astra` was acknowledged with **"Use `/unforce-model` to clear"** — and Codex's very next line was:

```
Unrecognized command '/unforce-model'. Type "/" for a list of supported commands.
```

Codex reserves a leading `/` for its own built-ins and never forwards the line, so every hint naming the slash form sent the user down a dead end. Four sites hardcoded it: the force-model ack, both router-feedback error hints, and the excluded-force dispatch error.

`directivePrefix(clientApp)` picks the sigil from the client identity already on the request context. This follows `feedbackFooterTextCodex`, which had solved exactly this for the rating footer — it was the one hint that already got it right, which is why the footer in the screenshot below reads `$rf` while the ack above it reads `/unforce-model`.

Ingress is unchanged: `parseForceModelCommand` accepts both spellings from every client. This only changes what we print back.

`ClassifyDispatchError` has no request context and many callers, so rather than thread `ctx` through for one HTTP error body, its hint drops the sigil — "Clear it with the unforce-model directive" is true everywhere.

## 2. `$router-session` bought an inference turn to answer a question we already knew

It was declared `capability=prompt` in `directives.tsv`, but no parser or handler was ever written — so it fell through to an ordinary routed turn. The model read the skill, shelled out to `emit.sh`, and echoed `$CODEX_SESSION_ID`: one inference turn, one tool exec, and a hard failure wherever that variable is unset.

The router receives that same id as `Session-Id` on every request and stores it for analytics joins — the skill's own docs said so. It now answers the directive synthetically from `ClientIdentity.SessionID`. No upstream call, and the id is by construction the one telemetry recorded rather than a client-side guess at it.

An absent id reports itself as absent; naming a substitute would point support at the wrong session.

The extractor reuses `extractLeadingCommand`, so it inherits the skill-blob skip from #1257 and the tool-result exclusion for free. The skill and its script stay installed as a fallback for older routers, matching how #1257 left `force-model` and `router-feedback`.

## What the session looked like before

```
› $fm astra
• Weave Router: force-model applied: gpt-6-astra (openai). Use /unforce-model to clear.
• Unrecognized command '/unforce-model'. Type "/" for a list of supported commands.

› $router-session
• + Weave Router → gpt-5.6-luna · best pick for this turn      ← a routed turn
• Ran /Users/…/.codex/skills/router-session/scripts/emit.sh    ← and a tool exec
  └ 01a08ca1-6f83-7233-9e53-bc6c07d2a805
```

Both now resolve with zero upstream dispatch, and the ack names `$unforce-model`.

## Validation

From the WorkWeave root, per the router guide:

- `wv router tc` — clean
- `wv router t` — green, no failures

From `router-internal/router/`:

- `go vet ./...`, `gofmt -l` — clean
- `make test-install` — 22 passed, 0 failed
- `make check-docs`, `make check-agent-guides`, `make inference-boundary` — pass

New regression tests cover both sigils on ingress, the skill-blob-follows-directive case, the "skill blob after an assistant turn is a real turn" case, the Codex vs Claude Code ack wording, and that reporting a session id touches no routing state.

## Not included

No installer change, so this ships through the gitlink alone — no npm release needed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two Codex directive bugs: hints now print the client's own sigil (`$` for Codex, `/` for others) instead of a slash form Codex rejects, and `$router-session` now answers synthetically from the router's request identity instead of costing a model turn.

- `$fm`, `$rf`, and `$router-session` acks and error hints name the form the client actually accepts.
- The excluded-force dispatch error drops the sigil entirely since it has no client context.
- `$router-session` reads the `Session-Id` header the router already records for telemetry, so the reported id matches what's in the dashboard; an absent id says so rather than guessing.
- The client-side skill remains installed as a fallback for older routers.

<sup>Written for commit 6f4e620d00fd69354271af2772872652d5dd83e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weave-os/router/pull/1267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

