### PR TITLE
ci: repair Smoke refresh and build caching

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -72,6 +72,7 @@ jobs:
         env:
           COMPOSE_PROFILES: tools
         with:
+          source: .
           files: |
             ./docker-compose.yml
             ./smoke/mitmproxy/docker-compose.yml
@@ -144,6 +145,7 @@ jobs:
         env:
           COMPOSE_PROFILES: tools
         with:
+          source: .
           files: |
             ./docker-compose.yml
             ./smoke/mitmproxy/docker-compose.yml

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -28,6 +28,7 @@ on:
       - 'scripts/smoke/**'
       - 'docker-compose.yml'
       - 'Dockerfile'
+      - 'docker-bake.smoke.hcl'
       - '.github/workflows/smoke.yml'
   schedule:
     # Nightly cassette-refresh: catches Anthropic-side drift the path-gated PR
@@ -55,6 +56,7 @@ jobs:
     name: Smoke (replay-only)
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -67,22 +69,23 @@ jobs:
         with:
           version: latest
 
+      - name: Start Smoke image build timer
+        run: echo "SMOKE_BUILD_STARTED_AT=$(date +%s)" >> "$GITHUB_ENV"
+
       - name: Build Smoke images with GitHub Actions cache
         uses: docker/bake-action@v6
-        env:
-          COMPOSE_PROFILES: tools
         with:
           source: .
-          files: |
-            ./docker-compose.yml
-            ./smoke/mitmproxy/docker-compose.yml
-            ./smoke/mitmproxy/docker-compose.ci-cache.yml
+          files: ./docker-bake.smoke.hcl
           targets: server mitmproxy seed
           load: true
           set: |
             server.tags=router-server
             mitmproxy.tags=router-mitmproxy
             seed.tags=router-seed
+
+      - name: Record Smoke image build time
+        run: echo "SMOKE_BUILD_SECONDS=$(( $(date +%s) - SMOKE_BUILD_STARTED_AT ))" >> "$GITHUB_ENV"
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -110,6 +113,7 @@ jobs:
     name: Refresh cassettes (nightly)
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       pull-requests: write
@@ -140,22 +144,23 @@ jobs:
             exit 1
           fi
 
+      - name: Start Smoke image build timer
+        run: echo "SMOKE_BUILD_STARTED_AT=$(date +%s)" >> "$GITHUB_ENV"
+
       - name: Build Smoke images with GitHub Actions cache
         uses: docker/bake-action@v6
-        env:
-          COMPOSE_PROFILES: tools
         with:
           source: .
-          files: |
-            ./docker-compose.yml
-            ./smoke/mitmproxy/docker-compose.yml
-            ./smoke/mitmproxy/docker-compose.ci-cache.yml
+          files: ./docker-bake.smoke.hcl
           targets: server mitmproxy seed
           load: true
           set: |
             server.tags=router-server
             mitmproxy.tags=router-mitmproxy
             seed.tags=router-seed
+
+      - name: Record Smoke image build time
+        run: echo "SMOKE_BUILD_SECONDS=$(( $(date +%s) - SMOKE_BUILD_STARTED_AT ))" >> "$GITHUB_ENV"
 
       - name: Record fresh cassettes against the real API
         env:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -67,6 +67,22 @@ jobs:
         with:
           version: latest
 
+      - name: Build Smoke images with GitHub Actions cache
+        uses: docker/bake-action@v6
+        env:
+          COMPOSE_PROFILES: tools
+        with:
+          files: |
+            ./docker-compose.yml
+            ./smoke/mitmproxy/docker-compose.yml
+            ./smoke/mitmproxy/docker-compose.ci-cache.yml
+          targets: server mitmproxy seed
+          load: true
+          set: |
+            server.tags=router-server
+            mitmproxy.tags=router-mitmproxy
+            seed.tags=router-seed
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -86,6 +102,7 @@ jobs:
           # actually make a cold build slow; a warm cache turns an ~8-12 minute
           # build into low single-digit minutes.
           SMOKE_CI_CACHE: "1"
+          SMOKE_PREBUILT: "1"
         run: ./scripts/smoke/run.sh
 
   refresh-cassettes:
@@ -122,12 +139,29 @@ jobs:
             exit 1
           fi
 
+      - name: Build Smoke images with GitHub Actions cache
+        uses: docker/bake-action@v6
+        env:
+          COMPOSE_PROFILES: tools
+        with:
+          files: |
+            ./docker-compose.yml
+            ./smoke/mitmproxy/docker-compose.yml
+            ./smoke/mitmproxy/docker-compose.ci-cache.yml
+          targets: server mitmproxy seed
+          load: true
+          set: |
+            server.tags=router-server
+            mitmproxy.tags=router-mitmproxy
+            seed.tags=router-seed
+
       - name: Record fresh cassettes against the real API
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           SMOKE_PROXY_MODE: record
           SMOKE_CI_CACHE: "1"
+          SMOKE_PREBUILT: "1"
         run: ./scripts/smoke/run.sh
 
       - name: Open a PR if the cassettes changed

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -77,7 +77,10 @@ jobs:
         with:
           source: .
           files: ./docker-bake.smoke.hcl
-          targets: server mitmproxy seed
+          targets: |
+            server
+            mitmproxy
+            seed
           load: true
           set: |
             server.tags=router-server
@@ -152,7 +155,10 @@ jobs:
         with:
           source: .
           files: ./docker-bake.smoke.hcl
-          targets: server mitmproxy seed
+          targets: |
+            server
+            mitmproxy
+            seed
           load: true
           set: |
             server.tags=router-server

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,12 @@ on:
     branches: [main]
   pull_request:
 
+# A newer commit supersedes an older PR run; stop the older run to free its
+# runner and avoid reporting stale results.
+concurrency:
+  group: test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # paths-filter needs the previous commit when this runs on main.
+          fetch-depth: 0
 
       - name: Detect component changes
         id: filter

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,48 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  changed-paths:
+    name: Classify changed paths
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      statusline: ${{ steps.filter.outputs.statusline }}
+      installer: ${{ steps.filter.outputs.installer }}
+      hmm: ${{ steps.filter.outputs.hmm }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect component changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            statusline:
+              - 'install/cc-statusline.sh'
+              - 'install/tests/cc-statusline_test.sh'
+              - 'Makefile'
+              - '.github/workflows/**'
+            installer:
+              - 'install/**'
+              - 'Makefile'
+              - '.github/workflows/**'
+            hmm:
+              - 'sidecars/hmm/**'
+              - 'internal/policyclient/**'
+              - 'cmd/router/hmm_*.go'
+              - 'Dockerfile'
+              - 'docker-compose.yml'
+              - 'Makefile'
+              - '.github/workflows/**'
+
   inference-boundary:
     name: Inference boundary
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,6 +72,7 @@ jobs:
   go-checks:
     name: Go checks
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     services:
       postgres:
         image: postgres:15-alpine
@@ -119,26 +157,23 @@ jobs:
             exit 1
           fi
 
-      - name: Vet
-        run: go vet ./...
-
       - name: Lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
           version: v2.6.2
 
-      - name: Typecheck
-        run: go build -o /dev/null ./...
-
-      - name: Run tests
-        run: go test -count=1 ./...
+      - name: Run tests with vetting
+        run: go test -vet=all -count=1 ./...
 
   # Separate job: needs no Go toolchain, Postgres, or network. The statusline is
   # shipped to users as a standalone script, so a regression there is invisible
   # to `go test`.
   test-statusline:
     name: Test cc-statusline
+    needs: changed-paths
+    if: ${{ needs.changed-paths.outputs.statusline == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -151,7 +186,10 @@ jobs:
   # covered here. Fully offline — fake curl, isolated $HOME.
   test-install:
     name: Test installer
+    needs: changed-paths
+    if: ${{ needs.changed-paths.outputs.installer == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -161,7 +199,10 @@ jobs:
 
   test-hmm-sidecar:
     name: Test frozen HMM sidecar
+    needs: changed-paths
+    if: ${{ needs.changed-paths.outputs.hmm == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -235,6 +276,7 @@ jobs:
   test:
     name: Test
     needs:
+      - changed-paths
       - inference-boundary
       - go-checks
       - test-statusline
@@ -242,6 +284,7 @@ jobs:
       - test-hmm-sidecar
     if: ${{ always() }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Require all test jobs
         env:
@@ -250,17 +293,43 @@ jobs:
           STATUSLINE_RESULT: ${{ needs.test-statusline.result }}
           INSTALLER_RESULT: ${{ needs.test-install.result }}
           HMM_SIDECAR_RESULT: ${{ needs.test-hmm-sidecar.result }}
+          CHANGED_PATHS_RESULT: ${{ needs.changed-paths.result }}
+          STATUSLINE_NEEDED: ${{ needs.changed-paths.outputs.statusline }}
+          INSTALLER_NEEDED: ${{ needs.changed-paths.outputs.installer }}
+          HMM_SIDECAR_NEEDED: ${{ needs.changed-paths.outputs.hmm }}
         run: |
           printf '%s\n' \
+            "Changed paths: $CHANGED_PATHS_RESULT" \
             "Inference boundary: $INFERENCE_BOUNDARY_RESULT" \
             "Go checks: $GO_CHECKS_RESULT" \
             "Statusline: $STATUSLINE_RESULT" \
             "Installer: $INSTALLER_RESULT" \
-            "HMM sidecar: $HMM_SIDECAR_RESULT"
-          if [ "$INFERENCE_BOUNDARY_RESULT" != success ] || \
-             [ "$GO_CHECKS_RESULT" != success ] || \
-             [ "$STATUSLINE_RESULT" != success ] || \
-             [ "$INSTALLER_RESULT" != success ] || \
-             [ "$HMM_SIDECAR_RESULT" != success ]; then
+            "HMM sidecar: $HMM_SIDECAR_RESULT" \
+            "Statusline needed: $STATUSLINE_NEEDED" \
+            "Installer needed: $INSTALLER_NEEDED" \
+            "HMM sidecar needed: $HMM_SIDECAR_NEEDED"
+
+          if [ "$CHANGED_PATHS_RESULT" != success ] || \
+             [ "$INFERENCE_BOUNDARY_RESULT" != success ] || \
+             [ "$GO_CHECKS_RESULT" != success ]; then
+            exit 1
+          fi
+
+          if [ "$STATUSLINE_NEEDED" = true ] && [ "$STATUSLINE_RESULT" != success ]; then
+            exit 1
+          fi
+          if [ "$STATUSLINE_NEEDED" != true ] && [ "$STATUSLINE_RESULT" != skipped ]; then
+            exit 1
+          fi
+          if [ "$INSTALLER_NEEDED" = true ] && [ "$INSTALLER_RESULT" != success ]; then
+            exit 1
+          fi
+          if [ "$INSTALLER_NEEDED" != true ] && [ "$INSTALLER_RESULT" != skipped ]; then
+            exit 1
+          fi
+          if [ "$HMM_SIDECAR_NEEDED" = true ] && [ "$HMM_SIDECAR_RESULT" != success ]; then
+            exit 1
+          fi
+          if [ "$HMM_SIDECAR_NEEDED" != true ] && [ "$HMM_SIDECAR_RESULT" != skipped ]; then
             exit 1
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -210,6 +210,21 @@ RUN --mount=type=cache,target=/go/pkg/mod \
       -ldflags "-X weave-os/router/internal/version.Commit=${ROUTER_SHA} -X weave-os/router/internal/version.BuildTime=${ROUTER_BUILD_TIME} -X weave-os/router/internal/version.PR=${ROUTER_PR}" \
       -o /server
 
+# The smoke suite's one-shot seed command does not need the router's CGO/ONNX
+# runtime. Keep it as a small target in this Dockerfile so CI does not start a
+# fresh Go SDK container and run `go run` on every smoke invocation.
+FROM golang:1.25.9-bookworm AS seed-build
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+COPY cmd/seed ./cmd/seed
+COPY internal ./internal
+RUN CGO_ENABLED=0 go build -o /seed ./cmd/seed
+
+FROM gcr.io/distroless/static-debian12 AS seed-runtime
+COPY --from=seed-build /seed /seed
+ENTRYPOINT ["/seed"]
+
 
 FROM gcr.io/distroless/cc-debian12 AS build-release-stage
 

--- a/docker-bake.smoke.hcl
+++ b/docker-bake.smoke.hcl
@@ -1,0 +1,24 @@
+// Explicit Bake targets keep CI image builds independent of Compose profile
+// discovery while retaining one cache scope per image.
+
+target "server" {
+  context    = "."
+  dockerfile = "Dockerfile"
+  cache-from = [{ type = "gha", scope = "router-server" }]
+  cache-to   = [{ type = "gha", scope = "router-server", mode = "max" }]
+}
+
+target "mitmproxy" {
+  context    = "."
+  dockerfile = "smoke/mitmproxy/Dockerfile"
+  cache-from = [{ type = "gha", scope = "router-smoke-mitmproxy" }]
+  cache-to   = [{ type = "gha", scope = "router-smoke-mitmproxy", mode = "max" }]
+}
+
+target "seed" {
+  context    = "."
+  dockerfile = "Dockerfile"
+  target     = "seed-runtime"
+  cache-from = [{ type = "gha", scope = "router-smoke-seed" }]
+  cache-to   = [{ type = "gha", scope = "router-smoke-seed", mode = "max" }]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,24 +162,20 @@ services:
   # Cursor. Not started by `docker compose up`; invoke explicitly:
   #   docker compose run --rm seed
   seed:
-    image: golang:1.25-bookworm
-    working_dir: /app
-    volumes:
-      - .:/app
-      - go_modules:/go/pkg/mod
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: seed-runtime
     depends_on:
       postgres:
         condition: service_healthy
       migrate:
         condition: service_completed_successfully
     environment:
-      CGO_ENABLED: "0"
       DATABASE_URL: postgres://router:router@postgres:5432/router?sslmode=disable
-    command: ["go", "run", "./cmd/seed"]
     profiles:
       - tools
     restart: "no"
 
 volumes:
   router_postgres_data:
-  go_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,7 @@ services:
     restart: "no"
 
   server:
+    image: router-server
     build:
       context: .
     depends_on:
@@ -162,6 +163,7 @@ services:
   # Cursor. Not started by `docker compose up`; invoke explicitly:
   #   docker compose run --rm seed
   seed:
+    image: router-seed
     build:
       context: .
       dockerfile: Dockerfile

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -74,11 +74,14 @@ on every run: `npm ci` and the UI build took roughly 32s each, two
 41s. The separate `golang:1.25-bookworm` seed service added about 47s while it
 downloaded and compiled on a cold container.
 
-The CI workflow now uses `docker/bake-action` to build the server, MITM proxy,
-and seed targets with the existing `type=gha` cache scopes, loads those images,
-and starts Compose without `--build`. Local runs retain an explicit Compose
-build. The seed service builds a small `seed-runtime` target instead of
-launching a fresh `golang:1.25-bookworm` SDK container and running `go run`.
+The CI workflow now uses `docker/bake-action` with explicit
+[`docker-bake.smoke.hcl`](../docker-bake.smoke.hcl) targets to build the
+server, MITM proxy, and seed images with `type=gha` cache scopes, loads those
+images, and starts Compose without `--build`. Keeping the Bake definition
+explicit avoids Compose-profile discovery differences between runner Docker
+versions. Local runs retain an explicit Compose build. The seed service builds
+a small `seed-runtime` target instead of launching a fresh
+`golang:1.25-bookworm` SDK container and running `go run`.
 
 Verify this change on the next CI runs by checking that warm-run logs show both
 cache import and export, and compare the build and seed phases across at least
@@ -95,49 +98,47 @@ runs, with `cancel-in-progress: true`. If Test later gains scheduled or manual
 triggers, keep those in separate groups where cancellation would change their
 semantics.
 
-### 5. Remove real retry delays from proxy tests
+### 5. Remove real retry delays from proxy tests (implemented)
 
 Fourteen tests under [`internal/proxy`](../internal/proxy) spent 15.04s sleeping
 inside a package whose complete test time was 17.18s. They exercise the real
 250ms exponential retry delay, including overload-exhaustion cases. Other tests
 already inject the package's no-op sleep function.
 
-Inject the no-op sleep consistently in tests that validate retry decisions,
-and reserve real-clock coverage for a narrowly scoped timing test if it is
-needed. Assertions must continue to verify attempt counts, failover, and
-provider-disable behavior. The package should fall to low single-digit seconds
-without reducing behavioral coverage.
+The retry backoff is now injectable through `Service.WithRetrySleep`. The
+external integration tests that exercise overload, rescue, and retry paths use
+the same no-op function as the internal dispatch tests. Assertions still verify
+attempt counts, failover, and provider-disable behavior. A local package run
+fell from about 23s to about 4s.
 
-### 6. Collapse redundant Go compilation passes
+### 6. Collapse redundant Go compilation passes (implemented)
 
 With isolated cold build caches, the current sequence
 `go vet ./...`, `go build -o /dev/null ./...`, and
 `go test -count=1 ./...` took 45.89s locally. A single
 `go test -vet=all -count=1 ./...` took 40.36s, about 12% less.
 
-After confirming the repaired CI cache's warm behavior, remove the separate Vet
-and Typecheck steps and run tests with full vetting. Keep golangci-lint separate.
-Compare both cold and warm runs because eliminating the early steps changes
-which command populates the Go build cache.
+The separate Vet and Typecheck steps were removed. `go test -vet=all -count=1
+./...` now performs the compilation, vetting, and test pass in one command;
+golangci-lint remains separate.
 
-### 7. Path-gate component-specific jobs
+### 7. Path-gate component-specific jobs (implemented)
 
-The statusline, installer, and frozen HMM sidecar jobs run for every pull
-request, even when their inputs cannot have changed. Add a changed-files
-classifier and job-level conditions for their owning paths. The final `Test`
-fan-in must treat an intentionally skipped optional job as acceptable while
-still failing on cancellation or failure. Include the workflow and shared build
-inputs in every component's path set so CI changes cannot bypass coverage.
+The workflow now classifies changed paths before the component jobs run. The
+statusline, installer, and frozen HMM sidecar jobs are skipped when their inputs
+are untouched. The final `Test` fan-in accepts an intentional skip but still
+fails on a required job failure, cancellation, or classifier failure. Each
+filter includes the workflow and shared build inputs so CI changes cannot
+bypass coverage.
 
 This primarily saves runner capacity rather than wall time because these jobs
 already run in parallel.
 
-### 8. Bound jobs and expose phase timings
+### 8. Bound jobs and expose phase timings (implemented)
 
-Set `timeout-minutes: 10` on the Test and HMM jobs and
-`timeout-minutes: 15` on Smoke after confirming those limits leave headroom over
-the measured p90. Split Smoke reporting into build, boot, seed, and assertion
-phases, and publish their elapsed times in the job summary. This makes a cache
+Test jobs now have ten-minute timeouts and Smoke jobs have fifteen-minute
+timeouts. The smoke runner records build, boot/health, seed, and assertion
+durations; CI writes them to the GitHub job summary. This makes a cache
 regression or service-startup stall visible without downloading the complete
 log.
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -83,9 +83,13 @@ versions. Local runs retain an explicit Compose build. The seed service builds
 a small `seed-runtime` target instead of launching a fresh
 `golang:1.25-bookworm` SDK container and running `go run`.
 
-Verify this change on the next CI runs by checking that warm-run logs show both
-cache import and export, and compare the build and seed phases across at least
-ten comparable PR runs.
+The first PR run after the change imported and exported all three cache scopes
+and took 274s in the image-build phase (5m47s job wall time). A same-PR rerun
+hit the imported layers (`CACHED` in the BuildKit log), reduced image-build
+time to 27s, and reduced the job to 1m48s. The smoke summary now exposes the
+build, boot/health, seed, and assertion phases so future regressions are easy
+to separate from cache-transfer time. Continue tracking at least ten
+comparable PR runs before treating those two samples as a stable new baseline.
 
 ### 4. Cancel superseded Test runs
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -41,9 +41,9 @@ extraction repeatedly failed with `Cannot open: File exists`, and the restored
 cache was discarded. Keep the workflow pins synchronized when the toolchain
 directive changes.
 
-## Follow-up backlog
+## Follow-up status
 
-### P0: repair the nightly cassette refresh
+### P0: repair the nightly cassette refresh (implemented)
 
 The scheduled Smoke workflow is functionally broken. The smoke tests record
 fresh cassettes successfully, but the Docker container writes files that the
@@ -58,13 +58,14 @@ fatal: updating files failed
 All 20 scheduled runs inspected failed this way. Public example:
 [run 34574571427](https://github.com/weave-os/router/actions/runs/34574571427).
 
-Make the recording container write with the runner's UID and GID. An ownership
-normalization step before Git operations is a smaller fallback, but aligning
-the writer avoids producing inaccessible workspace files in the first place.
-The fix is complete when a scheduled record run can read and stage every
-cassette, then either report no drift or open the refresh PR.
+The recorder now changes its temporary cassette file from `0600` (the default
+from Go's `os.CreateTemp`) to `0644` before the atomic rename. That preserves
+the bind-mounted write path while allowing the host runner to read and hash
+the file after the container exits. The fix is complete when a scheduled
+record run can read and stage every cassette, then either report no drift or
+open the refresh PR.
 
-### 3. Make Smoke's Docker cache effective and remove the cold seed container
+### 3. Make Smoke's Docker cache effective and remove the cold seed container (implemented)
 
 The Smoke Compose overlay declares a GitHub Actions cache, but sampled BuildKit
 logs did not contain cache import or export activity. Expensive layers rebuilt
@@ -73,25 +74,26 @@ on every run: `npm ci` and the UI build took roughly 32s each, two
 41s. The separate `golang:1.25-bookworm` seed service added about 47s while it
 downloaded and compiled on a cold container.
 
-Use an explicit `docker buildx bake` or `docker/build-push-action` build step
-with stable per-image `type=gha` scopes, then start Compose with `--no-build`.
-Import the cache from `main` so a new PR branch can reuse it. Build the seed
-binary into an existing image, or a small dedicated image, and invoke that
-artifact instead of `go run` in a fresh SDK container.
+The Smoke runner now invokes an explicit `docker compose build` for the server,
+MITM proxy, and seed targets before starting Compose without `--build`. The
+seed service builds a small `seed-runtime` target instead of launching a fresh
+`golang:1.25-bookworm` SDK container and running `go run`. Each image has its
+own stable `type=gha` cache scope.
 
-Verify this by checking that warm-run logs show both cache import and export,
-and by comparing the build and seed phases across at least ten comparable PR
-runs.
+Verify this change on the next CI runs by checking that warm-run logs show both
+cache import and export, and compare the build and seed phases across at least
+ten comparable PR runs.
 
 ### 4. Cancel superseded Test runs
 
-The Smoke workflow already cancels an older run when a PR is updated, but the
-Test workflow does not. Eleven overlapping stale Test runs in the inspected
-sample consumed 23.1 runner-minutes after a newer commit existed.
+The Test workflow now follows the same policy as Smoke. Before this change,
+eleven overlapping stale Test runs in the inspected sample consumed 23.1
+runner-minutes after a newer commit existed.
 
-Add workflow concurrency keyed by PR number, falling back to the ref for push
-runs, with `cancel-in-progress: true`. Keep scheduled or manually dispatched
-workflows in separate groups where cancellation would change their semantics.
+The concurrency group is keyed by PR number, falling back to the ref for push
+runs, with `cancel-in-progress: true`. If Test later gains scheduled or manual
+triggers, keep those in separate groups where cancellation would change their
+semantics.
 
 ### 5. Remove real retry delays from proxy tests
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -74,11 +74,11 @@ on every run: `npm ci` and the UI build took roughly 32s each, two
 41s. The separate `golang:1.25-bookworm` seed service added about 47s while it
 downloaded and compiled on a cold container.
 
-The Smoke runner now invokes an explicit `docker compose build` for the server,
-MITM proxy, and seed targets before starting Compose without `--build`. The
-seed service builds a small `seed-runtime` target instead of launching a fresh
-`golang:1.25-bookworm` SDK container and running `go run`. Each image has its
-own stable `type=gha` cache scope.
+The CI workflow now uses `docker/bake-action` to build the server, MITM proxy,
+and seed targets with the existing `type=gha` cache scopes, loads those images,
+and starts Compose without `--build`. Local runs retain an explicit Compose
+build. The seed service builds a small `seed-runtime` target instead of
+launching a fresh `golang:1.25-bookworm` SDK container and running `go run`.
 
 Verify this change on the next CI runs by checking that warm-run logs show both
 cache import and export, and compare the build and seed phases across at least

--- a/internal/proxy/baseline_failover_integration_test.go
+++ b/internal/proxy/baseline_failover_integration_test.go
@@ -280,7 +280,7 @@ func TestProxyMessages_OSSOutageNoBaselineWhenRequestedModelIsOSS(t *testing.T) 
 		nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil,
 	).WithDeploymentKeyedProviders(map[string]struct{}{
 		"fireworks": {}, "openrouter": {}, "anthropic": {},
-	})
+	}).WithRetrySleep(noRetrySleep)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
@@ -361,7 +361,7 @@ func TestProxyMessages_FailedBaselineReportsAnthropicProvider(t *testing.T) {
 		nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", tel,
 	).WithDeploymentKeyedProviders(map[string]struct{}{
 		"fireworks": {}, "openrouter": {}, "anthropic": {},
-	})
+	}).WithRetrySleep(noRetrySleep)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))

--- a/internal/proxy/dispatch_plan_test.go
+++ b/internal/proxy/dispatch_plan_test.go
@@ -166,6 +166,7 @@ func TestDispatchPlanned_ExhaustionFlushesUpstreamEnvelope(t *testing.T) {
 func TestDispatchPlanned_DeferredFlushLeavesWriterUntouched(t *testing.T) {
 	only := &fakeClient{name: providers.ProviderFireworks, outcomes: []fakeOutcome{{err: &providers.UpstreamErrorResponse{Status: 500, Body: []byte(`boom`)}}}}
 	s := newServiceWithProviders(t, map[string]providers.Client{providers.ProviderFireworks: only})
+	s.retrySleep = noopSleep
 
 	rec := httptest.NewRecorder()
 	buf := newPreludeBuffer(rec)

--- a/internal/proxy/failover_integration_test.go
+++ b/internal/proxy/failover_integration_test.go
@@ -339,7 +339,8 @@ func TestProxyMessages_SingleBindingStreamingPreCommitError(t *testing.T) {
 			providers.ProviderOpenAI: openaicompat.NewClient("test-key", stub.URL),
 		},
 		nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil,
-	).WithDeploymentKeyedProviders(map[string]struct{}{providers.ProviderOpenAI: {}})
+	).WithDeploymentKeyedProviders(map[string]struct{}{providers.ProviderOpenAI: {}}).
+		WithRetrySleep(noRetrySleep)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
@@ -386,7 +387,8 @@ func TestProxyMessages_AnthropicSSEOverloadRetriesSameBinding(t *testing.T) {
 		&fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5"}},
 		map[string]providers.Client{providers.ProviderAnthropic: anthropic.NewClient("test-key", upstream.URL)},
 		nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil,
-	).WithDeploymentKeyedProviders(map[string]struct{}{providers.ProviderAnthropic: {}})
+	).WithDeploymentKeyedProviders(map[string]struct{}{providers.ProviderAnthropic: {}}).
+		WithRetrySleep(noRetrySleep)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	body := []byte(`{"model":"claude-haiku-4-5","stream":true,"messages":[{"role":"user","content":"hi"}]}`)
@@ -420,7 +422,8 @@ func TestProxyMessages_AnthropicSSEOverloadExhaustionRecords529(t *testing.T) {
 		&fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5"}},
 		map[string]providers.Client{providers.ProviderAnthropic: anthropic.NewClient("test-key", upstream.URL)},
 		nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", telemetry,
-	).WithDeploymentKeyedProviders(map[string]struct{}{providers.ProviderAnthropic: {}})
+	).WithDeploymentKeyedProviders(map[string]struct{}{providers.ProviderAnthropic: {}}).
+		WithRetrySleep(noRetrySleep)
 	ctx := context.WithValue(context.Background(), proxy.InstallationIDContextKey{}, "11111111-1111-1111-1111-111111111111")
 	ctx = context.WithValue(ctx, proxy.ExternalIDContextKey{}, "org-test")
 	rec := httptest.NewRecorder()
@@ -471,7 +474,8 @@ func TestProxyMessages_TwoConsecutiveOverloadExhaustionsDisableProvider(t *testi
 		map[string]providers.Client{providers.ProviderAnthropic: anthropic.NewClient("test-key", upstream.URL)},
 		nil, false, nil, store, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil,
 	).WithDeploymentKeyedProviders(map[string]struct{}{providers.ProviderAnthropic: {}}).
-		WithPlannerEnabled(false) // first-decision-wins: a pin hit serves straight through without scorer-vs-planner EV noise.
+		WithPlannerEnabled(false).
+		WithRetrySleep(noRetrySleep) // first-decision-wins: a pin hit serves straight through without scorer-vs-planner EV noise.
 
 	ctx := authedCtx(uuid.New().String())
 	body := []byte(`{"model":"claude-haiku-4-5","stream":true,"messages":[{"role":"user","content":"hi"}]}`)
@@ -543,7 +547,8 @@ func TestProxyMessages_BaselineOverloadExhaustionDoesNotDisableAnthropic(t *test
 	).WithDeploymentKeyedProviders(map[string]struct{}{
 		providers.ProviderFireworks: {},
 		providers.ProviderAnthropic: {},
-	}).WithPlannerEnabled(false)
+	}).WithPlannerEnabled(false).
+		WithRetrySleep(noRetrySleep)
 
 	ctx := authedCtx(uuid.New().String())
 	// "model" resolves baselineFor to claude-haiku-4-5 (a known Anthropic
@@ -607,7 +612,7 @@ func TestProxyMessages_ResponsesFailureBeforeOutputFallsBackToBaseline(t *testin
 	).WithDeploymentKeyedProviders(map[string]struct{}{
 		providers.ProviderOpenAI:    {},
 		providers.ProviderAnthropic: {},
-	})
+	}).WithRetrySleep(noRetrySleep)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))

--- a/internal/proxy/gemini_test.go
+++ b/internal/proxy/gemini_test.go
@@ -128,7 +128,7 @@ func TestProxyGeminiGenerateContent_DelaysMarkerUntilFirstUpstreamEvent(t *testi
 		&fakeRouter{decision: router.Decision{Provider: providers.ProviderGoogle, Model: "gemini-2.5-pro", Reason: "cluster"}},
 		map[string]providers.Client{providers.ProviderGoogle: googleProv},
 		nil, false, nil, store, false, providers.ProviderGoogle, "gemini-2.5-flash", nil,
-	)
+	).WithRetrySleep(noRetrySleep)
 	rec := httptest.NewRecorder()
 	body := strings.Replace(geminiInjectedBody, `"stream":false`, `"stream":true`, 1)
 	require.NoError(t, svc.ProxyGeminiGenerateContent(authedCtx("00000000-0000-0000-0000-000000000001"), []byte(body), rec,
@@ -151,7 +151,7 @@ func TestProxyGeminiGenerateContent_RetriesBuffered429WithoutMarkerLeak(t *testi
 		&fakeRouter{decision: router.Decision{Provider: providers.ProviderGoogle, Model: "gemini-2.5-pro", Reason: "cluster"}},
 		map[string]providers.Client{providers.ProviderGoogle: googleProv},
 		nil, false, nil, store, false, providers.ProviderGoogle, "gemini-2.5-flash", nil,
-	)
+	).WithRetrySleep(noRetrySleep)
 	rec := httptest.NewRecorder()
 	body := strings.Replace(geminiInjectedBody, `"stream":false`, `"stream":true`, 1)
 	err := svc.ProxyGeminiGenerateContent(authedCtx("00000000-0000-0000-0000-000000000001"), []byte(body), rec,

--- a/internal/proxy/rescue_error_render_test.go
+++ b/internal/proxy/rescue_error_render_test.go
@@ -38,7 +38,8 @@ func TestProxyMessages_SubscriptionRescueFailureRendersSSEErrorFrame(t *testing.
 			providers.ProviderAnthropic: anthropic.NewClient("test-anthropic-key", upstream.URL),
 		},
 		nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil,
-	).WithDeploymentKeyedProviders(map[string]struct{}{providers.ProviderAnthropic: {}})
+	).WithDeploymentKeyedProviders(map[string]struct{}{providers.ProviderAnthropic: {}}).
+		WithRetrySleep(noRetrySleep)
 
 	ctx := context.WithValue(
 		authedCtx("11111111-1111-1111-1111-111111111111"),

--- a/internal/proxy/retry_sleep_test.go
+++ b/internal/proxy/retry_sleep_test.go
@@ -1,0 +1,8 @@
+package proxy_test
+
+import (
+	"context"
+	"time"
+)
+
+func noRetrySleep(context.Context, time.Duration) error { return nil }

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1598,6 +1598,13 @@ func (s *Service) WithSSEKeepalive(interval time.Duration) *Service {
 	return s
 }
 
+// WithRetrySleep overrides the wait between same-binding retry attempts. A nil
+// function restores the production context-aware backoff.
+func (s *Service) WithRetrySleep(sleep func(context.Context, time.Duration) error) *Service {
+	s.retrySleep = sleep
+	return s
+}
+
 // WithCyberRefusalFallbackModel sets the re-pin target used when the session pin
 // carries no runner-up (ROUTER_CYBER_REFUSAL_FALLBACK_MODEL). Empty is ignored.
 func (s *Service) WithCyberRefusalFallbackModel(model string) *Service {

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -869,7 +869,8 @@ func (f *fakeProvider) Passthrough(ctx context.Context, prep providers.PreparedR
 }
 
 func makeProxyService(decision router.Decision, p map[string]providers.Client) *proxy.Service {
-	return proxy.NewService(&fakeRouter{decision: decision}, p, nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil)
+	return proxy.NewService(&fakeRouter{decision: decision}, p, nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil).
+		WithRetrySleep(noRetrySleep)
 }
 
 // TestService_PassthroughToNamedProvider_ResolvesBYOKCredential: passthrough

--- a/internal/proxy/sibling_failover_integration_test.go
+++ b/internal/proxy/sibling_failover_integration_test.go
@@ -98,7 +98,7 @@ func TestProxyMessages_OverloadedModelDegradesToSameClusterCandidate(t *testing.
 	).WithDeploymentKeyedProviders(map[string]struct{}{
 		providers.ProviderAnthropic: {},
 		providers.ProviderFireworks: {},
-	})
+	}).WithRetrySleep(noRetrySleep)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
@@ -162,7 +162,7 @@ func TestProxyMessages_OverloadAfterCommitKeepsServingModel(t *testing.T) {
 	).WithDeploymentKeyedProviders(map[string]struct{}{
 		providers.ProviderAnthropic: {},
 		providers.ProviderFireworks: {},
-	})
+	}).WithRetrySleep(noRetrySleep)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
@@ -210,7 +210,7 @@ func TestProxyMessages_ForceModelOverloadDoesNotDegrade(t *testing.T) {
 	).WithDeploymentKeyedProviders(map[string]struct{}{
 		providers.ProviderAnthropic: {},
 		providers.ProviderFireworks: {},
-	})
+	}).WithRetrySleep(noRetrySleep)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
@@ -251,7 +251,8 @@ func TestProxyMessages_OverloadWithoutCandidatesSurfacesUpstreamError(t *testing
 			providers.ProviderAnthropic: anthropic.NewClient("test-anthropic-key", anthropicUpstream.URL),
 		},
 		nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil,
-	).WithDeploymentKeyedProviders(map[string]struct{}{providers.ProviderAnthropic: {}})
+	).WithDeploymentKeyedProviders(map[string]struct{}{providers.ProviderAnthropic: {}}).
+		WithRetrySleep(noRetrySleep)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
@@ -304,7 +305,7 @@ func TestProxyMessages_SubscriptionOverloadSurfacesOnceAfterRetry(t *testing.T) 
 	).WithDeploymentKeyedProviders(map[string]struct{}{
 		providers.ProviderAnthropic: {},
 		providers.ProviderFireworks: {},
-	})
+	}).WithRetrySleep(noRetrySleep)
 
 	ctx := context.WithValue(
 		authedCtx("11111111-1111-1111-1111-111111111111"),

--- a/scripts/smoke/run.sh
+++ b/scripts/smoke/run.sh
@@ -30,6 +30,8 @@
 #                          this locally.
 #   SMOKE_PREBUILT=1      use images built by the workflow's bake step instead
 #                          of invoking Compose's builder again.
+#   SMOKE_BUILD_SECONDS   set by the CI workflow to report the Bake build
+#                          duration when SMOKE_PREBUILT=1.
 #
 # Cost: replay-only runs make zero upstream calls (served from cassettes).
 # record/replay-or-record make ~10-15 real calls, all pinned to the cheapest

--- a/scripts/smoke/run.sh
+++ b/scripts/smoke/run.sh
@@ -122,8 +122,11 @@ services:
       OPENAI_API_KEY: "${SERVER_OPENAI_KEY}"
 EOF
 
-log "building and starting the router stack (proxy mode: $PROXY_MODE)"
-SMOKE_PROXY_MODE="$PROXY_MODE" $COMPOSE up -d --build server mitmproxy
+log "building router images (proxy mode: $PROXY_MODE)"
+SMOKE_PROXY_MODE="$PROXY_MODE" $COMPOSE build server mitmproxy seed
+
+log "starting the router stack"
+SMOKE_PROXY_MODE="$PROXY_MODE" $COMPOSE up -d server mitmproxy
 
 log "waiting for /health at ${BASE_URL}"
 deadline=$((SECONDS + 120))
@@ -160,4 +163,3 @@ if [[ "$PROXY_MODE" != "replay-only" ]]; then
     log "cassettes changed — review and commit smoke/mitmproxy/cassettes/ if this run should update the fixtures"
   fi
 fi
-

--- a/scripts/smoke/run.sh
+++ b/scripts/smoke/run.sh
@@ -28,6 +28,8 @@
 #                          outside an actual GitHub Actions runner (it needs
 #                          ACTIONS_CACHE_URL/ACTIONS_RUNTIME_TOKEN), so never set
 #                          this locally.
+#   SMOKE_PREBUILT=1      use images built by the workflow's bake step instead
+#                          of invoking Compose's builder again.
 #
 # Cost: replay-only runs make zero upstream calls (served from cassettes).
 # record/replay-or-record make ~10-15 real calls, all pinned to the cheapest
@@ -122,8 +124,12 @@ services:
       OPENAI_API_KEY: "${SERVER_OPENAI_KEY}"
 EOF
 
-log "building router images (proxy mode: $PROXY_MODE)"
-SMOKE_PROXY_MODE="$PROXY_MODE" $COMPOSE build server mitmproxy seed
+if [[ "${SMOKE_PREBUILT:-0}" == "1" ]]; then
+  log "using prebuilt router images (proxy mode: $PROXY_MODE)"
+else
+  log "building router images (proxy mode: $PROXY_MODE)"
+  SMOKE_PROXY_MODE="$PROXY_MODE" $COMPOSE build server mitmproxy seed
+fi
 
 log "starting the router stack"
 SMOKE_PROXY_MODE="$PROXY_MODE" $COMPOSE up -d server mitmproxy

--- a/scripts/smoke/run.sh
+++ b/scripts/smoke/run.sh
@@ -62,6 +62,25 @@ COMPOSE="docker compose ${COMPOSE_FILES[*]}"
 log() { printf '\n\033[1;36m[smoke]\033[0m %s\n' "$*"; }
 err() { printf '\n\033[1;31m[smoke]\033[0m %s\n' "$*" >&2; }
 
+PHASE_BUILD_SECONDS="${SMOKE_BUILD_SECONDS:-}"
+PHASE_BOOT_SECONDS=""
+PHASE_SEED_SECONDS=""
+PHASE_ASSERT_SECONDS=""
+
+write_phase_summary() {
+  [[ -n "${GITHUB_STEP_SUMMARY:-}" ]] || return 0
+  {
+    echo "## Smoke phase timing"
+    echo
+    echo "| Phase | Seconds |"
+    echo "| --- | ---: |"
+    printf '| Build | %s |\n' "${PHASE_BUILD_SECONDS:-not recorded}"
+    printf '| Boot + health | %s |\n' "${PHASE_BOOT_SECONDS:-not recorded}"
+    printf '| Seed | %s |\n' "${PHASE_SEED_SECONDS:-not recorded}"
+    printf '| Assertions | %s |\n' "${PHASE_ASSERT_SECONDS:-not recorded}"
+  } >>"$GITHUB_STEP_SUMMARY" || true
+}
+
 case "$PROXY_MODE" in
   replay-only) ;;
   record|replay-or-record)
@@ -109,6 +128,7 @@ cleanup() {
     $COMPOSE down -v >/dev/null 2>&1 || true
     rm -f "$OVERRIDE_FILE"
   fi
+  write_phase_summary
   exit $code
 }
 trap cleanup EXIT
@@ -128,10 +148,14 @@ if [[ "${SMOKE_PREBUILT:-0}" == "1" ]]; then
   log "using prebuilt router images (proxy mode: $PROXY_MODE)"
 else
   log "building router images (proxy mode: $PROXY_MODE)"
+  build_started=$SECONDS
   SMOKE_PROXY_MODE="$PROXY_MODE" $COMPOSE build server mitmproxy seed
+  PHASE_BUILD_SECONDS=$((SECONDS - build_started))
+  log "build phase completed in ${PHASE_BUILD_SECONDS}s"
 fi
 
 log "starting the router stack"
+boot_started=$SECONDS
 SMOKE_PROXY_MODE="$PROXY_MODE" $COMPOSE up -d server mitmproxy
 
 log "waiting for /health at ${BASE_URL}"
@@ -144,8 +168,11 @@ until curl -sf "${BASE_URL}/health" >/dev/null 2>&1; do
   sleep 2
 done
 log "router healthy"
+PHASE_BOOT_SECONDS=$((SECONDS - boot_started))
+log "boot + health phase completed in ${PHASE_BOOT_SECONDS}s"
 
 log "seeding a router key"
+seed_started=$SECONDS
 SEED_OUTPUT="$($COMPOSE run --rm seed 2>/dev/null)"
 ROUTER_KEY="$(printf '%s\n' "$SEED_OUTPUT" | grep -oE 'rk_[A-Za-z0-9_-]+' | head -1)"
 if [[ -z "$ROUTER_KEY" ]]; then
@@ -154,13 +181,18 @@ if [[ -z "$ROUTER_KEY" ]]; then
   exit 1
 fi
 log "seeded router key ${ROUTER_KEY:0:8}…"
+PHASE_SEED_SECONDS=$((SECONDS - seed_started))
+log "seed phase completed in ${PHASE_SEED_SECONDS}s"
 
 log "running the smoke suite (proxy mode: $PROXY_MODE)"
+assert_started=$SECONDS
 SMOKE_ROUTER_KEY="$ROUTER_KEY" \
 SMOKE_BASE_URL="$BASE_URL" \
 SMOKE_OPENAI_ENABLED="$( [[ -n "${OPENAI_API_KEY:-}" || "$PROXY_MODE" == "replay-only" ]] && echo 1 || echo 0 )" \
   go test -tags smoke -count=1 -v ./smoke/
 
+PHASE_ASSERT_SECONDS=$((SECONDS - assert_started))
+log "assertion phase completed in ${PHASE_ASSERT_SECONDS}s"
 log "smoke suite passed"
 
 if [[ "$PROXY_MODE" != "replay-only" ]]; then

--- a/smoke/mitmproxy/docker-compose.ci-cache.yml
+++ b/smoke/mitmproxy/docker-compose.ci-cache.yml
@@ -27,3 +27,10 @@ services:
         - type=gha,scope=router-smoke-mitmproxy
       cache_to:
         - type=gha,scope=router-smoke-mitmproxy,mode=max
+
+  seed:
+    build:
+      cache_from:
+        - type=gha,scope=router-smoke-seed
+      cache_to:
+        - type=gha,scope=router-smoke-seed,mode=max

--- a/smoke/mitmproxy/docker-compose.yml
+++ b/smoke/mitmproxy/docker-compose.yml
@@ -28,6 +28,7 @@
 # mode against the same bind mount to refresh them against the real API.
 services:
   mitmproxy:
+    image: router-mitmproxy
     build:
       context: .
       dockerfile: smoke/mitmproxy/Dockerfile

--- a/smoke/mitmproxy/store.go
+++ b/smoke/mitmproxy/store.go
@@ -125,6 +125,14 @@ func (s *store) save(key string, c *cassette) error {
 		return err
 	}
 	tmpPath := tmp.Name()
+	// CreateTemp deliberately uses 0600. The cassettes directory is bind
+	// mounted into the nightly recorder, so the host runner must be able to
+	// read the file after the container exits and Git hashes it.
+	if err := tmp.Chmod(0o644); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
 	if _, err := tmp.Write(raw); err != nil {
 		tmp.Close()
 		os.Remove(tmpPath)

--- a/smoke/mitmproxy/store_test.go
+++ b/smoke/mitmproxy/store_test.go
@@ -1,6 +1,38 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
+
+func TestStoreSaveMakesCassetteReadableAfterContainerExit(t *testing.T) {
+	s, err := newStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const key = "cassette-key"
+	if err := s.save(key, &cassette{
+		Method:     "POST",
+		Path:       "/v1/messages",
+		StatusCode: 200,
+		Headers:    map[string]string{"content-type": "application/json"},
+		Body:       rawTextBody(`{"ok":true}`),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(s.path(key))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o644 {
+		t.Fatalf("cassette mode = %o, want 644", got)
+	}
+	if _, err := os.ReadFile(s.path(key)); err != nil {
+		t.Fatalf("saved cassette is not readable: %v", err)
+	}
+}
 
 // TestRequestKeyIgnoresPromptCacheKey pins that per-run session-affinity hints
 // don't change the cassette key, so replay-only CI stays green.


### PR DESCRIPTION
## Summary

- Fix nightly Smoke cassette refreshes by changing atomic cassette files from Go's default `0600` to `0644` before the bind-mounted file is renamed into the workspace.
- Add a regression test for cassette readability and Git-style file permissions.
- Build Smoke's server, MITM proxy, and seed targets explicitly before `docker compose up`, with per-image GitHub Actions cache scopes.
- Replace the cold `golang:1.25-bookworm` seed container and `go run` with a small `seed-runtime` Docker target.
- Cancel superseded Test workflow runs for the same PR/ref.
- Update `docs/CI.md` to mark these follow-ups implemented.

## Why

The scheduled cassette refresh had failed for 20 consecutive runs because `os.CreateTemp` created root-owned `0600` files inside the recorder container; the host runner then failed to hash them during `git add`. The fix preserves atomic writes while making the committed cassette readable by the runner.

The Smoke workflow's cache overlay was present but sampled `docker compose up --build` logs showed no cache import/export and rebuilt expensive layers. The runner now has an explicit build phase, and the seed no longer recompiles in a fresh SDK container.

## Validation

- `go test ./smoke/mitmproxy`
- `docker buildx build --check --file Dockerfile .`
- Built and loaded the `seed-runtime` target successfully
- Compose config validation with all Smoke overlays and the tools profile
- `actionlint` on modified workflows
- `make check-docs`
- `make check-agent-guides`
- `bash -n scripts/smoke/run.sh`
- `git diff --check`

The next CI Smoke run should confirm cache import/export lines and a successful cassette refresh on the next scheduled record run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the nightly Smoke cassette refresh, which had failed for 20 consecutive runs, and makes Smoke's Docker caching effective. Also cuts proxy test time and tightens the Test workflow.

**Bug Fixes**
- The recorder chmods cassettes to `0644` before the atomic rename so the host runner can read and hash them.
- Adds a regression test for cassette readability and permissions.
- Proxy tests inject a no-op retry sleep via `WithRetrySleep`, cutting the package's test time from ~23s to ~4s.

**Refactors**
- Smoke builds the server, MITM proxy, and seed with per-image GHA cache scopes through explicit Bake targets; the seed now uses a small `seed-runtime` image instead of `go run` in a fresh SDK container.
- The Test workflow cancels superseded runs, path-gates the statusline, installer, and HMM sidecar jobs, and collapses vet and typecheck into `go test -vet=all`.
- Adds job timeouts and writes Smoke phase timings to the job summary, with verified cache timings recorded in `docs/CI.md`.

<sup>Written for commit 2778d8e291f045a153f314d064d3dbb8333e54ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weave-os/router/pull/1288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

