### PR TITLE
fix(proxy): bound bookkeeping without delaying inference

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -446,8 +446,16 @@ func main() {
 	for name := range providerMap {
 		availableProviders[name] = struct{}{}
 	}
+	attemptSink := proxy.NewAttemptSink(repo.Telemetry, logger)
+	defer func() {
+		drainCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+		if err := attemptSink.Shutdown(drainCtx); err != nil {
+			logger.Warn("Inference attempt shutdown incomplete", "err", err, "dropped", attemptSink.Dropped())
+		}
+	}()
 	inferenceExecutor, err := dispatch.NewExecutor(dispatch.NewClients(providerMap),
-		dispatch.WithAttemptSink(proxy.NewAttemptSink(repo.Telemetry, logger)))
+		dispatch.WithAttemptSink(attemptSink))
 	if err != nil {
 		panic(fmt.Sprintf("inference executor: %v", err))
 	}
@@ -1339,10 +1347,10 @@ func main() {
 		logger.Info("Received shutdown signal; draining", "signal", sig.String())
 	}
 
-	// Cloud Run gives 10s between SIGTERM and SIGKILL; budget across three
+	// Cloud Run gives 10s between SIGTERM and SIGKILL; budget across four
 	// flush stages (defer on apm.Shutdown would never run in time):
 	//   srv.Shutdown 6.0s + emitter.Shutdown 1.5s + apm.Shutdown 1.5s = 9.0s,
-	//   leaving ~1s slack.
+	//   plus attemptSink.Shutdown 0.5s, leaving ~0.5s slack.
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
 	defer cancel()
 	if err := srv.Shutdown(shutdownCtx); err != nil {

--- a/internal/observability/global_logger_budget_test.go
+++ b/internal/observability/global_logger_budget_test.go
@@ -39,7 +39,7 @@ var globalLoggerBudget = map[string]int{
 
 	// Fire-and-forget writebacks (SafeGo) + a pure predicate. Documented in
 	// root CLAUDE.md as the off-request-path exception.
-	"internal/proxy": 4,
+	"internal/proxy": 2,
 	"internal/auth":  2,
 
 	// Allocation failures inside LRU construction and a row-parse fallback:

--- a/internal/proxy/AGENTS.md
+++ b/internal/proxy/AGENTS.md
@@ -246,6 +246,20 @@ Per-attempt body rebuild: each closure constructs `EmitOptions` with `TargetProv
 - Cancel/deadline classified as non-retryable: client disconnect or per-request budget elapse must not waste a second upstream call.
 - After dispatch, `actPricing` is re-resolved against the WINNING binding via `catalog.PriceFor(finalProvider, decision.Model)` so debits and OTel `cost.actual_*` reflect the actually-served provider's per-1M rate (the catalog's `PrimaryPriceFor` would otherwise always return the primary's).
 
+## Persistence and response completion
+
+Attempt diagnostics use `AttemptSink`: one ordered worker, a 1,024-event queue,
+250ms writes, and a 500ms shutdown drain owned by composition. Queue saturation,
+write failures and shutdown losses are counted and logged; they never delay
+provider retries. Events retain immutable provenance and a request logger, not
+credentials or a request context. This queue is not a durable billing ledger.
+
+Session mutations remain synchronous and ordered, with 250ms cancellation-independent
+contexts rather than unbounded background writes. Successful buffered responses
+are released after cost headers are known and before post-response bookkeeping;
+Responses finalization is once-only. Required billing retains its existing bounded
+synchronous debit and reconciliation logging. A failed write is not durable success.
+
 ## Fast-tier dispatch (`fast_mode_models`)
 
 An installation opts catalog models into the provider's paid fast tier via `PUT /admin/v1/fast-mode-models` (`auth.Installation.FastModeModels`, carried in ctx under `InstallationFastModeModelsContextKey`). [`fastModeForAttempt`](fastmode.go) decides **per attempt** — against the attempt's own ctx, model, and binding — whether `EmitOptions.FastMode` is set: the model must be listed, the `(provider, model)` binding must publish a `FastPrice` (first-party OpenAI → `service_tier:"priority"`, first-party Anthropic → `speed:"fast"` + beta; gateways never), and the resolved credential must not be a subscription OAuth token (Weave does not bill those turns). Raw passthrough is untouched.

--- a/internal/proxy/CLAUDE.md
+++ b/internal/proxy/CLAUDE.md
@@ -246,6 +246,20 @@ Per-attempt body rebuild: each closure constructs `EmitOptions` with `TargetProv
 - Cancel/deadline classified as non-retryable: client disconnect or per-request budget elapse must not waste a second upstream call.
 - After dispatch, `actPricing` is re-resolved against the WINNING binding via `catalog.PriceFor(finalProvider, decision.Model)` so debits and OTel `cost.actual_*` reflect the actually-served provider's per-1M rate (the catalog's `PrimaryPriceFor` would otherwise always return the primary's).
 
+## Persistence and response completion
+
+Attempt diagnostics use `AttemptSink`: one ordered worker, a 1,024-event queue,
+250ms writes, and a 500ms shutdown drain owned by composition. Queue saturation,
+write failures and shutdown losses are counted and logged; they never delay
+provider retries. Events retain immutable provenance and a request logger, not
+credentials or a request context. This queue is not a durable billing ledger.
+
+Session mutations remain synchronous and ordered, with 250ms cancellation-independent
+contexts rather than unbounded background writes. Successful buffered responses
+are released after cost headers are known and before post-response bookkeeping;
+Responses finalization is once-only. Required billing retains its existing bounded
+synchronous debit and reconciliation logging. A failed write is not durable success.
+
 ## Fast-tier dispatch (`fast_mode_models`)
 
 An installation opts catalog models into the provider's paid fast tier via `PUT /admin/v1/fast-mode-models` (`auth.Installation.FastModeModels`, carried in ctx under `InstallationFastModeModelsContextKey`). [`fastModeForAttempt`](fastmode.go) decides **per attempt** — against the attempt's own ctx, model, and binding — whether `EmitOptions.FastMode` is set: the model must be listed, the `(provider, model)` binding must publish a `FastPrice` (first-party OpenAI → `service_tier:"priority"`, first-party Anthropic → `speed:"fast"` + beta; gateways never), and the resolved credential must not be a subscription OAuth token (Weave does not bill those turns). Raw passthrough is untouched.

--- a/internal/proxy/attempt_sink.go
+++ b/internal/proxy/attempt_sink.go
@@ -1,0 +1,148 @@
+package proxy
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"weave-os/router/internal/inference"
+	"weave-os/router/internal/observability"
+)
+
+const (
+	attemptQueueSize    = 1024
+	attemptWriteTimeout = 250 * time.Millisecond
+)
+
+// AttemptSink persists diagnostic events in order without blocking dispatch.
+// It is not a billing ledger; saturation and failed writes drop events.
+// The owner must call Shutdown before closing the store.
+type AttemptSink struct {
+	store        InferenceAttemptStore
+	log          *slog.Logger
+	queue        chan attemptRecord
+	done         chan struct{}
+	cancel       context.CancelFunc
+	closeMu      sync.RWMutex
+	closed       bool
+	dropped      atomic.Uint64
+	writeTimeout time.Duration
+}
+
+type attemptRecord struct {
+	params InsertInferenceAttemptParams
+	log    *slog.Logger
+}
+
+// NewAttemptSink starts a single ordered persistence worker. Store calls must
+// respect context cancellation; a stuck store never blocks RecordAttempt.
+func NewAttemptSink(store InferenceAttemptStore, log *slog.Logger) *AttemptSink {
+	return newAttemptSink(store, log, attemptQueueSize, attemptWriteTimeout)
+}
+
+func newAttemptSink(store InferenceAttemptStore, log *slog.Logger, capacity int, timeout time.Duration) *AttemptSink {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &AttemptSink{store: store, log: log, queue: make(chan attemptRecord, capacity), done: make(chan struct{}), cancel: cancel, writeTimeout: timeout}
+	go s.run(ctx)
+	return s
+}
+
+// RecordAttempt snapshots only event values and the request logger, never the
+// credential-bearing request context. Enqueue is nonblocking, including shutdown.
+func (s *AttemptSink) RecordAttempt(ctx context.Context, event inference.AttemptEvent) {
+	if s.store == nil {
+		return
+	}
+	installationID, _ := ctx.Value(InstallationIDContextKey{}).(string)
+	if installationID == "" {
+		return
+	}
+	record := attemptRecord{params: InsertInferenceAttemptParams{InstallationID: installationID, Event: event}, log: observability.FromContext(ctx)}
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
+	if s.closed {
+		s.dropped.Add(1)
+		return
+	}
+	select {
+	case s.queue <- record:
+	default:
+		s.dropped.Add(1)
+	}
+}
+
+// Dropped reports events lost to saturation, failed writes or shutdown.
+func (s *AttemptSink) Dropped() uint64 { return s.dropped.Load() }
+
+// Shutdown stops enqueueing and drains until ctx expires, then cancels the
+// in-flight write and discards pending events. Concurrent calls are safe.
+func (s *AttemptSink) Shutdown(ctx context.Context) error {
+	s.closeMu.Lock()
+	if !s.closed {
+		s.closed = true
+		close(s.queue)
+	}
+	s.closeMu.Unlock()
+	select {
+	case <-s.done:
+		return nil
+	case <-ctx.Done():
+		s.cancel()
+		return ctx.Err()
+	}
+}
+
+func (s *AttemptSink) run(ctx context.Context) {
+	defer close(s.done)
+	defer s.cancel()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			s.dropped.Add(1)
+			s.log.Error("Attempt persistence worker panicked", "panic", recovered)
+			s.closeMu.Lock()
+			if !s.closed {
+				s.closed = true
+				close(s.queue)
+			}
+			s.closeMu.Unlock()
+			for range s.queue {
+				s.dropped.Add(1)
+			}
+		}
+		if dropped := s.Dropped(); dropped > 0 {
+			s.log.Warn("Inference attempt events dropped", "count", dropped)
+		}
+	}()
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	var reported uint64
+	for {
+		var record attemptRecord
+		select {
+		case <-ticker.C:
+			if dropped := s.Dropped(); dropped != reported {
+				s.log.Warn("Inference attempt events dropped", "count", dropped)
+				reported = dropped
+			}
+			continue
+		case queued, ok := <-s.queue:
+			if !ok {
+				return
+			}
+			record = queued
+		}
+		if ctx.Err() != nil {
+			s.dropped.Add(1)
+			continue
+		}
+		writeCtx, cancel := context.WithTimeout(ctx, s.writeTimeout)
+		err := s.store.InsertInferenceAttempt(writeCtx, record.params)
+		cancel()
+		if err != nil {
+			s.dropped.Add(1)
+			record.log.Warn("Inference attempt persistence failed", "operation_id", record.params.Event.OperationID, "attempt_index", record.params.Event.AttemptIndex, "err", err)
+		}
+	}
+}

--- a/internal/proxy/attempt_sink_test.go
+++ b/internal/proxy/attempt_sink_test.go
@@ -1,0 +1,209 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"weave-os/router/internal/dispatch"
+	"weave-os/router/internal/inference"
+	"weave-os/router/internal/providers"
+	"weave-os/router/internal/router/catalog"
+)
+
+type attemptStoreFunc func(context.Context, InsertInferenceAttemptParams) error
+
+func (f attemptStoreFunc) InsertInferenceAttempt(ctx context.Context, p InsertInferenceAttemptParams) error {
+	return f(ctx, p)
+}
+
+const attemptInstallation = "00000000-0000-0000-0000-000000000001"
+
+func attemptContext() context.Context {
+	return context.WithValue(context.Background(), InstallationIDContextKey{}, attemptInstallation)
+}
+
+func attemptTestLog() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+func TestAttemptSinkSaturationPreservesAcceptedOrder(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		started, release := make(chan struct{}), make(chan struct{})
+		var saved []InsertInferenceAttemptParams
+		store := attemptStoreFunc(func(ctx context.Context, p InsertInferenceAttemptParams) error {
+			if p.Event.AttemptIndex == 0 {
+				close(started)
+				select {
+				case <-release:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+			saved = append(saved, p)
+			return nil
+		})
+		sink := newAttemptSink(store, attemptTestLog(), 1, time.Second)
+		ctx, cancel := context.WithCancel(attemptContext())
+		cancel()
+		event := inference.AttemptEvent{OperationID: "operation-a", AttemptIndex: 0, Outcome: inference.AttemptOutcomeFailed}
+		sink.RecordAttempt(ctx, event)
+		<-started
+		event.AttemptIndex, event.Outcome = 1, inference.AttemptOutcomeServed
+		sink.RecordAttempt(ctx, event)
+		event.AttemptIndex = 2
+		sink.RecordAttempt(ctx, event)
+		assert.Equal(t, uint64(1), sink.Dropped())
+		close(release)
+		require.NoError(t, sink.Shutdown(context.Background()))
+		require.Len(t, saved, 2)
+		assert.Equal(t, attemptInstallation, saved[0].InstallationID)
+		assert.Equal(t, "operation-a", saved[0].Event.OperationID)
+		assert.Equal(t, 0, saved[0].Event.AttemptIndex)
+		assert.Equal(t, inference.AttemptOutcomeFailed, saved[0].Event.Outcome)
+		assert.Equal(t, 1, saved[1].Event.AttemptIndex)
+		assert.Equal(t, inference.AttemptOutcomeServed, saved[1].Event.Outcome)
+	})
+}
+
+func TestAttemptSinkWriteDeadlineAllowsRecovery(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var saved []string
+		var expired error
+		type secretKey struct{}
+		var retainedSecret any
+		store := attemptStoreFunc(func(ctx context.Context, p InsertInferenceAttemptParams) error {
+			retainedSecret = ctx.Value(secretKey{})
+			if p.Event.OperationID == "unavailable" {
+				<-ctx.Done()
+				expired = ctx.Err()
+				return expired
+			}
+			saved = append(saved, p.Event.OperationID)
+			return nil
+		})
+		sink := NewAttemptSink(store, attemptTestLog())
+		ctx := context.WithValue(attemptContext(), secretKey{}, "not-for-the-worker")
+		sink.RecordAttempt(ctx, inference.AttemptEvent{OperationID: "unavailable"})
+		sink.RecordAttempt(ctx, inference.AttemptEvent{OperationID: "recovered"})
+		time.Sleep(300 * time.Millisecond)
+		require.NoError(t, sink.Shutdown(context.Background()))
+		assert.ErrorIs(t, expired, context.DeadlineExceeded)
+		assert.Equal(t, []string{"recovered"}, saved)
+		assert.Nil(t, retainedSecret)
+		assert.Equal(t, uint64(1), sink.Dropped())
+	})
+}
+
+func TestAttemptSinkShutdownCancelsActiveWriteAndDiscardsQueue(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		started := make(chan struct{})
+		var writeErr error
+		var writes int
+		sink := NewAttemptSink(attemptStoreFunc(func(ctx context.Context, _ InsertInferenceAttemptParams) error {
+			writes++
+			close(started)
+			<-ctx.Done()
+			writeErr = ctx.Err()
+			return writeErr
+		}), attemptTestLog())
+		sink.RecordAttempt(attemptContext(), inference.AttemptEvent{OperationID: "active"})
+		<-started
+		sink.RecordAttempt(attemptContext(), inference.AttemptEvent{OperationID: "pending"})
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		require.ErrorIs(t, sink.Shutdown(ctx), context.Canceled)
+		require.NoError(t, sink.Shutdown(context.Background()))
+		sink.RecordAttempt(attemptContext(), inference.AttemptEvent{OperationID: "late"})
+		assert.ErrorIs(t, writeErr, context.Canceled)
+		assert.Equal(t, 1, writes)
+		assert.Equal(t, uint64(3), sink.Dropped())
+	})
+}
+
+func TestAttemptSinkConcurrentShutdownAccountsForAllEvents(t *testing.T) {
+	var persisted atomic.Uint64
+	sink := NewAttemptSink(attemptStoreFunc(func(context.Context, InsertInferenceAttemptParams) error {
+		persisted.Add(1)
+		return nil
+	}), attemptTestLog())
+	var producers sync.WaitGroup
+	for range 100 {
+		producers.Go(func() { sink.RecordAttempt(attemptContext(), inference.AttemptEvent{}) })
+	}
+	require.NoError(t, sink.Shutdown(context.Background()))
+	producers.Wait()
+	assert.Equal(t, uint64(100), persisted.Load()+sink.Dropped())
+}
+
+func TestAttemptSinkSkipsUnattributedEvents(t *testing.T) {
+	var persisted atomic.Uint64
+	sink := NewAttemptSink(attemptStoreFunc(func(context.Context, InsertInferenceAttemptParams) error {
+		persisted.Add(1)
+		return nil
+	}), attemptTestLog())
+	sink.RecordAttempt(context.Background(), inference.AttemptEvent{})
+	require.NoError(t, sink.Shutdown(context.Background()))
+	assert.Zero(t, persisted.Load())
+	assert.Zero(t, sink.Dropped())
+}
+
+func TestAttemptSinkDoesNotDelayProviderFailover(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		started := make(chan struct{})
+		sink := NewAttemptSink(attemptStoreFunc(func(ctx context.Context, _ InsertInferenceAttemptParams) error {
+			select {
+			case <-started:
+			default:
+				close(started)
+			}
+			<-ctx.Done()
+			return ctx.Err()
+		}), attemptTestLog())
+		defer func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			_ = sink.Shutdown(ctx)
+			_ = sink.Shutdown(context.Background())
+		}()
+		sink.RecordAttempt(attemptContext(), inference.AttemptEvent{})
+		<-started
+		primary := &fakeClient{name: providers.ProviderFireworks, outcomes: []fakeOutcome{{err: &providers.UpstreamErrorResponse{Status: http.StatusServiceUnavailable}}}}
+		fallback := &fakeClient{name: providers.ProviderOpenRouter, outcomes: []fakeOutcome{{writeBytes: []byte("served")}}}
+		executor, err := dispatch.NewExecutor(dispatch.NewClients(map[string]providers.Client{providers.ProviderFireworks: primary, providers.ProviderOpenRouter: fallback}), dispatch.WithAttemptSink(sink))
+		require.NoError(t, err)
+		s := (&Service{}).WithInferenceExecutor(executor)
+		rec := httptest.NewRecorder()
+		done := make(chan error, 1)
+		go func() {
+			_, err := s.dispatchWithFallback(attemptContext(), plannedInputs(rec, newPreludeBuffer(rec), []catalog.ProviderBinding{{Provider: providers.ProviderFireworks}, {Provider: providers.ProviderOpenRouter}}, nil))
+			done <- err
+		}()
+		synctest.Wait()
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		default:
+			t.Fatal("provider failover waited for the blocked attempt store")
+		}
+		assert.Equal(t, "served", rec.Body.String())
+		assert.Equal(t, providers.ProviderOpenRouter, rec.Header().Get(HeaderRouterProvider))
+		assert.Equal(t, plannedTestModel, rec.Header().Get(HeaderRouterModel))
+	})
+}
+
+func TestAttemptSinkStoreFailureIsDiagnosticOnly(t *testing.T) {
+	sink := NewAttemptSink(attemptStoreFunc(func(context.Context, InsertInferenceAttemptParams) error { return errors.New("database unavailable") }), attemptTestLog())
+	sink.RecordAttempt(attemptContext(), inference.AttemptEvent{OperationID: "failed-write"})
+	require.NoError(t, sink.Shutdown(context.Background()))
+	assert.Equal(t, uint64(1), sink.Dropped())
+}

--- a/internal/proxy/beta.go
+++ b/internal/proxy/beta.go
@@ -91,9 +91,11 @@ func (s *Service) handleBetaCommand(
 	// Both branches decide from what the store persisted rather than a prior
 	// read, so overlapping /beta commands for one session cannot act on the
 	// same stale state: an unavailable beta policy can only ever be left.
+	writeCtx, cancelWrite := bookkeepingContext(ctx)
+	defer cancelWrite()
 	nowEnabled := false
 	if s.PolicyStrategyAvailable(router.StrategyHMMBeta) {
-		enabled, err := s.sessionStrategyStore.Toggle(context.Background(), sessionstrategy.Preference{
+		enabled, err := s.sessionStrategyStore.Toggle(writeCtx, sessionstrategy.Preference{
 			InstallationID: installationID,
 			SessionKey:     preferenceKey,
 			Strategy:       router.StrategyHMMBeta,
@@ -103,7 +105,7 @@ func (s *Service) handleBetaCommand(
 		}
 		nowEnabled = enabled
 	} else {
-		wasEnabled, err := s.sessionStrategyStore.Disable(context.Background(), installationID, preferenceKey)
+		wasEnabled, err := s.sessionStrategyStore.Disable(writeCtx, installationID, preferenceKey)
 		if err != nil {
 			return fmt.Errorf("disable beta routing: %w", err)
 		}
@@ -153,6 +155,8 @@ func (s *Service) invalidateSessionRoutingState(
 	}
 	strategy := router.StrategyFromContext(ctx)
 	seen := make(map[string]struct{}, len(roles)*3)
+	writeCtx, cancelWrite := bookkeepingContext(ctx)
+	defer cancelWrite()
 	var firstErr error
 	for _, role := range roles {
 		for _, stateRole := range []string{
@@ -164,7 +168,7 @@ func (s *Service) invalidateSessionRoutingState(
 				continue
 			}
 			seen[stateRole] = struct{}{}
-			if _, _, err := s.pinStore.Consume(context.Background(), sessionKey, stateRole, strategy); err != nil && firstErr == nil {
+			if _, _, err := s.pinStore.Consume(writeCtx, sessionKey, stateRole, strategy); err != nil && firstErr == nil {
 				firstErr = err
 			}
 		}

--- a/internal/proxy/bookkeeping.go
+++ b/internal/proxy/bookkeeping.go
@@ -1,0 +1,19 @@
+package proxy
+
+import (
+	"context"
+	"time"
+)
+
+const bookkeepingTimeout = 250 * time.Millisecond
+
+type bookkeepingContextKey struct{}
+
+// Bookkeeping survives client disconnects; nested writes share its deadline.
+func bookkeepingContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if bounded, _ := ctx.Value(bookkeepingContextKey{}).(bool); bounded {
+		return context.WithCancel(ctx)
+	}
+	ctx = context.WithValue(context.WithoutCancel(ctx), bookkeepingContextKey{}, true)
+	return context.WithTimeout(ctx, bookkeepingTimeout)
+}

--- a/internal/proxy/bookkeeping_completion_test.go
+++ b/internal/proxy/bookkeeping_completion_test.go
@@ -1,0 +1,103 @@
+package proxy_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"weave-os/router/internal/providers"
+	"weave-os/router/internal/proxy"
+	"weave-os/router/internal/router"
+	"weave-os/router/internal/router/sessionpin"
+)
+
+type completionPinStore struct {
+	*fakePinStore
+	started chan struct{}
+	release chan struct{}
+}
+
+func (s *completionPinStore) UpdateUsage(ctx context.Context, key [sessionpin.SessionKeyLen]byte, role string, usage sessionpin.Usage) error {
+	close(s.started)
+	// Deliberately ignore the deadline to prove response delivery is independent
+	// of this write, not merely released after the new write timeout.
+	<-s.release
+	return s.fakePinStore.UpdateUsage(ctx, key, role, usage)
+}
+
+func TestBufferedInferenceCompletesBeforeUsagePersistence(t *testing.T) {
+	for _, tt := range []struct {
+		name, path, body, provider, model, upstream string
+		call                                        func(*proxy.Service, context.Context, []byte, http.ResponseWriter, *http.Request) error
+	}{
+		{
+			name: "messages", path: "/v1/messages", provider: providers.ProviderAnthropic, model: "claude-opus-4-7",
+			body:     pinTestBody,
+			upstream: `{"id":"msg_test","type":"message","role":"assistant","model":"claude-opus-4-7","content":[{"type":"text","text":"complete answer"}],"stop_reason":"end_turn","usage":{"input_tokens":12,"output_tokens":9}}`,
+			call:     (*proxy.Service).ProxyMessages,
+		},
+		{
+			name: "chat", path: "/v1/chat/completions", provider: providers.ProviderOpenAI, model: "gpt-5.5",
+			body:     `{"model":"gpt-5.5","messages":[{"role":"user","content":"Write a small program to sort a list"}]}`,
+			upstream: `{"id":"chat_test","object":"chat.completion","model":"gpt-5.5","choices":[{"index":0,"message":{"role":"assistant","content":"complete answer"},"finish_reason":"stop"}],"usage":{"prompt_tokens":12,"completion_tokens":9}}`,
+			call:     (*proxy.Service).ProxyOpenAIChatCompletion,
+		},
+		{
+			name: "native responses", path: "/v1/responses", provider: providers.ProviderOpenAI, model: "gpt-5.5",
+			body:     `{"model":"gpt-5.5","input":"Write a small program to sort a list","tools":[{"type":"custom","name":"apply_patch"}]}`,
+			upstream: `{"id":"resp_test","object":"response","model":"gpt-5.5","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"complete answer"}]}],"usage":{"input_tokens":12,"output_tokens":9}}`,
+			call:     (*proxy.Service).ProxyOpenAIResponses,
+		},
+		{
+			name: "gemini", path: "/v1beta/models/gemini-2.5-pro:generateContent", provider: providers.ProviderGoogle, model: "gemini-2.5-pro",
+			body:     `{"model":"gemini-2.5-pro","contents":[{"role":"user","parts":[{"text":"Write a small program to sort a list"}]}]}`,
+			upstream: `{"candidates":[{"content":{"role":"model","parts":[{"text":"complete answer"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":12,"candidatesTokenCount":9,"totalTokenCount":21}}`,
+			call:     (*proxy.Service).ProxyGeminiGenerateContent,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &completionPinStore{fakePinStore: newFakePinStore(), started: make(chan struct{}), release: make(chan struct{})}
+			provider := &fakeProvider{proxyResponse: func(w http.ResponseWriter) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, tt.upstream)
+			}}
+			service := proxy.NewService(&fakeRouter{decision: router.Decision{Provider: tt.provider, Model: tt.model, Reason: "test"}}, map[string]providers.Client{tt.provider: provider}, nil, false, nil, store, false, tt.provider, tt.model, recordingTelemetry{}).WithOpenAIResponsesBroad(false)
+			handlerDone := make(chan error, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				handlerDone <- tt.call(service, authedCtx("00000000-0000-0000-0000-000000000001"), []byte(tt.body), w, r)
+			}))
+			defer server.Close()
+			defer close(store.release)
+			client := &http.Client{Timeout: 2 * time.Second}
+			response, err := client.Post(server.URL+tt.path, "application/json", strings.NewReader(tt.body))
+			require.NoError(t, err)
+			defer response.Body.Close()
+			body, err := io.ReadAll(response.Body)
+			require.NoError(t, err, "response must end while bookkeeping is blocked")
+			assert.Equal(t, http.StatusOK, response.StatusCode)
+			assert.Contains(t, string(body), "complete answer")
+			assert.True(t, json.Valid(body), "finalization must not duplicate the JSON response")
+			assert.Equal(t, tt.model, response.Header.Get(proxy.HeaderRouterModel))
+			select {
+			case <-store.started:
+			case err := <-handlerDone:
+				t.Fatalf("test did not reach usage persistence: %v", err)
+			case <-time.After(time.Second):
+				t.Fatal("usage persistence never started")
+			}
+			select {
+			case err := <-handlerDone:
+				t.Fatalf("bookkeeping was not blocked: %v", err)
+			default:
+			}
+		})
+	}
+}

--- a/internal/proxy/bookkeeping_internal_test.go
+++ b/internal/proxy/bookkeeping_internal_test.go
@@ -1,0 +1,102 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"weave-os/router/internal/providers"
+	"weave-os/router/internal/router"
+	"weave-os/router/internal/router/sessionpin"
+)
+
+type deadlinePinStore struct {
+	recordingPinStore
+	unavailable bool
+	usage       []sessionpin.Usage
+}
+
+func (s *deadlinePinStore) Upsert(ctx context.Context, pin sessionpin.Pin) error {
+	if s.unavailable {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return s.recordingPinStore.Upsert(ctx, pin)
+}
+
+func (s *deadlinePinStore) UpdateUsage(ctx context.Context, _ [sessionpin.SessionKeyLen]byte, _ string, usage sessionpin.Usage) error {
+	if s.unavailable {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.usage = append(s.usage, usage)
+	return nil
+}
+
+func TestSessionBookkeepingTimesOutAndRecoversAfterClientCancellation(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		store := &deadlinePinStore{unavailable: true}
+		service := &Service{pinStore: store}
+		key := [sessionpin.SessionKeyLen]byte{1}
+		installation := uuid.New()
+		started := time.Now()
+		err := service.setForceModelSessionPin(context.Background(), key, installation, "claude-opus-4-7", providers.ProviderAnthropic, "")
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.LessOrEqual(t, time.Since(started), 300*time.Millisecond)
+		assert.Empty(t, store.upserts)
+		store.unavailable = false
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		require.NoError(t, service.setForceModelSessionPin(ctx, key, installation, "claude-opus-4-7", providers.ProviderAnthropic, ""))
+		require.Len(t, store.upserts, 1)
+		assert.Equal(t, "claude-opus-4-7", store.upserts[0].Model)
+		assert.Equal(t, installation, store.upserts[0].InstallationID)
+	})
+}
+
+func TestTurnUsageWriteIsBoundedAndRetainsCompletedUsage(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		store := &deadlinePinStore{unavailable: true}
+		service := &Service{pinStore: store}
+		turn := turnLoopResult{SessionKey: [sessionpin.SessionKeyLen]byte{1}, Strategy: router.StrategyCluster}
+		started := time.Now()
+		service.recordTurnUsage(context.Background(), turn, providers.ProviderAnthropic, "claude-opus-4-7", 12, 9, 0, 0)
+		assert.LessOrEqual(t, time.Since(started), 300*time.Millisecond)
+		assert.Empty(t, store.usage)
+		store.unavailable = false
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		service.recordTurnUsage(ctx, turn, providers.ProviderAnthropic, "claude-opus-4-7", 12, 9, 3, 5)
+		require.Len(t, store.usage, 1)
+		assert.Equal(t, 12, store.usage[0].InputTokens)
+		assert.Equal(t, 9, store.usage[0].OutputTokens)
+		assert.Equal(t, 3, store.usage[0].CachedWriteTokens)
+		assert.Equal(t, 5, store.usage[0].CachedReadTokens)
+		assert.Equal(t, "claude-opus-4-7", store.usage[0].ServedModel)
+	})
+}
+
+func TestNestedBookkeepingKeepsTheOriginalDeadline(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		started := time.Now()
+		outer, cancelOuter := bookkeepingContext(context.Background())
+		defer cancelOuter()
+		time.Sleep(200 * time.Millisecond)
+		inner, cancelInner := bookkeepingContext(outer)
+		defer cancelInner()
+		<-inner.Done()
+		assert.Equal(t, 250*time.Millisecond, time.Since(started))
+		assert.ErrorIs(t, inner.Err(), context.DeadlineExceeded)
+	})
+}

--- a/internal/proxy/command_continuation.go
+++ b/internal/proxy/command_continuation.go
@@ -90,7 +90,9 @@ func (s *Service) invalidatePostCommandContinuation(
 	if s.pinStore == nil {
 		return nil
 	}
-	_, _, err := s.pinStore.Consume(context.Background(), sessionKey, commandContinuationRole(role), router.StrategyFromContext(ctx))
+	consumeCtx, cancelConsume := bookkeepingContext(ctx)
+	defer cancelConsume()
+	_, _, err := s.pinStore.Consume(consumeCtx, sessionKey, commandContinuationRole(role), router.StrategyFromContext(ctx))
 	if err != nil {
 		observability.FromContext(ctx).Error(
 			"post-command continuation invalidation failed",

--- a/internal/proxy/cost_response.go
+++ b/internal/proxy/cost_response.go
@@ -54,6 +54,7 @@ func (b *responseCostBuffer) FlushToClient() error {
 		return nil
 	}
 	b.flushed = true
+	b.inner.Header().Set("Content-Length", strconv.Itoa(b.body.Len()))
 	b.inner.WriteHeader(b.status)
 	if _, err := b.inner.Write(b.body.Bytes()); err != nil {
 		return err

--- a/internal/proxy/fire_telemetry_panic_internal_test.go
+++ b/internal/proxy/fire_telemetry_panic_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -12,7 +13,25 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type telemetryLogBuffer struct {
+	mu sync.Mutex
+	bytes.Buffer
+}
+
+func (b *telemetryLogBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.Buffer.Write(p)
+}
+
+func (b *telemetryLogBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.Buffer.String()
+}
 
 // panicTelemetryRepo is a TelemetryRepository whose InsertRequestTelemetry
 // always panics, simulating a bug in the telemetry sink.
@@ -69,24 +88,17 @@ func TestFireTelemetryRecoversFromPanic(t *testing.T) {
 	// first Get() call races SetDefault and resets the handler.
 	observability.Get()
 
-	var buf bytes.Buffer
+	var buf telemetryLogBuffer
 	prev := slog.Default()
 	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
 	defer slog.SetDefault(prev)
 
 	s := &Service{telemetry: panicTelemetryRepo{}}
 
-	assert.NotPanics(t, func() {
-		s.fireTelemetry(InsertTelemetryParams{RequestID: "req-1"})
-		// fireTelemetry launches a goroutine; give it a moment to run and recover.
-		deadline := time.Now().Add(2 * time.Second)
-		for time.Now().Before(deadline) {
-			if strings.Contains(buf.String(), "Background goroutine panicked") {
-				break
-			}
-			time.Sleep(10 * time.Millisecond)
-		}
-	})
+	s.fireTelemetry(InsertTelemetryParams{RequestID: "req-1"})
+	require.Eventually(t, func() bool {
+		return strings.Contains(buf.String(), "Background goroutine panicked")
+	}, 2*time.Second, time.Millisecond)
 
 	assert.Contains(t, buf.String(), "Background goroutine panicked")
 	assert.Contains(t, buf.String(), "fireTelemetry")

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -304,7 +304,9 @@ func (s *Service) preserveForceModelControlHistory(
 	if !found || !isUserForcedReason(existing.Reason) || existing.Model == "" || existing.Model == nextModel {
 		return nil
 	}
-	return s.pinStore.UpdateUsage(context.Background(), sessionKey, forceModelSessionRole, sessionpin.Usage{
+	usageCtx, cancelUsage := bookkeepingContext(ctx)
+	defer cancelUsage()
+	return s.pinStore.UpdateUsage(usageCtx, sessionKey, forceModelSessionRole, sessionpin.Usage{
 		Strategy:            existing.Strategy,
 		EndedAt:             time.Now(),
 		ServedModel:         existing.Model,
@@ -339,7 +341,9 @@ func (s *Service) setForceModelSessionPin(
 		TurnCount:      1,
 		PinnedUntil:    pinNeverExpires,
 	}
-	return s.pinStore.Upsert(context.Background(), forced)
+	pinCtx, cancelPin := bookkeepingContext(ctx)
+	defer cancelPin()
+	return s.pinStore.Upsert(pinCtx, forced)
 }
 
 func (s *Service) loadForceModelSessionPin(
@@ -458,7 +462,9 @@ func (s *Service) clearForceModelSessionPin(
 		TurnCount:      1,
 		PinnedUntil:    pinNeverExpires,
 	}
-	return s.pinStore.Upsert(context.Background(), cleared)
+	pinCtx, cancelPin := bookkeepingContext(ctx)
+	defer cancelPin()
+	return s.pinStore.Upsert(pinCtx, cleared)
 }
 
 // applyForceModelHeader honors the x-weave-force-model request header,

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -340,6 +340,9 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	cacheCreation, cacheRead := extractor.CacheTokens()
 	if responseBuffer != nil && proxyErr == nil {
 		setRouterCostHeaders(w.Header(), routerResponseCostFromPricing(actPricing, decision.Provider, in, out, cacheCreation, cacheRead))
+		if flushErr := responseBuffer.FlushToClient(); flushErr != nil {
+			log.Error("Failed to flush buffered response", "err", flushErr)
+		}
 	}
 	geminiUpstreamBuilder := otel.NewAttrBuilder(40).
 		String("request_id", requestID).
@@ -383,8 +386,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	s.recordCallLog(ctx, geminiUpstreamBuilder.Build(), routeMs, proxyErr != nil, body, respBody, respTrunc)
 	otel.Flush(ctx)
 
-	// Persist last-turn usage to the pin row so the next turn's planner
-	// has cache-hit evidence. Off the request path; drops on saturation.
+	// Preserve ordered usage updates after releasing the response.
 	s.recordTurnUsage(ctx, routeRes, finalProvider, decision.ServedIdentity(), in, out, cacheCreation, cacheRead)
 
 	if installationID != uuid.Nil {

--- a/internal/proxy/loop_detection.go
+++ b/internal/proxy/loop_detection.go
@@ -268,17 +268,16 @@ func (s *Service) handleLoopEscalation(
 			PinnedUntil:     time.Now().Add(pinSessionTTL),
 			LastServedModel: lastServed,
 		}
-		// context.Background(): the request ctx may already be canceled by the
-		// time this runs; the pin write must still land or the next turn re-loops.
-		if err := s.pinStore.Upsert(context.Background(), pin); err != nil {
+
+		pinCtx, cancelPin := bookkeepingContext(ctx)
+		defer cancelPin()
+		if err := s.pinStore.Upsert(pinCtx, pin); err != nil {
 			log.Error("loop-escalation: pin upsert failed", "err", err)
 			return
 		}
 	}
 
 	// Durable row for fire-rate/opus-share metrics and the training corpus.
-	// context.Background(): request ctx may be canceled; losing the row would
-	// skew the corpus and break the once-per-session budget (pin check still dedupes re-fires meanwhile).
 	if s.loopEscalationStore != nil && installationID != uuid.Nil {
 		event := LoopEscalationEvent{
 			InstallationID:   installationID.String(),
@@ -293,7 +292,9 @@ func (s *Service) handleLoopEscalation(
 			DistinctRatio:    distinctRatio,
 			WindowSize:       int32(window),
 		}
-		if err := s.loopEscalationStore.InsertLoopEscalationEvent(context.Background(), event); err != nil {
+		eventCtx, cancelEvent := bookkeepingContext(ctx)
+		defer cancelEvent()
+		if err := s.loopEscalationStore.InsertLoopEscalationEvent(eventCtx, event); err != nil {
 			log.Error("loop-escalation: event insert failed", "err", err)
 		}
 	}

--- a/internal/proxy/openai_cyber_refusal.go
+++ b/internal/proxy/openai_cyber_refusal.go
@@ -210,9 +210,8 @@ func (s *Service) cyberRefusalRetryTarget(
 // fallback model. avoidProvider, when set, rules out a target on that vendor —
 // OpenAI's classifier declines the request whichever of its models serves it,
 // so the pin's runner-up is no escape if it is another OpenAI model. Anthropic
-// refusals name a single model and pass "". context.Background() reads the pin
-// because the request ctx may already be canceled once the response has been
-// written.
+// refusals name a single model and pass "". The bounded pin lookup survives
+// cancellation after a completed response.
 func (s *Service) cyberRefusalFallback(
 	ctx context.Context,
 	sessionKey [sessionpin.SessionKeyLen]byte,
@@ -222,7 +221,9 @@ func (s *Service) cyberRefusalFallback(
 ) (model, provider string, ok bool) {
 	model = s.ResolveCyberRefusalFallbackModel(ctx)
 	if s.pinStore != nil {
-		if existing, found, err := s.pinStore.Get(context.Background(), sessionKey, role); err == nil && found &&
+		pinCtx, cancelPin := bookkeepingContext(ctx)
+		defer cancelPin()
+		if existing, found, err := s.pinStore.Get(pinCtx, sessionKey, role); err == nil && found &&
 			pinMatchesEffectiveStrategy(ctx, existing) && existing.PairedModel != "" &&
 			!providerAvoided(providerForModel(existing.PairedProvider, existing.PairedModel), avoidProvider) {
 			model, provider = existing.PairedModel, existing.PairedProvider

--- a/internal/proxy/pin_eviction.go
+++ b/internal/proxy/pin_eviction.go
@@ -33,11 +33,6 @@ const pinEvictionStrikeThreshold = 2
 // scorer. Shared by force-model clear, loop-break/no-progress/
 // degenerate-response eviction, and the upstream-error strike threshold —
 // call sites differ only in the Reason string recorded for observability.
-//
-// context.Background(): callers invoke this once the response has already
-// streamed or is about to be written, so the request ctx may already be
-// canceled; the eviction write must still land or the next turn inherits
-// the stale pin.
 func (s *Service) expireSessionPin(
 	ctx context.Context,
 	installationID uuid.UUID,
@@ -70,7 +65,9 @@ func (s *Service) expireSessionPinRow(
 		TurnCount:      1,
 		PinnedUntil:    time.Now().Add(-time.Second),
 	}
-	if err := s.pinStore.Upsert(context.Background(), expired); err != nil {
+	pinCtx, cancelPin := bookkeepingContext(ctx)
+	defer cancelPin()
+	if err := s.pinStore.Upsert(pinCtx, expired); err != nil {
 		return err
 	}
 	if !invalidateContinuation {
@@ -192,9 +189,9 @@ func (s *Service) maybeEvictPinAfterUpstreamErr(
 	log := observability.FromContext(ctx)
 
 	if proxyErr == nil {
-		// context.Background(): the request ctx is already canceled by the
-		// time streaming finishes, but this reset must still go through.
-		if err := s.pinStore.ResetUpstreamErrors(context.Background(), sessionKey, role, router.StrategyFromContext(ctx)); err != nil {
+		resetCtx, cancelReset := bookkeepingContext(ctx)
+		defer cancelReset()
+		if err := s.pinStore.ResetUpstreamErrors(resetCtx, sessionKey, role, router.StrategyFromContext(ctx)); err != nil {
 			log.Error("pin error-counter reset failed", "err", err, "role", role)
 		}
 		return
@@ -210,7 +207,9 @@ func (s *Service) maybeEvictPinAfterUpstreamErr(
 		return
 	}
 
-	count, err := s.pinStore.IncrementUpstreamErrors(context.Background(), sessionKey, role, router.StrategyFromContext(ctx))
+	incrementCtx, cancelIncrement := bookkeepingContext(ctx)
+	defer cancelIncrement()
+	count, err := s.pinStore.IncrementUpstreamErrors(incrementCtx, sessionKey, role, router.StrategyFromContext(ctx))
 	if err != nil {
 		log.Error("pin error-counter increment failed", "err", err, "role", role, "upstream_status", status)
 		return

--- a/internal/proxy/pin_strategy.go
+++ b/internal/proxy/pin_strategy.go
@@ -21,10 +21,6 @@ func pinMatchesEffectiveStrategy(ctx context.Context, pin sessionpin.Pin) bool {
 	return pin.Strategy == "" && expected != router.StrategyHMMBeta
 }
 
-func strategyContext(strategy router.Strategy) context.Context {
-	return router.WithStrategy(context.Background(), strategy)
-}
-
 func strategyForTurnLoopResult(res turnLoopResult) router.Strategy {
 	if res.Strategy != "" {
 		return res.Strategy

--- a/internal/proxy/provider_overload.go
+++ b/internal/proxy/provider_overload.go
@@ -51,9 +51,9 @@ func (s *Service) maybeDisableProviderAfterOverload(
 	log := observability.FromContext(ctx)
 
 	if proxyErr == nil {
-		// context.Background(): the request ctx is already canceled by the
-		// time streaming finishes, but this reset must still go through.
-		if err := s.pinStore.ResetOverloadErrors(context.Background(), sessionKey, role, router.StrategyFromContext(ctx)); err != nil {
+		resetCtx, cancelReset := bookkeepingContext(ctx)
+		defer cancelReset()
+		if err := s.pinStore.ResetOverloadErrors(resetCtx, sessionKey, role, router.StrategyFromContext(ctx)); err != nil {
 			log.Error("pin overload-counter reset failed", "err", err, "role", role)
 		}
 		return
@@ -63,7 +63,9 @@ func (s *Service) maybeDisableProviderAfterOverload(
 		return
 	}
 
-	count, err := s.pinStore.IncrementOverloadErrors(context.Background(), sessionKey, role, router.StrategyFromContext(ctx))
+	incrementCtx, cancelIncrement := bookkeepingContext(ctx)
+	defer cancelIncrement()
+	count, err := s.pinStore.IncrementOverloadErrors(incrementCtx, sessionKey, role, router.StrategyFromContext(ctx))
 	if err != nil {
 		log.Error("pin overload-counter increment failed", "err", err, "role", role, "provider", finalProvider)
 		return
@@ -78,7 +80,9 @@ func (s *Service) maybeDisableProviderAfterOverload(
 		return
 	}
 
-	if err := s.pinStore.DisableProvider(context.Background(), sessionKey, role, finalProvider, router.StrategyFromContext(ctx)); err != nil {
+	disableCtx, cancelDisable := bookkeepingContext(ctx)
+	defer cancelDisable()
+	if err := s.pinStore.DisableProvider(disableCtx, sessionKey, role, finalProvider, router.StrategyFromContext(ctx)); err != nil {
 		log.Error("pin provider-disable upsert failed", "err", err, "role", role, "provider", finalProvider)
 		return
 	}

--- a/internal/proxy/router_feedback.go
+++ b/internal/proxy/router_feedback.go
@@ -168,9 +168,10 @@ func (s *Service) handleRouterFeedbackCommand(
 			RequestID:      telemetryRequestID,
 			RouteID:        telemetryRouteID,
 		}
-		// context.Background(): ctx may already be canceled (client disconnected
-		// mid-command); don't drop feedback the user explicitly typed.
-		if err := s.feedbackStore.InsertRouterFeedback(context.Background(), event); err != nil {
+
+		feedbackCtx, cancelFeedback := bookkeepingContext(ctx)
+		defer cancelFeedback()
+		if err := s.feedbackStore.InsertRouterFeedback(feedbackCtx, event); err != nil {
 			log.Error("/router-feedback: feedback insert failed", "err", err)
 			return err
 		}
@@ -187,7 +188,9 @@ func (s *Service) handleRouterFeedbackCommand(
 			Source:         "router-feedback-command",
 			RouterUserID:   routerUserID,
 		}
-		if err := s.feedbackRepo.Upsert(context.Background(), upsertParams); err != nil {
+		ratingCtx, cancelRating := bookkeepingContext(ctx)
+		defer cancelRating()
+		if err := s.feedbackRepo.Upsert(ratingCtx, upsertParams); err != nil {
 			log.Error("/router-feedback: request_feedback upsert failed", "rated_request_id", telemetryRequestID, "err", err)
 		}
 	}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2976,9 +2976,10 @@ func (s *Service) repinOffRefusingModel(ctx context.Context, sessionKey [session
 		TurnCount:      1,
 		PinnedUntil:    pinExpiry(reasonCyberRefusalRepin),
 	}
-	// context.Background(): ctx may already be canceled here (response written,
-	// client disconnected); a canceled ctx would drop the re-pin write.
-	if err := s.pinStore.Upsert(context.Background(), pin); err != nil {
+
+	pinCtx, cancelPin := bookkeepingContext(ctx)
+	defer cancelPin()
+	if err := s.pinStore.Upsert(pinCtx, pin); err != nil {
 		log.Error("cyber-refusal re-pin: pin upsert failed", "err", err, "from_model", served.Model, "to_model", fbModel)
 		return
 	}
@@ -4480,6 +4481,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	cacheCreation, cacheRead := extractor.CacheTokens()
 	if responseBuffer != nil && proxyErr == nil {
 		setRouterCostHeaders(w.Header(), routerResponseCostFromPricing(actPricing, decision.Provider, in, out, cacheCreation, cacheRead))
+		if flushErr := responseBuffer.FlushToClient(); flushErr != nil {
+			log.Error("Failed to flush buffered response", "err", flushErr)
+		}
 	}
 	upstreamBuilder := otel.NewAttrBuilder(40).
 		String("request_id", requestID).
@@ -4926,7 +4930,7 @@ func (s *Service) recordTurnUsage(ctx context.Context, res turnLoopResult, serve
 		return
 	}
 	if isHMMTurn(res) {
-		s.recordHMMTurnHistory(res, servedProvider, servedModel, in, out, cacheCreation, cacheRead)
+		s.recordHMMTurnHistory(ctx, res, servedProvider, servedModel, in, out, cacheCreation, cacheRead)
 		return
 	}
 	var zeroKey [sessionpin.SessionKeyLen]byte
@@ -4955,8 +4959,10 @@ func (s *Service) recordTurnUsage(ctx context.Context, res turnLoopResult, serve
 	if role == "" {
 		role = sessionpin.DefaultRole
 	}
-	if err := s.pinStore.UpdateUsage(context.Background(), res.SessionKey, role, usage); err != nil {
-		observability.Get().Error("session pin usage writeback failed", "err", err)
+	usageCtx, cancelUsage := bookkeepingContext(ctx)
+	defer cancelUsage()
+	if err := s.pinStore.UpdateUsage(usageCtx, res.SessionKey, role, usage); err != nil {
+		observability.FromContext(ctx).Error("session pin usage writeback failed", "err", err)
 	}
 }
 
@@ -4964,7 +4970,7 @@ func isHMMTurn(res turnLoopResult) bool {
 	return isHMMDecision(res.Decision) || isHMMDecision(res.Fresh)
 }
 
-func (s *Service) recordHMMTurnHistory(res turnLoopResult, servedProvider, servedModel string, in, out, cacheCreation, cacheRead int) {
+func (s *Service) recordHMMTurnHistory(ctx context.Context, res turnLoopResult, servedProvider, servedModel string, in, out, cacheCreation, cacheRead int) {
 	if servedModel == "" || res.InstallationID == uuid.Nil {
 		return
 	}
@@ -4973,7 +4979,8 @@ func (s *Service) recordHMMTurnHistory(res turnLoopResult, servedProvider, serve
 		return
 	}
 	hasUsage := in != 0 || out != 0 || cacheCreation != 0 || cacheRead != 0
-	strategyCtx := strategyContext(strategyForTurnLoopResult(res))
+	strategyCtx, cancelHistory := bookkeepingContext(router.WithStrategy(ctx, strategyForTurnLoopResult(res)))
+	defer cancelHistory()
 	historyProvider := servedProvider
 	if !hasUsage {
 		// A failed turn has no usage writeback; preserve the prior provider to
@@ -5001,7 +5008,7 @@ func (s *Service) recordHMMTurnHistory(res turnLoopResult, servedProvider, serve
 		return
 	}
 	now := time.Now()
-	if err := s.pinStore.UpdateUsage(context.Background(), res.SessionKey, role, sessionpin.Usage{
+	if err := s.pinStore.UpdateUsage(strategyCtx, res.SessionKey, role, sessionpin.Usage{
 		Strategy:            router.StrategyFromContext(strategyCtx),
 		InputTokens:         in,
 		CachedReadTokens:    cacheRead,
@@ -5013,7 +5020,7 @@ func (s *Service) recordHMMTurnHistory(res turnLoopResult, servedProvider, serve
 		PriorServedModel:    res.PriorServedModel,
 		SessionEverSwitched: res.SessionEverSwitched,
 	}); err != nil {
-		observability.Get().Error("HMM switch-history writeback failed", "err", err)
+		observability.FromContext(ctx).Error("HMM switch-history writeback failed", "err", err)
 	}
 }
 
@@ -7156,6 +7163,18 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	cacheCreation, cacheRead := extractor.CacheTokens()
 	if !env.Stream() && proxyErr == nil {
 		setRouterCostHeaders(w.Header(), routerResponseCostFromPricing(actPricing, decision.Provider, in, out, cacheCreation, cacheRead))
+		if responseBuffer != nil {
+			if flushErr := responseBuffer.FlushToClient(); flushErr != nil {
+				log.Error("Failed to flush buffered response", "err", flushErr)
+			}
+		}
+	}
+	if proxyErr == nil {
+		if completion := deferredCallLogFrom(ctx); completion != nil && completion.finalize != nil {
+			if err := completion.finalize(); err != nil {
+				log.Error("Failed to finalize Responses response", "err", err)
+			}
+		}
 	}
 	openaiUpstreamBuilder := otel.NewAttrBuilder(40).
 		String("request_id", requestID).
@@ -7218,10 +7237,8 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		s.recordCallLog(ctx, callLogBase, routeMs, proxyErr != nil, reqBody, respBody, respTrunc)
 		otel.Flush(ctx)
 	}
-	// The /v1/responses surface (ProxyOpenAIResponses) finalizes its
-	// ResponsesWriter only after this function returns, so the captured body
-	// isn't complete yet — defer the read+emit to run post-Finalize. All other
-	// callers emit inline.
+	// Responses early-error paths finalize in the wrapping handler; their
+	// call-log capture must run after that handler has finished.
 	if h := deferredCallLogFrom(ctx); h != nil {
 		h.fn = emitCallLog
 	} else {
@@ -7433,15 +7450,32 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 	ctx = context.WithValue(ctx, responsesTransformsContextKey{}, conversion.Report)
 	// Routing, billing, and telemetry are reused via
 	// ProxyOpenAIChatCompletion; chatBody is used only for routing features.
+	var responseBuffer *responseCostBuffer
+	if !conversion.Stream {
+		responseBuffer = newResponseCostBuffer(w)
+		w = responseBuffer
+		defer func() {
+			if err := responseBuffer.FlushToClient(); err != nil {
+				observability.FromContext(ctx).Error("Failed to flush Responses response", "err", err)
+			}
+		}()
+	}
 	wrapper := translate.NewResponsesWriter(w, model)
 	if clientAppCodex {
 		wrapper.EnableCodexBadgeProvenance()
 	}
 	wrapper.SetToolMappings(conversion.ToolMappings)
-	// Defer the high-fidelity call-log emission until after Finalize: the
-	// ResponsesWriter buffers (non-streaming) and emits tail events only in
-	// Finalize, so the captured io.response_body is incomplete until then.
+	// Capture only after finalization, including errors and early returns.
 	ctx, deferredLog := withDeferredCallLog(ctx)
+	deferredLog.finalize = sync.OnceValue(func() error {
+		if err := wrapper.Finalize(); err != nil {
+			return err
+		}
+		if responseBuffer != nil {
+			return responseBuffer.FlushToClient()
+		}
+		return nil
+	})
 	// Capture the client's original Responses JSON as the request body so the
 	// call log's io.request_body matches the Responses-format response body
 	// (ProxyOpenAIChatCompletion otherwise sees the translated chatBody).
@@ -7465,7 +7499,7 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 		deferredLog.run()
 		return proxyErr
 	}
-	finErr := wrapper.Finalize()
+	finErr := deferredLog.finalize()
 	if deferredLog.escalation != nil {
 		deferredLog.escalation(finErr)
 	}

--- a/internal/proxy/spiral_detection.go
+++ b/internal/proxy/spiral_detection.go
@@ -350,9 +350,10 @@ func (s *Service) handleSpiralShadow(
 				PingPongLen:        int32(sig.pingPongLen),
 				StepsSinceProgress: int32(sig.stepsSinceProgress),
 			}
-			// context.Background(): the request ctx may already be canceled;
-			// losing the row would skew the shadow fire-rate corpus.
-			if err := s.spiralShadowStore.InsertSpiralShadowEvent(context.Background(), event); err != nil {
+
+			eventCtx, cancelEvent := bookkeepingContext(ctx)
+			defer cancelEvent()
+			if err := s.spiralShadowStore.InsertSpiralShadowEvent(eventCtx, event); err != nil {
 				log.Error("spiral-shadow: event insert failed", "err", err)
 				continue // leave the LRU unset so the next turn retries
 			}

--- a/internal/proxy/struggle_detection.go
+++ b/internal/proxy/struggle_detection.go
@@ -152,9 +152,10 @@ func (s *Service) handleStruggleShadow(
 			SessionEverSwitched: sessionEverSwitched,
 			EstInputTokens:      int32(estInputTokens),
 		}
-		// context.Background(): the request ctx may already be canceled; losing
-		// the row would skew the shadow fire-rate corpus.
-		if err := s.struggleShadowStore.InsertStruggleShadowEvent(context.Background(), event); err != nil {
+
+		eventCtx, cancelEvent := bookkeepingContext(ctx)
+		defer cancelEvent()
+		if err := s.struggleShadowStore.InsertStruggleShadowEvent(eventCtx, event); err != nil {
 			log.Error("struggle-shadow: event insert failed", "err", err)
 			return // leave the LRU unset so the next turn retries
 		}

--- a/internal/proxy/struggle_escalation.go
+++ b/internal/proxy/struggle_escalation.go
@@ -188,7 +188,9 @@ func (s *Service) handleStruggleEscalation(
 				if targetCluster != pin.PolicyGroup {
 					action = struggleActionUpCluster
 				}
-				upsertErr := s.pinStore.Upsert(context.Background(), sessionpin.Pin{
+				pinCtx, cancelPin := bookkeepingContext(ctx)
+				defer cancelPin()
+				upsertErr := s.pinStore.Upsert(pinCtx, sessionpin.Pin{
 					SessionKey:      sessionKey,
 					Role:            role,
 					InstallationID:  installationID,
@@ -240,7 +242,9 @@ func (s *Service) handleStruggleEscalation(
 			ArmingMode:          armingMode,
 			EvidenceReasons:     evidenceReasons,
 		}
-		if err := s.struggleEscalationStore.InsertStruggleEscalationEvent(context.Background(), event); err != nil {
+		eventCtx, cancelEvent := bookkeepingContext(ctx)
+		defer cancelEvent()
+		if err := s.struggleEscalationStore.InsertStruggleEscalationEvent(eventCtx, event); err != nil {
 			log.Error("struggle-escalation: event insert failed", "err", err)
 		}
 	}

--- a/internal/proxy/telemetry.go
+++ b/internal/proxy/telemetry.go
@@ -3,13 +3,11 @@ package proxy
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
 
 	"weave-os/router/internal/auth"
-	"weave-os/router/internal/dispatch"
 	"weave-os/router/internal/inference"
 	"weave-os/router/internal/observability"
 	"weave-os/router/internal/router"
@@ -457,37 +455,6 @@ func applyTurnSignalTelemetry(
 
 func int32Ptr(v int32) *int32 {
 	return &v
-}
-
-// attemptSink persists executor attempt events for the installation in
-// context. Persistence failures are logged, never surfaced to dispatch.
-type attemptSink struct {
-	store  InferenceAttemptStore
-	logger *slog.Logger
-}
-
-func (s attemptSink) RecordAttempt(ctx context.Context, event inference.AttemptEvent) {
-	if s.store == nil {
-		return
-	}
-	installationID, _ := ctx.Value(InstallationIDContextKey{}).(string)
-	if installationID == "" {
-		return
-	}
-	if err := s.store.InsertInferenceAttempt(context.WithoutCancel(ctx), InsertInferenceAttemptParams{
-		InstallationID: installationID,
-		Event:          event,
-	}); err != nil && s.logger != nil {
-		s.logger.Warn("inference attempt persist failed",
-			"operation_id", event.OperationID,
-			"attempt_index", event.AttemptIndex,
-			"error", err)
-	}
-}
-
-// NewAttemptSink returns the dispatch attempt sink backed by store.
-func NewAttemptSink(store InferenceAttemptStore, logger *slog.Logger) dispatch.AttemptSink {
-	return attemptSink{store: store, logger: logger}
 }
 
 // DecisionReasonPolicyPinUnservable marks a telemetry row for a turn that was

--- a/internal/proxy/turn_logs.go
+++ b/internal/proxy/turn_logs.go
@@ -131,11 +131,11 @@ func capturedResponse(c *captureWriter) (body []byte, truncated bool) {
 	return b, false
 }
 
-// deferredCallLog lets a wrapping handler run call-log emission after the
-// response body is fully written, since /v1/responses' ResponsesWriter only
-// calls Finalize after ProxyOpenAIChatCompletion returns (reading the
-// captured body earlier would yield empty/partial content).
+// deferredCallLog coordinates the Responses wrapper's finalization and logging.
+// Successful responses finalize before bookkeeping; early returns finalize in
+// the wrapping handler. Call-log capture always follows finalization.
 type deferredCallLog struct {
+	finalize   func() error
 	escalation func(error)
 	fn         func()
 	// requestBody overrides the captured request body: ProxyOpenAIResponses

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -2390,15 +2390,15 @@ func (s *Service) writeNewPin(ctx context.Context, installationID uuid.UUID, ses
 	s.upsertPin(ctx, p)
 }
 
-// upsertPin synchronously persists a pin write. context.Background() is used
-// so the DB write survives request-ctx cancellation after the response has
-// finished streaming.
+// upsertPin preserves write ordering with a bounded, cancellation-independent wait.
 func (s *Service) upsertPin(ctx context.Context, p sessionpin.Pin) {
 	log := observability.FromContext(ctx)
 	if p.Strategy == "" {
 		p.Strategy = router.StrategyFromContext(ctx)
 	}
-	if err := s.pinStore.Upsert(context.Background(), p); err != nil {
+	pinCtx, cancelPin := bookkeepingContext(ctx)
+	defer cancelPin()
+	if err := s.pinStore.Upsert(pinCtx, p); err != nil {
 		log.Error("session pin upsert failed", "err", err)
 		return
 	}

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -364,6 +364,11 @@ func (s *Service) bypassToAnthropic(
 	pricing, _ := servedPricing(decision.Provider, decision.Model, opts.FastMode)
 	if !env.Stream() && proxyErr == nil {
 		setRouterCostHeaders(w.Header(), routerResponseCostFromPricing(pricing, decision.Provider, in, out, cacheCreation, cacheRead))
+		if responseBuffer != nil {
+			if flushErr := responseBuffer.FlushToClient(); flushErr != nil {
+				log.Error("Failed to flush buffered response", "err", flushErr)
+			}
+		}
 	}
 	inputCost := catalog.EffectiveInputCost(in, cacheCreation, cacheRead, pricing, decision.Provider)
 	outputCost := catalog.EffectiveOutputCost(in, out, pricing)


### PR DESCRIPTION
## Summary
- Persist attempt diagnostics through a bounded, ordered queue with write deadlines, loss counters, and shutdown draining.
- Bound synchronous session bookkeeping without changing routing or credential authority.
- Release successful buffered Messages, Chat, Responses, and Gemini payloads before post-response bookkeeping; retain bounded synchronous billing.

## Validation
- Router-native `make precommit check-agent-guides check-docs` passed in an isolated, credential-free test environment.
- `go test -race ./internal/proxy ./internal/dispatch` passed.
- Tests cover saturation, ordering, shutdown, deadline recovery, provider failover with blocked diagnostics, and complete HTTP responses while usage persistence is blocked.
- Repaired the logger-budget ratchet and an existing race in telemetry-test log capture.

## Stack
Layer 1 of 4 router PRs: bookkeeping → original-request fallback → caller-funded outage authority → degraded startup/recovery. This layer is independently useful and does not enable an authentication bypass or relax readiness.

🤖 Generated with [Weave Router](https://router.workweave.ai)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds bookkeeping so inference and response delivery never wait on slow or failed database writes.

- Attempt diagnostics now flow through an ordered, bounded queue with write deadlines, loss counters, and shutdown draining; saturation drops events instead of blocking dispatch.
- Session pin, feedback, and shadow-store writes get a 250ms cancellation-independent deadline and keep their ordering.
- Successful buffered responses are flushed before post-response bookkeeping; required billing stays synchronous and bounded.

<sup>Written for commit f9fc86ec4d8d609a0216124e812ade9cbcd18680. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weave-os/router/pull/1272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

