### PR TITLE
ci: parallelize tests and stabilize Go caching

### DIFF
--- a/.github/workflows/check_cluster_routing.yml
+++ b/.github/workflows/check_cluster_routing.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.25.9'
           cache-dependency-path: go.sum
 
       - name: Render report + metadata

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.25.9'
           cache-dependency-path: go.sum
 
       - name: Run smoke suite
@@ -110,7 +110,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.25.9'
           cache-dependency-path: go.sum
 
       - name: Require Anthropic key

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,18 +20,14 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.25.9'
           cache-dependency-path: go.sum
 
       - name: Check policy registry and inference boundary
         run: make inference-boundary
 
-  test:
-    name: Test
-    # The branch ruleset requires this check, so gating it on the
-    # prerequisite jobs makes architecture and classifier contract checks required.
-    needs: [inference-boundary, test-hmm-sidecar]
-    if: ${{ always() }}
+  go-checks:
+    name: Go checks
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -49,17 +45,13 @@ jobs:
           --health-retries 30
 
     steps:
-      - name: Require inference and sidecar gates
-        if: needs.inference-boundary.result != 'success' || needs.test-hmm-sidecar.result != 'success'
-        run: exit 1
-
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.25.9'
           cache-dependency-path: go.sum
 
       - name: Install golang-migrate
@@ -182,7 +174,7 @@ jobs:
       - name: Set up Go for the serving contract
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.25.9'
           cache-dependency-path: go.sum
 
       - name: Verify Go to bundled Python contract
@@ -230,3 +222,39 @@ jobs:
         run: |
           docker compose -f docker-compose.yml -f sidecars/hmm/docker-compose.yml \
             --profile hmm config --quiet
+
+  # Keep the branch ruleset's required `Test` check stable while the expensive
+  # jobs run in parallel. `always()` ensures a failed or cancelled dependency
+  # is reported as a failed gate instead of leaving the required check pending.
+  test:
+    name: Test
+    needs:
+      - inference-boundary
+      - go-checks
+      - test-statusline
+      - test-install
+      - test-hmm-sidecar
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require all test jobs
+        env:
+          INFERENCE_BOUNDARY_RESULT: ${{ needs.inference-boundary.result }}
+          GO_CHECKS_RESULT: ${{ needs.go-checks.result }}
+          STATUSLINE_RESULT: ${{ needs.test-statusline.result }}
+          INSTALLER_RESULT: ${{ needs.test-install.result }}
+          HMM_SIDECAR_RESULT: ${{ needs.test-hmm-sidecar.result }}
+        run: |
+          printf '%s\n' \
+            "Inference boundary: $INFERENCE_BOUNDARY_RESULT" \
+            "Go checks: $GO_CHECKS_RESULT" \
+            "Statusline: $STATUSLINE_RESULT" \
+            "Installer: $INSTALLER_RESULT" \
+            "HMM sidecar: $HMM_SIDECAR_RESULT"
+          if [ "$INFERENCE_BOUNDARY_RESULT" != success ] || \
+             [ "$GO_CHECKS_RESULT" != success ] || \
+             [ "$STATUSLINE_RESULT" != success ] || \
+             [ "$INSTALLER_RESULT" != success ] || \
+             [ "$HMM_SIDECAR_RESULT" != success ]; then
+            exit 1
+          fi

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,0 +1,148 @@
+# CI performance
+
+This document records the September 2026 CI timing investigation, the changes
+made from it, and the remaining optimization backlog. The baseline uses wall
+time from `run_started_at` to `updated_at` for successful pull-request runs in
+the latest 100 workflow entries available on 2026-09-11.
+
+## Baseline
+
+| Workflow | Successful PR runs | Median | p90 | Maximum |
+|---|---:|---:|---:|---:|
+| Test | 70 | 3m 57s | 4m 24s | 5m 14s |
+| Smoke | 82 | 4m 26s | 4m 51s | 6m 15s |
+
+[Test run 34648736869](https://github.com/weave-os/router/actions/runs/34648736869)
+showed why the Test critical path was longer than any individual gate:
+
+| Job | Duration |
+|---|---:|
+| Inference boundary | 60s |
+| Test frozen HMM sidecar | 59s |
+| Test installer | 43s |
+| Test cc-statusline | 27s |
+| Test (Go checks, after the first two gates) | 173s |
+
+The Go job did not start until the inference-boundary and HMM jobs completed,
+so the workflow paid roughly 60s plus 173s on its critical path.
+
+## Completed changes
+
+The main Go checks now start at the same time as the other jobs. A small final
+job retains the required check name `Test` and fails unless every constituent
+job succeeds. This keeps branch protection stable while changing the critical
+path to the longest constituent job plus the fan-in job's startup time.
+
+All `actions/setup-go` uses now install Go 1.25.9 explicitly, matching the
+`toolchain go1.25.9` directive in [`go.mod`](../go.mod). Previously setup-go
+installed the `go 1.25.0` directive first. Go then downloaded 1.25.9 into the
+module cache before setup-go restored its roughly 299 MB archive. Cache
+extraction repeatedly failed with `Cannot open: File exists`, and the restored
+cache was discarded. Keep the workflow pins synchronized when the toolchain
+directive changes.
+
+## Follow-up backlog
+
+### P0: repair the nightly cassette refresh
+
+The scheduled Smoke workflow is functionally broken. The smoke tests record
+fresh cassettes successfully, but the Docker container writes files that the
+runner cannot read. The subsequent Git step fails with errors such as:
+
+```text
+error: open("smoke/mitmproxy/cassettes/...json"): Permission denied
+fatal: cannot hash smoke/mitmproxy/cassettes/...json
+fatal: updating files failed
+```
+
+All 20 scheduled runs inspected failed this way. Public example:
+[run 34574571427](https://github.com/weave-os/router/actions/runs/34574571427).
+
+Make the recording container write with the runner's UID and GID. An ownership
+normalization step before Git operations is a smaller fallback, but aligning
+the writer avoids producing inaccessible workspace files in the first place.
+The fix is complete when a scheduled record run can read and stage every
+cassette, then either report no drift or open the refresh PR.
+
+### 3. Make Smoke's Docker cache effective and remove the cold seed container
+
+The Smoke Compose overlay declares a GitHub Actions cache, but sampled BuildKit
+logs did not contain cache import or export activity. Expensive layers rebuilt
+on every run: `npm ci` and the UI build took roughly 32s each, two
+`go mod download` layers took 27-32s, and the Go builds took roughly 13s and
+41s. The separate `golang:1.25-bookworm` seed service added about 47s while it
+downloaded and compiled on a cold container.
+
+Use an explicit `docker buildx bake` or `docker/build-push-action` build step
+with stable per-image `type=gha` scopes, then start Compose with `--no-build`.
+Import the cache from `main` so a new PR branch can reuse it. Build the seed
+binary into an existing image, or a small dedicated image, and invoke that
+artifact instead of `go run` in a fresh SDK container.
+
+Verify this by checking that warm-run logs show both cache import and export,
+and by comparing the build and seed phases across at least ten comparable PR
+runs.
+
+### 4. Cancel superseded Test runs
+
+The Smoke workflow already cancels an older run when a PR is updated, but the
+Test workflow does not. Eleven overlapping stale Test runs in the inspected
+sample consumed 23.1 runner-minutes after a newer commit existed.
+
+Add workflow concurrency keyed by PR number, falling back to the ref for push
+runs, with `cancel-in-progress: true`. Keep scheduled or manually dispatched
+workflows in separate groups where cancellation would change their semantics.
+
+### 5. Remove real retry delays from proxy tests
+
+Fourteen tests under [`internal/proxy`](../internal/proxy) spent 15.04s sleeping
+inside a package whose complete test time was 17.18s. They exercise the real
+250ms exponential retry delay, including overload-exhaustion cases. Other tests
+already inject the package's no-op sleep function.
+
+Inject the no-op sleep consistently in tests that validate retry decisions,
+and reserve real-clock coverage for a narrowly scoped timing test if it is
+needed. Assertions must continue to verify attempt counts, failover, and
+provider-disable behavior. The package should fall to low single-digit seconds
+without reducing behavioral coverage.
+
+### 6. Collapse redundant Go compilation passes
+
+With isolated cold build caches, the current sequence
+`go vet ./...`, `go build -o /dev/null ./...`, and
+`go test -count=1 ./...` took 45.89s locally. A single
+`go test -vet=all -count=1 ./...` took 40.36s, about 12% less.
+
+After confirming the repaired CI cache's warm behavior, remove the separate Vet
+and Typecheck steps and run tests with full vetting. Keep golangci-lint separate.
+Compare both cold and warm runs because eliminating the early steps changes
+which command populates the Go build cache.
+
+### 7. Path-gate component-specific jobs
+
+The statusline, installer, and frozen HMM sidecar jobs run for every pull
+request, even when their inputs cannot have changed. Add a changed-files
+classifier and job-level conditions for their owning paths. The final `Test`
+fan-in must treat an intentionally skipped optional job as acceptable while
+still failing on cancellation or failure. Include the workflow and shared build
+inputs in every component's path set so CI changes cannot bypass coverage.
+
+This primarily saves runner capacity rather than wall time because these jobs
+already run in parallel.
+
+### 8. Bound jobs and expose phase timings
+
+Set `timeout-minutes: 10` on the Test and HMM jobs and
+`timeout-minutes: 15` on Smoke after confirming those limits leave headroom over
+the measured p90. Split Smoke reporting into build, boot, seed, and assertion
+phases, and publish their elapsed times in the job summary. This makes a cache
+regression or service-startup stall visible without downloading the complete
+log.
+
+## Measuring future changes
+
+Use successful pull-request runs with comparable changed paths. Report median,
+p90, and maximum wall time, plus runner-minutes when a change affects parallel
+work rather than the critical path. Treat cancelled, skipped, and
+`action_required` runs separately so they do not appear as zero-duration
+successes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Index of Markdown documentation in the `router/` repo.
 | [HMM_GO_SELECTION.md](HMM_GO_SELECTION.md) | Architecture, `policy_router_v3` split, and rollback story for Go-owned HMM roster ownership and deterministic arm selection. |
 | [TRANSLATION_COMPATIBILITY.md](TRANSLATION_COMPATIBILITY.md) | Cross-format translation requirements and rollout modes. |
 | [SMOKE.md](SMOKE.md) | Pre-merge record/replay smoke-suite scenarios, cassettes, and local workflow. |
+| [CI.md](CI.md) | CI timing baseline, completed improvements, and the remaining optimization backlog. |
 
 For engineering conventions (layer model, package layout, recipes), see the
 root [`CLAUDE.md`](../CLAUDE.md) (and its mirror [`AGENTS.md`](../AGENTS.md)).


### PR DESCRIPTION
## Summary

- Start the main Go checks in parallel with the inference-boundary and HMM jobs.
- Add a final fan-in job that preserves the required `Test` status context and fails unless every constituent test succeeds.
- Pin all `actions/setup-go` steps to Go 1.25.9, matching the module toolchain directive and avoiding the failed ~299 MB cache restores.
- Document the remaining CI optimization backlog and the broken nightly Smoke cassette refresh in `docs/CI.md`.

## Why

The sampled Test run [34648736869](https://github.com/weave-os/router/actions/runs/34648736869) spent about 60 seconds waiting for prerequisite jobs before its 173-second Go job could start. The fan-in structure removes that serialization while keeping branch protection's required `Test` context unchanged.

The previous `go-version-file: go.mod` setup installed Go 1.25.0, after which Go downloaded the `toolchain go1.25.9` toolchain into the module cache. Cache extraction then repeatedly failed with `Cannot open: File exists`, discarding the cache.

## Validation

- `actionlint` passed for the modified workflows.
- Documentation link/symbol/index checks passed, including the new CI document.
- `make check-agent-guides` passed.
- YAML parsing and `git diff --check` passed.

Follow-up recommendations (Docker cache/seed, Test concurrency, retry-test sleeps, Go command consolidation, path gating, timeouts/timing summaries, and the nightly cassette permission failure) are documented but intentionally not implemented in this PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelizes the main Go checks so they no longer wait for prerequisite jobs, and pins Go 1.25.9 in all `actions/setup-go` steps to fix flaky cache restores.

- The Go checks previously started only after the inference-boundary and HMM sidecar jobs finished; they now run in parallel with them.
- A final fan-in job keeps the required `Test` status context and fails unless every constituent job succeeds.
- `setup-go` previously read `go.mod` and installed Go 1.25.0, after which Go downloaded the 1.25.9 toolchain and cache restores failed with `Cannot open: File exists`; all steps now pin `1.25.9` directly.
- Adds `docs/CI.md` documenting the timing baseline, completed changes, and remaining backlog (including the broken nightly Smoke cassette refresh).

**Migration**
- Keep the `actions/setup-go` pins synchronized with the `go.mod` toolchain directive.

<sup>Written for commit 723164a613b3548dbc991dbc4cd9778bb7f67fd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weave-os/router/pull/1286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

