### PR TITLE
Revert "feat(router): allow pinning an installation to the hmm_beta lane"

### DIFF
--- a/internal/api/admin/policy_catalog.go
+++ b/internal/api/admin/policy_catalog.go
@@ -37,6 +37,11 @@ func PolicyCatalogHandler(service *proxy.Service, defaultStrategy router.Strateg
 		}}
 		if service != nil {
 			for _, strategy := range service.RegisteredStrategies() {
+				// Beta is a session control, not an installation strategy. Keep it
+				// out of the control-plane catalog so /beta remains its only surface.
+				if strategy == router.StrategyHMMBeta {
+					continue
+				}
 				capabilities, _ := service.PolicyCapabilities(strategy)
 				// Derived, not separately negotiated: ranked fallback is the
 				// precondition for cluster overrides taking effect.

--- a/internal/api/admin/policy_catalog_test.go
+++ b/internal/api/admin/policy_catalog_test.go
@@ -64,13 +64,11 @@ func TestPolicyCatalogHandlerReportsDefaultAndCapabilities(t *testing.T) {
 	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &payload))
 	assert.Equal(t, policy.SchemaVersionV1, payload.SchemaVersion)
 	assert.Equal(t, "hmm", payload.DefaultStrategy)
-	require.Len(t, payload.Strategies, 3)
+	require.Len(t, payload.Strategies, 2)
 	assert.Equal(t, "cluster", payload.Strategies[0].Strategy)
 	assert.True(t, payload.Strategies[0].Capabilities.SupportsPreview)
 	assert.True(t, payload.Strategies[0].Capabilities.SupportsShadow)
 	assert.Equal(t, "hmm", payload.Strategies[1].Strategy)
 	assert.True(t, payload.Strategies[1].Available)
-	assert.Equal(t, string(router.StrategyHMMBeta), payload.Strategies[2].Strategy,
-		"beta is listed so the control plane can pin an installation to the beta lane")
-	assert.True(t, payload.Strategies[2].Available)
+	assert.NotContains(t, recorder.Body.String(), string(router.StrategyHMMBeta))
 }

--- a/internal/proxy/beta.go
+++ b/internal/proxy/beta.go
@@ -20,7 +20,6 @@ const (
 	betaDisabledMessage = "Beta disabled. Stable routing restored."
 	betaUsageMessage    = "Usage: /beta"
 	betaUnavailable     = "Beta is unavailable for this session."
-	betaPinnedMessage   = "Beta is always on for this installation; /beta has no effect."
 )
 
 type betaArtifactHistoryContextKey struct{}
@@ -81,11 +80,6 @@ func (s *Service) handleBetaCommand(
 	}
 	if s.sessionStrategyStore == nil || installationID == uuid.Nil || preferenceKey == ([sessionpin.SessionKeyLen]byte{}) || clientSessionIDForRequest(ctx, env) == "" {
 		return writeBetaCommandResponse(w, env, betaUnavailable, inputTokens)
-	}
-	// Runs before applySessionStrategy, so the context strategy here is the
-	// installation's baseline; a session toggle cannot leave an installation pin.
-	if router.StrategyFromContext(ctx) == router.StrategyHMMBeta {
-		return writeBetaCommandResponse(w, env, betaPinnedMessage, inputTokens)
 	}
 
 	// Both branches decide from what the store persisted rather than a prior

--- a/internal/proxy/beta_internal_test.go
+++ b/internal/proxy/beta_internal_test.go
@@ -221,26 +221,6 @@ func TestHandleBetaCommandTogglesAndAcknowledges(t *testing.T) {
 	assert.Equal(t, router.StrategyHMMBeta, pins.consumedStrategy[len(pins.consumedStrategy)-1])
 }
 
-func TestHandleBetaCommandIsInertWhenInstallationPinnedToBeta(t *testing.T) {
-	store := &betaTestPreferenceStore{}
-	pins := &betaCleanupPinStore{}
-	svc := (&Service{pinStore: pins}).
-		WithPolicyStrategy(policy.StrategySpec{Strategy: router.StrategyHMMBeta, Router: &betaTestRouter{}}).
-		WithSessionStrategyStore(store)
-	env := betaTestEnvelope(t, "/beta", true)
-	cmd, found := env.ExtractBetaCommand()
-	require.True(t, found)
-	var sessionKey [sessionstrategy.SessionKeyLen]byte
-	sessionKey[0] = 1
-	ctx := router.WithStrategy(context.Background(), router.StrategyHMMBeta)
-
-	response := httptest.NewRecorder()
-	require.NoError(t, svc.handleBetaCommand(ctx, response, env, cmd, uuid.New(), sessionKey, sessionKey, 1))
-	assert.Equal(t, "✦ **Weave Router** → "+betaPinnedMessage+"\n\n", gjson.Get(response.Body.String(), "content.0.text").String())
-	assert.Equal(t, 0, store.toggles, "an installation pin must not be shadowed by a session toggle")
-	assert.Empty(t, pins.consumedStrategy)
-}
-
 func TestHandleBetaCommandAcceptsHeaderOnlyClientSession(t *testing.T) {
 	store := &betaTestPreferenceStore{}
 	svc := (&Service{pinStore: &betaCleanupPinStore{}}).

--- a/internal/server/middleware/router_strategy_override.go
+++ b/internal/server/middleware/router_strategy_override.go
@@ -16,21 +16,17 @@ import (
 // default.
 const RouterStrategyOverrideHeader = "x-weave-router-strategy"
 
-// StrategyAvailability reports whether a registered strategy has a live router
-// right now; the proxy service's PolicyStrategyAvailable satisfies it.
-type StrategyAvailability func(router.Strategy) bool
+// WithRouterStrategyOverride applies the persisted installation strategy and permits
+// an eval header override when authorized; available is injected by the proxy registry.
+func WithRouterStrategyOverride(available ...router.Strategy) gin.HandlerFunc {
+	return WithRouterStrategyDefault(router.StrategyCluster, available...)
+}
 
-// WithRouterStrategyDefault applies the persisted installation strategy, permits an
-// eval header override when authorized, and applies a deployment-level default for
-// installations with no explicit override (allowlist-first, then one-flag global
-// rollout); available is injected by the proxy registry.
-// hmm_beta may be pinned per installation (or requested by an authorized header)
-// but never becomes the deployment default, so a broken beta lane cannot take
-// every installation with it. Beta is also gated on live availability: the lane
-// is registered even when its manager never loaded a snapshot, and a pin to an
-// empty lane must fall back to cluster rather than 503 every turn. A nil
-// liveAvailability leaves beta unselectable.
-func WithRouterStrategyDefault(defaultStrategy router.Strategy, liveAvailability StrategyAvailability, available ...router.Strategy) gin.HandlerFunc {
+// WithRouterStrategyDefault applies a deployment-level default for installations
+// with no explicit override, enabling allowlist-first then one-flag global rollout.
+func WithRouterStrategyDefault(defaultStrategy router.Strategy, available ...router.Strategy) gin.HandlerFunc {
+	allowed := make(map[router.Strategy]struct{}, len(available)+1)
+	allowed[router.StrategyCluster] = struct{}{}
 	if len(available) == 0 {
 		available = []router.Strategy{
 			router.StrategyRL,
@@ -39,18 +35,14 @@ func WithRouterStrategyDefault(defaultStrategy router.Strategy, liveAvailability
 			router.StrategyBandit,
 		}
 	}
-	allowed := make(map[router.Strategy]struct{}, len(available)+1)
-	allowed[router.StrategyCluster] = struct{}{}
 	for _, strategy := range available {
+		// hmm_beta is session-only: never activated by header, installation, or deployment default.
+		if strategy == router.StrategyHMMBeta {
+			continue
+		}
 		allowed[strategy] = struct{}{}
 	}
-	defaultStrategy = NormalizeRouterStrategyDefault(defaultStrategy, available...)
-	selectable := func(strategy router.Strategy) bool {
-		if !strategyAllowed(strategy, allowed) {
-			return false
-		}
-		return strategy != router.StrategyHMMBeta || (liveAvailability != nil && liveAvailability(strategy))
-	}
+	defaultStrategy = normalizeRouterStrategyDefault(defaultStrategy, allowed)
 	return func(c *gin.Context) {
 		installation := InstallationFrom(c)
 		if installation == nil {
@@ -62,9 +54,9 @@ func WithRouterStrategyDefault(defaultStrategy router.Strategy, liveAvailability
 		if strategy == "" {
 			strategy = defaultStrategy
 		}
-		if !selectable(strategy) {
+		if _, ok := allowed[strategy]; !ok {
 			observability.FromGin(c).Warn(
-				"Persisted router strategy is not registered or unavailable; using cluster",
+				"Persisted router strategy is not registered; using cluster",
 				"installation_id", installation.ID,
 				"persisted_strategy", strategy,
 			)
@@ -77,8 +69,8 @@ func WithRouterStrategyDefault(defaultStrategy router.Strategy, liveAvailability
 			switch {
 			case !installation.PolicyHeaderOverridesEnabled:
 				observability.FromGin(c).Warn("Router-strategy override ignored: installation is not authorized for policy headers", "installation_id", installation.ID)
-			case !selectable(requested):
-				observability.FromGin(c).Warn("Router-strategy override ignored: strategy is not registered or unavailable", "installation_id", installation.ID, "requested_strategy", raw)
+			case !strategyAllowed(requested, allowed):
+				observability.FromGin(c).Warn("Router-strategy override ignored: strategy is not registered", "installation_id", installation.ID, "requested_strategy", raw)
 			default:
 				strategy = requested
 				observability.FromGin(c).Info("Router-strategy override applied", "installation_id", installation.ID, "requested_strategy", raw)
@@ -91,9 +83,7 @@ func WithRouterStrategyDefault(defaultStrategy router.Strategy, liveAvailability
 	}
 }
 
-// NormalizeRouterStrategyDefault clamps an unregistered deployment default to
-// cluster. hmm_beta is never a valid default: it is an opt-in lane pinned per
-// installation or per session, not a fleet-wide policy.
+// NormalizeRouterStrategyDefault clamps an unregistered deployment default to cluster.
 func NormalizeRouterStrategyDefault(defaultStrategy router.Strategy, available ...router.Strategy) router.Strategy {
 	allowed := make(map[router.Strategy]struct{}, len(available)+1)
 	allowed[router.StrategyCluster] = struct{}{}
@@ -103,6 +93,10 @@ func NormalizeRouterStrategyDefault(defaultStrategy router.Strategy, available .
 		}
 		allowed[strategy] = struct{}{}
 	}
+	return normalizeRouterStrategyDefault(defaultStrategy, allowed)
+}
+
+func normalizeRouterStrategyDefault(defaultStrategy router.Strategy, allowed map[router.Strategy]struct{}) router.Strategy {
 	if !strategyAllowed(defaultStrategy, allowed) {
 		return router.StrategyCluster
 	}

--- a/internal/server/middleware/router_strategy_override_test.go
+++ b/internal/server/middleware/router_strategy_override_test.go
@@ -14,21 +14,7 @@ import (
 )
 
 // runStrategyOverride reports the strategy observed on the request context after WithRouterStrategyOverride runs.
-// allRegisteredLive stands in for a deployment whose every registered lane has a loaded snapshot.
-func allRegisteredLive(router.Strategy) bool { return true }
-
 func runStrategyOverride(t *testing.T, installation *auth.Installation, header string, available ...router.Strategy) router.Strategy {
-	t.Helper()
-	return runStrategyOverrideWithAvailability(t, installation, header, allRegisteredLive, available...)
-}
-
-func runStrategyOverrideWithAvailability(
-	t *testing.T,
-	installation *auth.Installation,
-	header string,
-	liveAvailability middleware.StrategyAvailability,
-	available ...router.Strategy,
-) router.Strategy {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 	engine := gin.New()
@@ -38,7 +24,7 @@ func runStrategyOverrideWithAvailability(
 		}
 		c.Next()
 	})
-	engine.Use(middleware.WithRouterStrategyDefault(router.StrategyCluster, liveAvailability, available...))
+	engine.Use(middleware.WithRouterStrategyOverride(available...))
 
 	var observed router.Strategy
 	engine.GET("/probe", func(c *gin.Context) {
@@ -94,7 +80,6 @@ func TestRouterStrategyOverride_UsesDeploymentDefaultWithoutInstallationOverride
 	})
 	engine.Use(middleware.WithRouterStrategyDefault(
 		router.StrategyHMM,
-		nil,
 		router.StrategyHMM,
 	))
 	var observed router.Strategy
@@ -120,7 +105,6 @@ func TestRouterStrategyOverride_ExplicitClusterWinsOverDeploymentDefault(t *test
 	})
 	engine.Use(middleware.WithRouterStrategyDefault(
 		router.StrategyHMM,
-		nil,
 		router.StrategyHMM,
 	))
 	var observed router.Strategy
@@ -143,90 +127,24 @@ func TestNormalizeRouterStrategyDefault(t *testing.T) {
 		"beta cannot be activated by a deployment default")
 }
 
-func TestRouterStrategyOverride_AuthorizedBetaHeaderActivatesBeta(t *testing.T) {
+func TestRouterStrategyOverride_BetaHeaderCannotActivateBeta(t *testing.T) {
 	got := runStrategyOverride(
 		t,
 		&auth.Installation{ID: "inst-beta", PolicyHeaderOverridesEnabled: true},
 		string(router.StrategyHMMBeta),
 		router.StrategyHMMBeta,
 	)
-	assert.Equal(t, router.StrategyHMMBeta, got)
-}
-
-func TestRouterStrategyOverride_PersistedInstallationBetaActivatesBeta(t *testing.T) {
-	got := runStrategyOverride(
-		t,
-		&auth.Installation{ID: "inst-beta", RoutingStrategy: router.StrategyHMMBeta},
-		"",
-		router.StrategyHMMBeta,
-	)
-	assert.Equal(t, router.StrategyHMMBeta, got)
-}
-
-func TestRouterStrategyOverride_PersistedBetaIgnoredWhenBetaUnregistered(t *testing.T) {
-	got := runStrategyOverride(
-		t,
-		&auth.Installation{ID: "inst-beta", RoutingStrategy: router.StrategyHMMBeta},
-		"",
-		router.StrategyHMM,
-	)
-	assert.Equal(t, router.StrategyCluster, got, "a beta lane that failed to load must not be selectable")
-}
-
-func TestRouterStrategyOverride_PersistedBetaClampsWhileBetaLaneEmpty(t *testing.T) {
-	betaLaneEmpty := func(strategy router.Strategy) bool { return strategy != router.StrategyHMMBeta }
-	got := runStrategyOverrideWithAvailability(
-		t,
-		&auth.Installation{ID: "inst-beta", RoutingStrategy: router.StrategyHMMBeta},
-		"",
-		betaLaneEmpty,
-		router.StrategyHMM,
-		router.StrategyHMMBeta,
-	)
-	assert.Equal(t, router.StrategyCluster, got, "a registered beta lane with no snapshot must not 503 a pinned installation")
-}
-
-func TestRouterStrategyOverride_BetaHeaderIgnoredWhileBetaLaneEmpty(t *testing.T) {
-	betaLaneEmpty := func(strategy router.Strategy) bool { return strategy != router.StrategyHMMBeta }
-	got := runStrategyOverrideWithAvailability(
-		t,
-		&auth.Installation{ID: "inst-beta", RoutingStrategy: router.StrategyHMM, PolicyHeaderOverridesEnabled: true},
-		string(router.StrategyHMMBeta),
-		betaLaneEmpty,
-		router.StrategyHMM,
-		router.StrategyHMMBeta,
-	)
-	assert.Equal(t, router.StrategyHMM, got)
-}
-
-func TestRouterStrategyOverride_BetaUnselectableWithoutAvailabilitySource(t *testing.T) {
-	got := runStrategyOverrideWithAvailability(
-		t,
-		&auth.Installation{ID: "inst-beta", RoutingStrategy: router.StrategyHMMBeta},
-		"",
-		nil,
-		router.StrategyHMMBeta,
-	)
 	assert.Equal(t, router.StrategyCluster, got)
 }
 
-func TestRouterStrategyOverride_DeploymentDefaultBetaClampsToCluster(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	engine := gin.New()
-	engine.Use(func(c *gin.Context) {
-		c.Set("router_installation", &auth.Installation{ID: "inst-global"})
-		c.Next()
-	})
-	engine.Use(middleware.WithRouterStrategyDefault(router.StrategyHMMBeta, allRegisteredLive, router.StrategyHMMBeta))
-	var observed router.Strategy
-	engine.GET("/probe", func(c *gin.Context) {
-		observed = router.StrategyFromContext(c.Request.Context())
-		c.Status(http.StatusOK)
-	})
-
-	engine.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/probe", nil))
-
-	assert.Equal(t, router.StrategyCluster, observed, "beta cannot be activated by a deployment default")
+func TestRouterStrategyOverride_InstallationDefaultBetaCannotActivateBeta(t *testing.T) {
+	got := runStrategyOverride(
+		t,
+		&auth.Installation{ID: "inst-beta", RoutingStrategy: router.StrategyHMMBeta},
+		"",
+		router.StrategyHMMBeta,
+	)
+	assert.Equal(t, router.StrategyCluster, got)
 }
 
 func TestRouterStrategyOverride_UnknownValueIgnored(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -141,10 +141,8 @@ func RegisterWithFeatures(engine *gin.Engine, authSvc *auth.Service, proxySvc *p
 	// used by the README's managed-deployment badge. Public build metadata, unauthed like /health.
 	engine.GET("/v1/version", middleware.WithTimeout(healthTimeout), admin.VersionHandler)
 	var registeredStrategies []router.Strategy
-	var strategyAvailability middleware.StrategyAvailability
 	if proxySvc != nil {
 		registeredStrategies = proxySvc.RegisteredStrategies()
-		strategyAvailability = proxySvc.PolicyStrategyAvailable
 	}
 	defaultStrategy := middleware.NormalizeRouterStrategyDefault(DefaultStrategyFromEnv(), registeredStrategies...)
 	engine.GET(
@@ -265,7 +263,7 @@ func RegisterWithFeatures(engine *gin.Engine, authSvc *auth.Service, proxySvc *p
 	messagesMiddleware = append(messagesMiddleware,
 		middleware.WithEmbedOnlyUserMessageOverride(),
 		middleware.WithClusterVersionOverride(),
-		middleware.WithRouterStrategyDefault(defaultStrategy, strategyAvailability, registeredStrategies...),
+		middleware.WithRouterStrategyDefault(defaultStrategy, registeredStrategies...),
 		middleware.WithPolicyDebugOverride(),
 		middleware.WithAllowedModelsOverride(proxySvc),
 		middleware.WithRoutingKnobsOverride(),
@@ -292,7 +290,7 @@ func RegisterWithFeatures(engine *gin.Engine, authSvc *auth.Service, proxySvc *p
 	chatCompletionMiddleware = append(chatCompletionMiddleware,
 		middleware.WithEmbedOnlyUserMessageOverride(),
 		middleware.WithClusterVersionOverride(),
-		middleware.WithRouterStrategyDefault(defaultStrategy, strategyAvailability, registeredStrategies...),
+		middleware.WithRouterStrategyDefault(defaultStrategy, registeredStrategies...),
 		middleware.WithPolicyDebugOverride(),
 		middleware.WithAllowedModelsOverride(proxySvc),
 		middleware.WithRoutingKnobsOverride(),
@@ -340,7 +338,7 @@ func RegisterWithFeatures(engine *gin.Engine, authSvc *auth.Service, proxySvc *p
 	routeMiddleware = append(routeMiddleware,
 		middleware.WithEmbedOnlyUserMessageOverride(),
 		middleware.WithClusterVersionOverride(),
-		middleware.WithRouterStrategyDefault(defaultStrategy, strategyAvailability, registeredStrategies...),
+		middleware.WithRouterStrategyDefault(defaultStrategy, registeredStrategies...),
 		middleware.WithPolicyDebugOverride(),
 		middleware.WithAllowedModelsOverride(proxySvc),
 		middleware.WithRoutingKnobsOverride(),
@@ -355,7 +353,7 @@ func RegisterWithFeatures(engine *gin.Engine, authSvc *auth.Service, proxySvc *p
 		middleware.WithTimeout(routeTimeout),
 		middleware.WithAuth(authSvc, byokRequiresOptIn),
 		middleware.WithEmbedOnlyUserMessageOverride(),
-		middleware.WithRouterStrategyDefault(defaultStrategy, strategyAvailability, registeredStrategies...),
+		middleware.WithRouterStrategyDefault(defaultStrategy, registeredStrategies...),
 		middleware.WithPolicyDebugOverride(),
 		middleware.WithAllowedModelsOverride(proxySvc),
 		middleware.WithRoutingKnobsOverride(),


### PR DESCRIPTION
Reverts weave-os/router#1289

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the ability to pin an installation to the `hmm_beta` lane. Beta is session-only again — the `/beta` command is the only way to activate it, and previously pinned installations now fall back to `cluster`.

- Removes beta from the admin policy catalog and blocks it in all router-strategy override paths (header, installation default, deployment default).
- Removes the beta lane's live-availability gate and the `/beta` no-op response for pinned installations.
- Installations with a persisted `hmm_beta` strategy will route with `cluster` until a new strategy is set.

<sup>Written for commit 2f456b9861f9360768a1702887cb17180e918103. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weave-os/router/pull/1292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

