### PR TITLE
feat(codex): answer a bare router-models directive server-side

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -310,8 +310,20 @@ router could see the directive behind the skill block. It is retired, and an
 upgrade removes both the hook and its helper.
 
 One group stays skill-driven because it is not router state: the local toggles
-(`$router-on`/`$router-off`/`$router-status`/`$router-models`/
-`$disable-routing`) mutate config on disk, which the router cannot do.
+(`$router-on`/`$router-off`/`$router-status`/`$disable-routing`) mutate config
+on disk, which the router cannot do.
+
+`$router-models` is split. A **bare** invocation is a read, and the router
+answers it directly — with more than the skill could: `weave-router models`
+gets a 404 from the admin API on a managed router and degrades to the plain
+catalog, which is why it has to print "this router does not report which of
+them your installation has enabled". The installation's exclusions are on the
+request, so the router marks each row `[x]`/`[ ]` instead. Anything with
+arguments (`enable`, `disable`, `prefer`, `providers`) still goes to the skill:
+those hit `/admin/v1/*`, which requires an admin session and rejects the `rk_`
+data-plane key a chat request carries — deliberately, so a leaked key cannot
+rewrite routing config. The registry still lists it as `local-toggle` because
+that column names the adapter its mutating path needs.
 
 `$router-session` used to be in that group and no longer is. It reported
 `$CODEX_SESSION_ID` from a script, which cost a model turn plus a tool exec and

--- a/internal/proxy/router_models.go
+++ b/internal/proxy/router_models.go
@@ -30,13 +30,19 @@ func (s *Service) handleRouterModelsCommand(
 	log := observability.FromContext(ctx)
 	routable := s.RoutableModels()
 	excluded := s.excludedModelsForRequest(ctx)
+	// Deployment-wide automatic exclusions are a separate, softer set: the
+	// router may not CHOOSE these, but an explicit force still serves them.
+	// Folding them into `excluded` would claim they are unusable; leaving
+	// them out would claim they are routable. They get their own marker.
+	automaticExcluded := s.globalAutomaticExcludedModels(ctx)
 
 	log.Debug("/router-models: answered from the request's own routing view",
 		"routable", len(routable),
 		"excluded", len(excluded),
+		"automatic_excluded", len(automaticExcluded),
 	)
 
-	msg := routerModelsMessage(routable, excluded,
+	msg := routerModelsMessage(routable, excluded, automaticExcluded,
 		directivePrefix(ClientIdentityFrom(ctx).ClientApp), env.SourceFormat())
 	if env.SourceFormat() == translate.FormatOpenAI {
 		return writeSyntheticOpenAIResponse(w, env, msg, inputTokens)
@@ -48,7 +54,14 @@ func (s *Service) handleRouterModelsCommand(
 // primary provider, marking what this installation may actually be routed to.
 // The [x]/[ ] form matches what `weave-router models` prints, so the two
 // surfaces stay recognizably the same listing.
-func routerModelsMessage(routable, excluded map[string]struct{}, prefix string, format translate.Format) string {
+//
+// [-] is the third state, and it exists because the two model-restriction
+// layers differ in kind: [ ] is an org exclusion or a model outside the
+// allowlist, which nothing can route to, while [-] is a deployment-wide
+// automatic exclusion the scorer honours but an explicit force ignores. The
+// legend is printed only when at least one model is in that state, so the
+// common listing is unchanged.
+func routerModelsMessage(routable, excluded, automaticExcluded map[string]struct{}, prefix string, format translate.Format) string {
 	if len(routable) == 0 {
 		const detail = "no routable models are configured on this router."
 		if format == translate.FormatOpenAI {
@@ -75,15 +88,20 @@ func routerModelsMessage(routable, excluded map[string]struct{}, prefix string, 
 
 	var b strings.Builder
 	enabled := 0
+	forceOnly := 0
 	for _, p := range providers {
 		models := byProvider[p]
 		sort.Strings(models)
 		b.WriteString("\n" + p + "\n")
 		for _, id := range models {
 			mark := "x"
-			if _, off := excluded[id]; off {
+			switch {
+			case contains(excluded, id):
 				mark = " "
-			} else {
+			case contains(automaticExcluded, id):
+				mark = "-"
+				forceOnly++
+			default:
 				enabled++
 			}
 			b.WriteString(fmt.Sprintf("  [%s] %s\n", mark, id))
@@ -96,9 +114,20 @@ func routerModelsMessage(routable, excluded map[string]struct{}, prefix string, 
 	footer := fmt.Sprintf(
 		"\n%d of %d routable here. Change the selection with `%srouter-models enable <id>` or `%srouter-models disable <id>`.",
 		enabled, len(routable), prefix, prefix)
+	if forceOnly > 0 {
+		footer += fmt.Sprintf(
+			"\n[-] means automatic routing is disabled for that model deployment-wide; %sforce-model still serves it.",
+			prefix)
+	}
 
 	if format == translate.FormatOpenAI {
 		return fmt.Sprintf("Weave Router: models this installation can be routed to.\n%s%s", b.String(), footer)
 	}
 	return fmt.Sprintf("✦ **Weave Router** → models this installation can be routed to\n```\n%s```\n%s\n\n", b.String(), footer)
+}
+
+// contains keeps the three-way mark switch readable; a nil map is empty.
+func contains(set map[string]struct{}, id string) bool {
+	_, ok := set[id]
+	return ok
 }

--- a/internal/proxy/router_models.go
+++ b/internal/proxy/router_models.go
@@ -1,0 +1,104 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"weave-os/router/internal/observability"
+	"weave-os/router/internal/router/catalog"
+	"weave-os/router/internal/translate"
+)
+
+// handleRouterModelsCommand answers a bare router-models directive
+// synthetically, with no upstream call.
+//
+// This reports strictly more than the skill it replaces. The skill shells out
+// to `weave-router models`, which on a managed router gets a 404 from the
+// admin API and degrades to the unauthenticated catalog -- a flat list that
+// has to tell the user "this router does not report which of them your
+// installation has enabled". The exclusions ARE on this request, so the
+// router can mark each row instead of disclaiming the question.
+func (s *Service) handleRouterModelsCommand(
+	ctx context.Context,
+	w http.ResponseWriter,
+	env *translate.RequestEnvelope,
+	inputTokens int,
+) error {
+	log := observability.FromContext(ctx)
+	routable := s.RoutableModels()
+	excluded := s.excludedModelsForRequest(ctx)
+
+	log.Debug("/router-models: answered from the request's own routing view",
+		"routable", len(routable),
+		"excluded", len(excluded),
+	)
+
+	msg := routerModelsMessage(routable, excluded,
+		directivePrefix(ClientIdentityFrom(ctx).ClientApp), env.SourceFormat())
+	if env.SourceFormat() == translate.FormatOpenAI {
+		return writeSyntheticOpenAIResponse(w, env, msg, inputTokens)
+	}
+	return writeSyntheticAnthropicResponse(w, env, msg, inputTokens)
+}
+
+// routerModelsMessage renders the routable universe grouped by each model's
+// primary provider, marking what this installation may actually be routed to.
+// The [x]/[ ] form matches what `weave-router models` prints, so the two
+// surfaces stay recognizably the same listing.
+func routerModelsMessage(routable, excluded map[string]struct{}, prefix string, format translate.Format) string {
+	if len(routable) == 0 {
+		const detail = "no routable models are configured on this router."
+		if format == translate.FormatOpenAI {
+			return "Weave Router: " + detail
+		}
+		return "✦ **Weave Router** → " + detail + "\n\n"
+	}
+
+	byProvider := make(map[string][]string, len(routable))
+	for id := range routable {
+		provider := "other"
+		if m, ok := catalog.ByID(id); ok {
+			if p := m.PrimaryProvider(); p != "" {
+				provider = p
+			}
+		}
+		byProvider[provider] = append(byProvider[provider], id)
+	}
+	providers := make([]string, 0, len(byProvider))
+	for p := range byProvider {
+		providers = append(providers, p)
+	}
+	sort.Strings(providers)
+
+	var b strings.Builder
+	enabled := 0
+	for _, p := range providers {
+		models := byProvider[p]
+		sort.Strings(models)
+		b.WriteString("\n" + p + "\n")
+		for _, id := range models {
+			mark := "x"
+			if _, off := excluded[id]; off {
+				mark = " "
+			} else {
+				enabled++
+			}
+			b.WriteString(fmt.Sprintf("  [%s] %s\n", mark, id))
+		}
+	}
+
+	// The mutating subcommands stay on the skill (they need admin auth the
+	// chat key deliberately lacks), so the footer has to name the real path
+	// rather than imply this directive can change anything.
+	footer := fmt.Sprintf(
+		"\n%d of %d routable here. Change the selection with `%srouter-models enable <id>` or `%srouter-models disable <id>`.",
+		enabled, len(routable), prefix, prefix)
+
+	if format == translate.FormatOpenAI {
+		return fmt.Sprintf("Weave Router: models this installation can be routed to.\n%s%s", b.String(), footer)
+	}
+	return fmt.Sprintf("✦ **Weave Router** → models this installation can be routed to\n```\n%s```\n%s\n\n", b.String(), footer)
+}

--- a/internal/proxy/router_models_internal_test.go
+++ b/internal/proxy/router_models_internal_test.go
@@ -23,6 +23,7 @@ func TestRouterModelsMessage_MarksExcludedRowsOff(t *testing.T) {
 	msg := routerModelsMessage(
 		set("claude-opus-5", "gpt-5.5"),
 		set("gpt-5.5"),
+		nil,
 		"$", translate.FormatOpenAI)
 
 	assert.Contains(t, msg, "[x] claude-opus-5")
@@ -31,18 +32,18 @@ func TestRouterModelsMessage_MarksExcludedRowsOff(t *testing.T) {
 }
 
 func TestRouterModelsMessage_UsesTheClientsOwnSigilInTheFooter(t *testing.T) {
-	codex := routerModelsMessage(set("claude-opus-5"), nil, "$", translate.FormatOpenAI)
+	codex := routerModelsMessage(set("claude-opus-5"), nil, nil, "$", translate.FormatOpenAI)
 	assert.Contains(t, codex, "$router-models enable")
 	assert.NotContains(t, codex, "/router-models enable")
 
-	claude := routerModelsMessage(set("claude-opus-5"), nil, "/", translate.FormatAnthropic)
+	claude := routerModelsMessage(set("claude-opus-5"), nil, nil, "/", translate.FormatAnthropic)
 	assert.Contains(t, claude, "/router-models enable")
 	assert.Contains(t, claude, routingMarkerPrefix)
 }
 
 func TestRouterModelsMessage_EmptyUniverseSaysSo(t *testing.T) {
 	for _, format := range []translate.Format{translate.FormatOpenAI, translate.FormatAnthropic} {
-		msg := routerModelsMessage(nil, nil, "$", format)
+		msg := routerModelsMessage(nil, nil, nil, "$", format)
 		assert.Contains(t, msg, "no routable models")
 		assert.NotContains(t, msg, "[x]")
 	}
@@ -53,8 +54,34 @@ func TestRouterModelsMessage_EmptyUniverseSaysSo(t *testing.T) {
 // between turns rather than reordering with Go's map iteration.
 func TestRouterModelsMessage_IsDeterministicallyOrdered(t *testing.T) {
 	models := set("claude-opus-5", "claude-haiku-4-5", "gpt-5.5", "gemini-3-pro-preview")
-	first := routerModelsMessage(models, nil, "$", translate.FormatOpenAI)
+	first := routerModelsMessage(models, nil, nil, "$", translate.FormatOpenAI)
 	for range 8 {
-		assert.Equal(t, first, routerModelsMessage(models, nil, "$", translate.FormatOpenAI))
+		assert.Equal(t, first, routerModelsMessage(models, nil, nil, "$", translate.FormatOpenAI))
 	}
+}
+
+// A deployment-wide automatic exclusion is not an org exclusion: the scorer
+// will not pick the model, but an explicit force still serves it. Collapsing
+// the two into [x]/[ ] would have claimed one or the other.
+func TestRouterModelsMessage_AutomaticExclusionGetsItsOwnMark(t *testing.T) {
+	msg := routerModelsMessage(
+		set("claude-opus-5", "gpt-5.5", "gemini-3-pro-preview"),
+		set("gemini-3-pro-preview"),
+		set("gpt-5.5"),
+		"$", translate.FormatOpenAI)
+
+	assert.Contains(t, msg, "[x] claude-opus-5")
+	assert.Contains(t, msg, "[-] gpt-5.5", "automatic exclusion is force-only, not off")
+	assert.Contains(t, msg, "[ ] gemini-3-pro-preview", "an org exclusion is off outright")
+	// Only the freely-routable one counts as enabled.
+	assert.Contains(t, msg, "1 of 3 routable here")
+	assert.Contains(t, msg, "$force-model still serves it")
+}
+
+// The legend is noise on the overwhelmingly common listing, so it only
+// appears when something is actually in that state.
+func TestRouterModelsMessage_NoAutomaticExclusionsMeansNoLegend(t *testing.T) {
+	msg := routerModelsMessage(set("claude-opus-5"), nil, nil, "$", translate.FormatOpenAI)
+	assert.NotContains(t, msg, "[-]")
+	assert.NotContains(t, msg, "still serves it")
 }

--- a/internal/proxy/router_models_internal_test.go
+++ b/internal/proxy/router_models_internal_test.go
@@ -1,0 +1,60 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"weave-os/router/internal/translate"
+)
+
+func set(ids ...string) map[string]struct{} {
+	out := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		out[id] = struct{}{}
+	}
+	return out
+}
+
+// The whole point of answering server-side: the skill's managed-router path
+// degrades to a flat catalog and has to say it cannot report what is enabled.
+// The exclusions are on the request here, so each row gets marked.
+func TestRouterModelsMessage_MarksExcludedRowsOff(t *testing.T) {
+	msg := routerModelsMessage(
+		set("claude-opus-5", "gpt-5.5"),
+		set("gpt-5.5"),
+		"$", translate.FormatOpenAI)
+
+	assert.Contains(t, msg, "[x] claude-opus-5")
+	assert.Contains(t, msg, "[ ] gpt-5.5")
+	assert.Contains(t, msg, "1 of 2 routable here")
+}
+
+func TestRouterModelsMessage_UsesTheClientsOwnSigilInTheFooter(t *testing.T) {
+	codex := routerModelsMessage(set("claude-opus-5"), nil, "$", translate.FormatOpenAI)
+	assert.Contains(t, codex, "$router-models enable")
+	assert.NotContains(t, codex, "/router-models enable")
+
+	claude := routerModelsMessage(set("claude-opus-5"), nil, "/", translate.FormatAnthropic)
+	assert.Contains(t, claude, "/router-models enable")
+	assert.Contains(t, claude, routingMarkerPrefix)
+}
+
+func TestRouterModelsMessage_EmptyUniverseSaysSo(t *testing.T) {
+	for _, format := range []translate.Format{translate.FormatOpenAI, translate.FormatAnthropic} {
+		msg := routerModelsMessage(nil, nil, "$", format)
+		assert.Contains(t, msg, "no routable models")
+		assert.NotContains(t, msg, "[x]")
+	}
+}
+
+// Grouping is by the model's primary catalog binding, and both the group
+// order and the ids inside a group are sorted so the listing is stable
+// between turns rather than reordering with Go's map iteration.
+func TestRouterModelsMessage_IsDeterministicallyOrdered(t *testing.T) {
+	models := set("claude-opus-5", "claude-haiku-4-5", "gpt-5.5", "gemini-3-pro-preview")
+	first := routerModelsMessage(models, nil, "$", translate.FormatOpenAI)
+	for range 8 {
+		assert.Equal(t, first, routerModelsMessage(models, nil, "$", translate.FormatOpenAI))
+	}
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3184,6 +3184,14 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
 		return nil
 	}
+	if !agentShadowMode && env.ExtractRouterModelsCommand() {
+		log.Info("ProxyMessages router-models command")
+		if err := s.handleRouterModelsCommand(ctx, w, env, feats.Tokens); err != nil {
+			return err
+		}
+		s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
+		return nil
+	}
 
 	// Sanitize after command extraction: a skill can encode its command as a
 	// plain user string after an assistant tool_use, and sanitizing first would
@@ -6039,6 +6047,14 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	if env.ExtractRouterSessionCommand() {
 		log.Info("ProxyOpenAIChatCompletion router-session command")
 		if err := s.handleRouterSessionCommand(ctx, w, env, feats.Tokens); err != nil {
+			return err
+		}
+		s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
+		return nil
+	}
+	if env.ExtractRouterModelsCommand() {
+		log.Info("ProxyOpenAIChatCompletion router-models command")
+		if err := s.handleRouterModelsCommand(ctx, w, env, feats.Tokens); err != nil {
 			return err
 		}
 		s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))

--- a/internal/translate/force_model.go
+++ b/internal/translate/force_model.go
@@ -393,41 +393,6 @@ func cutAnyPrefix(text string, prefixes ...string) (after string, ok bool) {
 // and complete <tag>...</tag> blocks. Only simple attribute-free tag names are
 // recognized, so pasted XML/HTML containing a stray /force-model line can't
 // satisfy the guard; unclosed or attribute-bearing tags stop the scan.
-// isOnlyKnownInjectedText reports whether text holds nothing but the wrapper
-// blocks a client injects around a user's message.
-//
-// Deliberately stricter than isOnlyInjectedCommandText, which delegates to
-// leadingInjectedPrefixEnd and therefore accepts ANY well-formed
-// <name>...</name>. That is fine where the text still reaches a model, but a
-// directive that short-circuits the turn must not decide that arbitrary
-// tagged text the user wrote is synthetic and drop it -- pasting
-// "<error>...</error>" under a directive would lose it silently.
-//
-// Claude Code appends its own wrappers to user messages, so those still have
-// to pass; only the names in claudeCodeInjectedBlockPrefixes do.
-func isOnlyKnownInjectedText(text string) bool {
-	rest := strings.TrimSpace(text)
-	for rest != "" {
-		// Checks the LEADING tag against the known set, then consumes exactly
-		// that block: leadingInjectedPrefixEnd would run past an unknown block
-		// sitting behind a known one.
-		if !isClaudeCodeInjectedBlock(rest) {
-			return false
-		}
-		gt := strings.Index(rest, ">")
-		if gt < 0 {
-			return false
-		}
-		closeTag := "</" + rest[1:gt] + ">"
-		closeIdx := strings.Index(rest[gt+1:], closeTag)
-		if closeIdx < 0 {
-			return false
-		}
-		rest = strings.TrimSpace(rest[gt+1+closeIdx+len(closeTag):])
-	}
-	return true
-}
-
 func leadingInjectedPrefixEnd(text string) int {
 	i := 0
 	for i < len(text) {
@@ -467,6 +432,41 @@ func leadingInjectedPrefixEnd(text string) int {
 		i = nameEnd + 1 + closeIdx + len(closeTag)
 	}
 	return i
+}
+
+// isOnlyKnownInjectedText reports whether text holds nothing but the wrapper
+// blocks a client injects around a user's message.
+//
+// Deliberately stricter than isOnlyInjectedCommandText, which delegates to
+// leadingInjectedPrefixEnd and therefore accepts ANY well-formed
+// <name>...</name>. That is fine where the text still reaches a model, but a
+// directive that short-circuits the turn must not decide that arbitrary
+// tagged text the user wrote is synthetic and drop it -- pasting
+// "<error>...</error>" under a directive would lose it silently.
+//
+// Claude Code appends its own wrappers to user messages, so those still have
+// to pass; only the names in claudeCodeInjectedBlockPrefixes do.
+func isOnlyKnownInjectedText(text string) bool {
+	rest := strings.TrimSpace(text)
+	for rest != "" {
+		// Checks the LEADING tag against the known set, then consumes exactly
+		// that block: leadingInjectedPrefixEnd would run past an unknown block
+		// sitting behind a known one.
+		if !isClaudeCodeInjectedBlock(rest) {
+			return false
+		}
+		gt := strings.Index(rest, ">")
+		if gt < 0 {
+			return false
+		}
+		closeTag := "</" + rest[1:gt] + ">"
+		closeIdx := strings.Index(rest[gt+1:], closeTag)
+		if closeIdx < 0 {
+			return false
+		}
+		rest = strings.TrimSpace(rest[gt+1+closeIdx+len(closeTag):])
+	}
+	return true
 }
 
 func isTagNameByte(c byte, first bool) bool {

--- a/internal/translate/force_model.go
+++ b/internal/translate/force_model.go
@@ -393,6 +393,41 @@ func cutAnyPrefix(text string, prefixes ...string) (after string, ok bool) {
 // and complete <tag>...</tag> blocks. Only simple attribute-free tag names are
 // recognized, so pasted XML/HTML containing a stray /force-model line can't
 // satisfy the guard; unclosed or attribute-bearing tags stop the scan.
+// isOnlyKnownInjectedText reports whether text holds nothing but the wrapper
+// blocks a client injects around a user's message.
+//
+// Deliberately stricter than isOnlyInjectedCommandText, which delegates to
+// leadingInjectedPrefixEnd and therefore accepts ANY well-formed
+// <name>...</name>. That is fine where the text still reaches a model, but a
+// directive that short-circuits the turn must not decide that arbitrary
+// tagged text the user wrote is synthetic and drop it -- pasting
+// "<error>...</error>" under a directive would lose it silently.
+//
+// Claude Code appends its own wrappers to user messages, so those still have
+// to pass; only the names in claudeCodeInjectedBlockPrefixes do.
+func isOnlyKnownInjectedText(text string) bool {
+	rest := strings.TrimSpace(text)
+	for rest != "" {
+		// Checks the LEADING tag against the known set, then consumes exactly
+		// that block: leadingInjectedPrefixEnd would run past an unknown block
+		// sitting behind a known one.
+		if !isClaudeCodeInjectedBlock(rest) {
+			return false
+		}
+		gt := strings.Index(rest, ">")
+		if gt < 0 {
+			return false
+		}
+		closeTag := "</" + rest[1:gt] + ">"
+		closeIdx := strings.Index(rest[gt+1:], closeTag)
+		if closeIdx < 0 {
+			return false
+		}
+		rest = strings.TrimSpace(rest[gt+1+closeIdx+len(closeTag):])
+	}
+	return true
+}
+
 func leadingInjectedPrefixEnd(text string) int {
 	i := 0
 	for i < len(text) {

--- a/internal/translate/router_models.go
+++ b/internal/translate/router_models.go
@@ -64,7 +64,7 @@ func parseRouterModelsCommand(text string) (found bool, stripped string) {
 	// and for router-models it would silently drop a mutating argument split
 	// across lines ("$router-models\nenable gpt-5.5"), answering with a bare
 	// listing instead of falling through to the skill that can apply it.
-	if !isOnlyInjectedCommandText(stripped) {
+	if !isOnlyKnownInjectedText(stripped) {
 		return false, text
 	}
 	return true, stripped

--- a/internal/translate/router_models.go
+++ b/internal/translate/router_models.go
@@ -58,5 +58,14 @@ func parseRouterModelsCommand(text string) (found bool, stripped string) {
 	remaining := make([]string, 0, len(lines)-1)
 	remaining = append(remaining, lines[:cmdIdx]...)
 	remaining = append(remaining, lines[cmdIdx+1:]...)
-	return true, strings.TrimSpace(prefix + strings.Join(remaining, "\n"))
+	stripped = strings.TrimSpace(prefix + strings.Join(remaining, "\n"))
+	// Nothing but the directive may remain. Matching the token alone and
+	// discarding the rest would swallow whatever the user wrote under it --
+	// and for router-models it would silently drop a mutating argument split
+	// across lines ("$router-models\nenable gpt-5.5"), answering with a bare
+	// listing instead of falling through to the skill that can apply it.
+	if !isOnlyInjectedCommandText(stripped) {
+		return false, text
+	}
+	return true, stripped
 }

--- a/internal/translate/router_models.go
+++ b/internal/translate/router_models.go
@@ -1,0 +1,62 @@
+package translate
+
+import "strings"
+
+// routerModelsTokens are the spellings of the router-models directive and its
+// `models` alias, in both sigils. Codex reserves `/…` for its own built-ins
+// and exposes the directive as a `$name` skill, so both are accepted for the
+// same reason parseForceModelCommand accepts both.
+var routerModelsTokens = [...]string{
+	"/router-models",
+	"$router-models",
+	"/models",
+	"$models",
+}
+
+// ExtractRouterModelsCommand reports whether the trailing user message is a
+// bare router-models directive, stripping it so no upstream ever sees it.
+//
+// Bare only, and that restriction is load-bearing. Listing is a read the
+// router can answer from the request it is already holding. Mutating the
+// selection (`enable`/`disable`/`prefer`/`providers`) is an admin operation:
+// those endpoints sit behind WithAdminOnly, which rejects the rk_ data-plane
+// key a chat request carries precisely so a leaked key cannot rewrite routing
+// config. Answering an argument form here would either be a no-op or a hole
+// through that boundary, so anything with arguments falls through to the
+// skill, which shells out to the installer and authenticates properly.
+func (env *RequestEnvelope) ExtractRouterModelsCommand() bool {
+	return env.extractLeadingCommand(parseRouterModelsCommand)
+}
+
+// parseRouterModelsCommand matches a bare directive on the first non-empty
+// line and returns the text with that line removed. Restricted to the leading
+// line so a pasted transcript cannot fire one.
+func parseRouterModelsCommand(text string) (found bool, stripped string) {
+	prefixEnd := leadingInjectedPrefixEnd(text)
+	prefix := text[:prefixEnd]
+	body := text[prefixEnd:]
+
+	lines := strings.Split(body, "\n")
+	cmdIdx := -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		for _, tok := range routerModelsTokens {
+			if trimmed == tok {
+				cmdIdx = i
+				break
+			}
+		}
+		break
+	}
+	if cmdIdx < 0 {
+		return false, text
+	}
+
+	remaining := make([]string, 0, len(lines)-1)
+	remaining = append(remaining, lines[:cmdIdx]...)
+	remaining = append(remaining, lines[cmdIdx+1:]...)
+	return true, strings.TrimSpace(prefix + strings.Join(remaining, "\n"))
+}

--- a/internal/translate/router_models_test.go
+++ b/internal/translate/router_models_test.go
@@ -44,6 +44,23 @@ func TestExtractRouterModelsCommand_CodexSkillBlobFollowsDirective(t *testing.T)
 	require.True(t, env.ExtractRouterModelsCommand())
 }
 
+// An argument on its own line is still an argument. Matching the bare token
+// and dropping the rest would answer with a listing while silently discarding
+// the mutation the user asked for.
+func TestExtractRouterModelsCommand_ArgumentOnTheNextLineStillFallsThrough(t *testing.T) {
+	for _, text := range []string{
+		"$router-models\nenable gpt-5.5",
+		"$router-models\n\ndisable gpt-5.5",
+		"/router-models\nprefer claude-opus-5",
+	} {
+		t.Run(text, func(t *testing.T) {
+			env := codexEnvelope(t, codexUserItem(text))
+			assert.False(t, env.ExtractRouterModelsCommand(),
+				"%q carries a mutating argument and must reach the skill", text)
+		})
+	}
+}
+
 func TestExtractRouterModelsCommand_IgnoresNonLeadingUses(t *testing.T) {
 	for name, text := range map[string]string{
 		"not on the leading line": "notes below\n$router-models",

--- a/internal/translate/router_models_test.go
+++ b/internal/translate/router_models_test.go
@@ -1,0 +1,57 @@
+package translate_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractRouterModelsCommand_BareFormsInBothSigils(t *testing.T) {
+	for _, directive := range []string{
+		"/router-models", "$router-models", "/models", "$models",
+	} {
+		t.Run(directive, func(t *testing.T) {
+			env := codexEnvelope(t, codexUserItem(directive))
+			require.True(t, env.ExtractRouterModelsCommand(), "expected %q to be recognized", directive)
+		})
+	}
+}
+
+// Mutation needs admin auth the chat key deliberately lacks, so an argument
+// form must fall through to the skill rather than be answered here.
+func TestExtractRouterModelsCommand_ArgumentFormsFallThroughToTheSkill(t *testing.T) {
+	for _, text := range []string{
+		"$router-models enable gpt-5.5",
+		"$router-models disable gpt-5.5",
+		"$router-models prefer claude-opus-5 gpt-5.5",
+		"$router-models providers",
+		"$models enable gpt-5.5",
+	} {
+		t.Run(text, func(t *testing.T) {
+			env := codexEnvelope(t, codexUserItem(text))
+			assert.False(t, env.ExtractRouterModelsCommand(),
+				"%q mutates admin state and must not be short-circuited", text)
+		})
+	}
+}
+
+func TestExtractRouterModelsCommand_CodexSkillBlobFollowsDirective(t *testing.T) {
+	env := codexEnvelope(t,
+		codexUserItem("$router-models"),
+		codexUserItem("<skill>\nname: router-models\nList the models.\n</skill>"),
+	)
+	require.True(t, env.ExtractRouterModelsCommand())
+}
+
+func TestExtractRouterModelsCommand_IgnoresNonLeadingUses(t *testing.T) {
+	for name, text := range map[string]string{
+		"not on the leading line": "notes below\n$router-models",
+		"mentioned inline":        "run `$router-models` to see the list",
+	} {
+		t.Run(name, func(t *testing.T) {
+			env := codexEnvelope(t, codexUserItem(text))
+			assert.False(t, env.ExtractRouterModelsCommand(), "should not match %q", text)
+		})
+	}
+}

--- a/internal/translate/router_models_test.go
+++ b/internal/translate/router_models_test.go
@@ -72,3 +72,34 @@ func TestExtractRouterModelsCommand_IgnoresNonLeadingUses(t *testing.T) {
 		})
 	}
 }
+
+// A tag is not a licence to discard. leadingInjectedPrefixEnd accepts any
+// well-formed <name>...</name>, so the earlier guard treated arbitrary tagged
+// text as synthetic and dropped it -- here, a mutating argument.
+func TestExtractRouterModelsCommand_TaggedArgumentIsNotSynthetic(t *testing.T) {
+	for _, text := range []string{
+		"$router-models\n<foo>enable gpt-5.5</foo>",
+		"$router-models\n<note>disable gpt-5.5</note>",
+	} {
+		t.Run(text, func(t *testing.T) {
+			env := codexEnvelope(t, codexUserItem(text))
+			assert.False(t, env.ExtractRouterModelsCommand(),
+				"%q is the user's text, not a client wrapper", text)
+		})
+	}
+}
+
+// The client's OWN wrappers still have to pass, or the directive breaks for
+// every Claude Code user: it appends these to user messages.
+func TestExtractRouterModelsCommand_ClientWrappersStillCount(t *testing.T) {
+	for _, text := range []string{
+		"/router-models\n<system-reminder>be concise</system-reminder>",
+		"<command-name>/router-models</command-name>\n/router-models",
+	} {
+		t.Run(text, func(t *testing.T) {
+			env := codexEnvelope(t, codexUserItem(text))
+			assert.True(t, env.ExtractRouterModelsCommand(),
+				"%q carries only client-injected wrappers", text)
+		})
+	}
+}

--- a/internal/translate/router_session.go
+++ b/internal/translate/router_session.go
@@ -65,7 +65,7 @@ func parseRouterSessionCommand(text string) (found bool, stripped string) {
 	// so matching the token alone and discarding the rest would swallow
 	// whatever the user wrote under it -- "$router-session\nand what has this
 	// session cost?" would answer the first line and drop the question.
-	if !isOnlyInjectedCommandText(stripped) {
+	if !isOnlyKnownInjectedText(stripped) {
 		return false, text
 	}
 	return true, stripped

--- a/internal/translate/router_session.go
+++ b/internal/translate/router_session.go
@@ -60,5 +60,13 @@ func parseRouterSessionCommand(text string) (found bool, stripped string) {
 	remaining := make([]string, 0, len(lines)-1)
 	remaining = append(remaining, lines[:cmdIdx]...)
 	remaining = append(remaining, lines[cmdIdx+1:]...)
-	return true, strings.TrimSpace(prefix + strings.Join(remaining, "\n"))
+	stripped = strings.TrimSpace(prefix + strings.Join(remaining, "\n"))
+	// Nothing but the directive may remain. The short-circuit ends the turn,
+	// so matching the token alone and discarding the rest would swallow
+	// whatever the user wrote under it -- "$router-session\nand what has this
+	// session cost?" would answer the first line and drop the question.
+	if !isOnlyInjectedCommandText(stripped) {
+		return false, text
+	}
+	return true, stripped
 }

--- a/internal/translate/router_session_test.go
+++ b/internal/translate/router_session_test.go
@@ -38,6 +38,21 @@ func TestExtractRouterSessionCommand_SkillBlobAfterAssistantIsNotADirective(t *t
 	assert.False(t, env.ExtractRouterSessionCommand())
 }
 
+// The short-circuit ends the turn, so a directive carrying anything else must
+// not fire -- the rest of the message would never reach a model.
+func TestExtractRouterSessionCommand_DoesNotSwallowTrailingPrompt(t *testing.T) {
+	for _, text := range []string{
+		"$router-session\nand what has this session cost?",
+		"$router-session\n\nalso summarize the diff",
+	} {
+		t.Run(text, func(t *testing.T) {
+			env := codexEnvelope(t, codexUserItem(text))
+			assert.False(t, env.ExtractRouterSessionCommand(),
+				"%q would lose the user's question", text)
+		})
+	}
+}
+
 func TestExtractRouterSessionCommand_IgnoresNonLeadingAndArgumentForms(t *testing.T) {
 	for name, text := range map[string]string{
 		"not on the leading line": "here is a transcript\n$router-session",

--- a/internal/translate/router_session_test.go
+++ b/internal/translate/router_session_test.go
@@ -66,3 +66,23 @@ func TestExtractRouterSessionCommand_IgnoresNonLeadingAndArgumentForms(t *testin
 		})
 	}
 }
+
+// Same guard as router-models: a pasted <error>...</error> under the directive
+// is the user's text, and short-circuiting would lose it entirely.
+func TestExtractRouterSessionCommand_TaggedTrailingTextIsNotSynthetic(t *testing.T) {
+	for _, text := range []string{
+		"$router-session\n<error>stack trace here</error>",
+		"$router-session\n<log>what happened?</log>",
+	} {
+		t.Run(text, func(t *testing.T) {
+			env := codexEnvelope(t, codexUserItem(text))
+			assert.False(t, env.ExtractRouterSessionCommand(),
+				"%q would lose the user's text", text)
+		})
+	}
+}
+
+func TestExtractRouterSessionCommand_ClientWrappersStillCount(t *testing.T) {
+	env := codexEnvelope(t, codexUserItem("/router-session\n<system-reminder>be concise</system-reminder>"))
+	assert.True(t, env.ExtractRouterSessionCommand())
+}


### PR DESCRIPTION
A bare `$router-models` / `/router-models` (and the `models` alias) is a read, and the router can answer it from the request it is already holding. It now does — the fourth directive to stop costing a model turn, after `force-model`, `router-feedback` and `router-session`.

## The listing got better, not just cheaper

The skill shells out to `weave-router models`, which asks `/admin/v1/models`. On a **managed** router that API isn't mounted at all, so it 404s, degrades to the unauthenticated catalog, and has to print:

> This router does not report which of them your installation has enabled: selection is an organization-wide setting here.

The installation's exclusions are already on the chat request. So the router can just answer the question:

```
anthropic
  [x] claude-opus-5
  [x] claude-haiku-4-5
openai
  [ ] gpt-5.5

2 of 3 routable here. Change the selection with `$router-models enable <id>` …
```

Grouping is by primary catalog binding, with both group order and ids sorted, so the listing doesn't reshuffle between turns on Go's map iteration — there's a test that pins that.

## Only the bare form, and that's the point

`enable` / `disable` / `prefer` / `providers` are admin operations. Those endpoints sit behind `WithAdminOnly`, whose comment says exactly why:

> Mutations: admin cookie REQUIRED. `rk_` tokens are rejected so a leaked data-plane key can't mint fresh router keys or rotate provider credentials.

A chat request carries an `rk_` key. Answering an argument form server-side would be a no-op on managed and **a hole through that boundary** on self-hosted, so anything with arguments falls through to the skill, which authenticates properly. The synthetic footer names that path so the user isn't left guessing.

## Behaviour change worth flagging

Previously a bare `$router-models` started an interactive model turn — it listed models and could take "now turn off gpt-5.5" as a follow-up in the same breath. Now the bare form is a static answer and the change is a second directive. That's the trade for zero inference; I think it's the right one, since the follow-up was never guaranteed to be interpreted the way the user meant, but it is a change.

`directives.tsv` still lists `router-models` as `local-toggle`. That column names the adapter the mutating path needs, and the skill has to keep shipping for it — flipping it to `prompt` would pull it into `weave_registry_skill_names` and change adapter generation. The hybrid is documented in `install/README.md` instead.

## Validation

From the WorkWeave root, per the router guide:

- `wv router tc` — clean
- `wv router t` — green

From `router-internal/router/`:

- `go build ./...`, `go vet ./internal/...`, `gofmt -l` — clean
- `make test-install` — 22 passed, 0 failed
- `make check-docs` — pass

New tests cover all four spellings on ingress, argument forms falling through, the Codex skill-blob case, non-leading uses being ignored, `[x]`/`[ ]` marking against exclusions, per-client footer sigil, the empty-universe case, and ordering determinism.

## Not included

No installer change, so this ships through the gitlink alone — no npm release.

The four genuine local toggles (`$router-on` / `$router-off` / `$router-status` / `$disable-routing`) still cost two turns each; they mutate config on disk, so the router cannot answer them at all. Those need a client-side hook and are a separate change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Answers a bare `$router-models` / `/router-models` (and `models` alias) directive server-side, so it no longer costs a model turn. The listing now marks each model `[x]`/`[ ]`/`[-]` against the installation's restrictions instead of degrading to a flat catalog that can't report what's enabled.

**Behavior change**
- A bare `$router-models` used to accept follow-ups like "now turn off gpt-5.5" in the same turn; it's now a static answer, so that's a second directive.
- A directive with anything else under it is no longer treated as bare: `$router-models\nenable gpt-5.5` falls through to the skill instead of silently dropping the mutation, and `$router-session` with a following question no longer answers the first line and discards the rest.
- Trailing text is only ignored when it's one of the client's own wrappers (`<system-reminder>` and friends); pasted tags like `<error>...</error>` or `<foo>enable gpt-5.5</foo>` now fall through instead of being swallowed.
- `[-]` marks a deployment-wide automatic exclusion, which the scorer won't pick but an explicit `force-model` still serves; the legend only prints when a model is in that state.

**Admin boundary**
- Only bare forms are short-circuited. `enable`/`disable`/`prefer`/`providers` fall through to the skill because they hit admin endpoints that reject the chat request's `rk_` key.

<sup>Written for commit 7155b75695f86a14d5c78aac263632cacdb80407. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weave-os/router/pull/1269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

