### PR TITLE
refactor(translate): one bare-directive parser, not one per directive

### DIFF
--- a/internal/translate/bare_directive.go
+++ b/internal/translate/bare_directive.go
@@ -1,0 +1,57 @@
+package translate
+
+import "strings"
+
+// parseBareDirective matches one of tokens, alone on the first non-empty line
+// of text, and returns the text with that line removed.
+//
+// Shared by every directive whose only form is the bare token (router-models,
+// router-session). They had a copy each, and the copies were the hazard
+// rather than the duplication itself: the same two defects had to be fixed
+// twice, once per file, and a third fix reaching only one of them would have
+// left the directives silently inconsistent.
+//
+// Two rules, both load-bearing:
+//
+// Leading line only, so a pasted transcript that happens to contain a
+// directive cannot fire one.
+//
+// Nothing but the directive may remain. These callers short-circuit the turn,
+// so anything left over reaches no model at all -- "$router-models\nenable
+// gpt-5.5" would answer with a bare listing and drop the mutation, and
+// "$router-session\nand what has this cost?" would drop the question. Only a
+// client's own wrapper blocks may remain, via isOnlyKnownInjectedText;
+// arbitrary tagged text is the user's, not synthetic.
+func parseBareDirective(text string, tokens []string) (found bool, stripped string) {
+	prefixEnd := leadingInjectedPrefixEnd(text)
+	prefix := text[:prefixEnd]
+	body := text[prefixEnd:]
+
+	lines := strings.Split(body, "\n")
+	cmdIdx := -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		for _, tok := range tokens {
+			if trimmed == tok {
+				cmdIdx = i
+				break
+			}
+		}
+		break
+	}
+	if cmdIdx < 0 {
+		return false, text
+	}
+
+	remaining := make([]string, 0, len(lines)-1)
+	remaining = append(remaining, lines[:cmdIdx]...)
+	remaining = append(remaining, lines[cmdIdx+1:]...)
+	stripped = strings.TrimSpace(prefix + strings.Join(remaining, "\n"))
+	if !isOnlyKnownInjectedText(stripped) {
+		return false, text
+	}
+	return true, stripped
+}

--- a/internal/translate/bare_directive_test.go
+++ b/internal/translate/bare_directive_test.go
@@ -1,0 +1,58 @@
+package translate_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"weave-os/router/internal/translate"
+)
+
+// The duplication this replaced was a drift hazard, not just repetition: the
+// same two defects had to be fixed twice, once per copy. This pins the shared
+// rules against BOTH directives at once, so a rule that reaches one and not
+// the other fails here rather than shipping as an inconsistency.
+func TestBareDirectives_ShareTheSameRules(t *testing.T) {
+	extractors := map[string]struct {
+		token   string
+		extract func(*translate.RequestEnvelope) bool
+	}{
+		"router-models":  {"$router-models", (*translate.RequestEnvelope).ExtractRouterModelsCommand},
+		"router-session": {"$router-session", (*translate.RequestEnvelope).ExtractRouterSessionCommand},
+	}
+
+	for name, e := range extractors {
+		t.Run(name, func(t *testing.T) {
+			fires := func(text string) bool {
+				return e.extract(codexEnvelope(t, codexUserItem(text)))
+			}
+
+			assert.True(t, fires(e.token), "the bare directive must fire")
+
+			// Leading line only.
+			assert.False(t, fires("pasted transcript\n"+e.token),
+				"a directive below other text is not a directive")
+			assert.False(t, fires("see `"+e.token+"` for details"),
+				"a mention inside prose is not a directive")
+
+			// Nothing but the directive may remain: these short-circuit the
+			// turn, so a leftover reaches no model.
+			assert.False(t, fires(e.token+" and something"),
+				"a same-line tail must fall through")
+			assert.False(t, fires(e.token+"\nand something"),
+				"a next-line tail must fall through")
+			assert.False(t, fires(e.token+"\n<foo>tagged text</foo>"),
+				"arbitrary tagged text is the user's, not a client wrapper")
+
+			// ...except the client's own wrappers, which it appends itself.
+			assert.True(t, fires(e.token+"\n<system-reminder>be brief</system-reminder>"),
+				"a known client wrapper must not stop the directive")
+
+			// Codex appends the skill blob as a second user message.
+			assert.True(t, e.extract(codexEnvelope(t,
+				codexUserItem(e.token),
+				codexUserItem("<skill>\nname: x\n</skill>"),
+			)), "the Codex skill attachment must not hide the directive")
+		})
+	}
+}

--- a/internal/translate/router_models.go
+++ b/internal/translate/router_models.go
@@ -1,7 +1,5 @@
 package translate
 
-import "strings"
-
 // routerModelsTokens are the spellings of the router-models directive and its
 // `models` alias, in both sigils. Codex reserves `/…` for its own built-ins
 // and exposes the directive as a `$name` skill, so both are accepted for the
@@ -28,44 +26,8 @@ func (env *RequestEnvelope) ExtractRouterModelsCommand() bool {
 	return env.extractLeadingCommand(parseRouterModelsCommand)
 }
 
-// parseRouterModelsCommand matches a bare directive on the first non-empty
-// line and returns the text with that line removed. Restricted to the leading
-// line so a pasted transcript cannot fire one.
+// parseRouterModelsCommand recognizes the bare directive; parseBareDirective holds the
+// rules, so a fix there reaches every directive at once.
 func parseRouterModelsCommand(text string) (found bool, stripped string) {
-	prefixEnd := leadingInjectedPrefixEnd(text)
-	prefix := text[:prefixEnd]
-	body := text[prefixEnd:]
-
-	lines := strings.Split(body, "\n")
-	cmdIdx := -1
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" {
-			continue
-		}
-		for _, tok := range routerModelsTokens {
-			if trimmed == tok {
-				cmdIdx = i
-				break
-			}
-		}
-		break
-	}
-	if cmdIdx < 0 {
-		return false, text
-	}
-
-	remaining := make([]string, 0, len(lines)-1)
-	remaining = append(remaining, lines[:cmdIdx]...)
-	remaining = append(remaining, lines[cmdIdx+1:]...)
-	stripped = strings.TrimSpace(prefix + strings.Join(remaining, "\n"))
-	// Nothing but the directive may remain. Matching the token alone and
-	// discarding the rest would swallow whatever the user wrote under it --
-	// and for router-models it would silently drop a mutating argument split
-	// across lines ("$router-models\nenable gpt-5.5"), answering with a bare
-	// listing instead of falling through to the skill that can apply it.
-	if !isOnlyKnownInjectedText(stripped) {
-		return false, text
-	}
-	return true, stripped
+	return parseBareDirective(text, routerModelsTokens[:])
 }

--- a/internal/translate/router_session.go
+++ b/internal/translate/router_session.go
@@ -1,7 +1,5 @@
 package translate
 
-import "strings"
-
 // routerSessionTokens are the spellings of the router-session directive.
 // Codex reserves `/…` for its own built-ins and exposes the directive as a
 // `$name` skill, so both sigils are accepted here for the same reason
@@ -28,45 +26,8 @@ func (env *RequestEnvelope) ExtractRouterSessionCommand() bool {
 	return env.extractLeadingCommand(parseRouterSessionCommand)
 }
 
-// parseRouterSessionCommand matches the directive on the first non-empty line
-// and returns the text with that line removed. Restricted to the leading line
-// for the same reason as the other directives: pasted transcripts must not be
-// able to fire one. The directive takes no arguments, so a line carrying
-// anything after the token is left alone as ordinary prompt text.
+// parseRouterSessionCommand recognizes the bare directive; parseBareDirective holds the
+// rules, so a fix there reaches every directive at once.
 func parseRouterSessionCommand(text string) (found bool, stripped string) {
-	prefixEnd := leadingInjectedPrefixEnd(text)
-	prefix := text[:prefixEnd]
-	body := text[prefixEnd:]
-
-	lines := strings.Split(body, "\n")
-	cmdIdx := -1
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" {
-			continue
-		}
-		for _, tok := range routerSessionTokens {
-			if trimmed == tok {
-				cmdIdx = i
-				break
-			}
-		}
-		break
-	}
-	if cmdIdx < 0 {
-		return false, text
-	}
-
-	remaining := make([]string, 0, len(lines)-1)
-	remaining = append(remaining, lines[:cmdIdx]...)
-	remaining = append(remaining, lines[cmdIdx+1:]...)
-	stripped = strings.TrimSpace(prefix + strings.Join(remaining, "\n"))
-	// Nothing but the directive may remain. The short-circuit ends the turn,
-	// so matching the token alone and discarding the rest would swallow
-	// whatever the user wrote under it -- "$router-session\nand what has this
-	// session cost?" would answer the first line and drop the question.
-	if !isOnlyKnownInjectedText(stripped) {
-		return false, text
-	}
-	return true, stripped
+	return parseBareDirective(text, routerSessionTokens[:])
 }


### PR DESCRIPTION
`parseRouterModelsCommand` and `parseRouterSessionCommand` differed only in their name and their token slice — 38 near-identical lines each:

```
< func parseRouterModelsCommand(...)        > func parseRouterSessionCommand(...)
< for _, tok := range routerModelsTokens    > for _, tok := range routerSessionTokens
```

Everything else was the same algorithm, twice.

## The duplication wasn't the problem — the drift was

Both copies had to be fixed for the same two defects, in turn:

1. A directive with a second line still counted as bare, so `$router-models\nenable gpt-5.5` answered with a listing and dropped the mutation ([#1269](https://github.com/weave-os/router/pull/1269), `8b3b37e`).
2. Arbitrary tagged text was classed as synthetic, so `$router-session\n<error>…</error>` reached no model at all (`0c3f280`).

Each fix had to be applied twice. A third one reaching only one copy would have left the two directives silently inconsistent — which is exactly what cubic flagged, and the near-miss had already happened twice.

## What changed

`parseBareDirective(text, tokens)` holds the rules once. Both callers become one delegating line.

A new test asserts the shared rules against **both** directives in the same table — leading-line-only, no leftover text, arbitrary tags rejected, known client wrappers accepted, Codex skill attachment tolerated. A rule that reaches one directive and not the other now fails here instead of shipping.

## No behaviour change

Every existing test is untouched and passes — that's the point of the diff, and the evidence for it:

- `go test ./internal/translate/... ./internal/proxy/...` — all green
- 88 passing assertions across the directive suites, none modified
- `go build`, `go vet`, `gofmt` — clean

## Why it's here and not in #1270

cubic raised it on [#1270](https://github.com/weave-os/router/pull/1270), but by then the code had already merged to `main` via #1269, and #1270 is installer-only. Folding a `internal/translate` refactor into it would have muddied that diff for no reason.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates the two bare-directive parsers (`parseRouterModelsCommand`, `parseRouterSessionCommand`) into a single `parseBareDirective` that takes the token set. No behavior change; all existing tests pass.

**Refactors**
- Removes ~80 duplicated lines across `router_models.go` and `router_session.go`.
- Adds a shared table test asserting both directives follow identical rules, so a fix that reaches only one copy fails here.

<sup>Written for commit cd1684ff630eeb0999c3b85175b6366f604c106a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weave-os/router/pull/1271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

