### PR TITLE
Fix expired credential failing routing entirely

### DIFF
--- a/internal/proxy/openai_subscription_pool_failover_test.go
+++ b/internal/proxy/openai_subscription_pool_failover_test.go
@@ -1,0 +1,138 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"weave-os/router/internal/auth"
+	"weave-os/router/internal/billing"
+	"weave-os/router/internal/providers"
+	"weave-os/router/internal/router"
+	"weave-os/router/internal/router/sessionpin"
+	"weave-os/router/internal/translate"
+)
+
+func claudeOpusPinnedDecision() router.Decision {
+	return router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-opus-5",
+		Reason:   translate.ReasonLoopEscalation,
+		Metadata: &router.RoutingMetadata{
+			CandidateModels:    []string{"claude-opus-5", "gpt-5.6-luna"},
+			CandidateProviders: map[string]string{"gpt-5.6-luna": providers.ProviderOpenAI},
+		},
+	}
+}
+
+func openaiChatBody() []byte {
+	return []byte(`{"model":"gpt-5.6-sol","stream":true,"messages":[{"role":"user","content":"hi"}]}`)
+}
+
+func anthropicMessagesBody() []byte {
+	return []byte(`{"model":"claude-opus-5","max_tokens":1024,"stream":true,"messages":[{"role":"user","content":"read main.go"}],"tools":[{"name":"read_file","input_schema":{"type":"object","properties":{"path":{"type":"string"}}}}]}`)
+}
+
+func TestProxyOpenAIChatCompletion_SubscriptionPoolExhaustionRescuesSibling(t *testing.T) {
+	leaser := &scriptedSubscriptionLeaser{}
+	rescue := &responsesRetryClient{}
+	store := &evictionStubPinStore{}
+	svc := NewService(
+		staticRouter{decision: claudeOpusPinnedDecision()},
+		map[string]providers.Client{
+			providers.ProviderAnthropic: &fakeClient{name: providers.ProviderAnthropic},
+			providers.ProviderOpenAI:    rescue,
+		},
+		nil, false, nil, store, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil,
+	).WithManagedSubscriptions(leaser).
+		WithDeploymentKeyedProviders(map[string]struct{}{
+			providers.ProviderAnthropic: {},
+			providers.ProviderOpenAI:    {},
+		})
+
+	installationID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	ctx := context.WithValue(managedSubscriptionContext(auth.SubscriptionProviderClaude),
+		InstallationIDContextKey{}, installationID.String())
+	rec := httptest.NewRecorder()
+	body := openaiChatBody()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(body)))
+
+	err := svc.ProxyOpenAIChatCompletion(ctx, body, rec, req)
+
+	require.NoError(t, err, "an empty Claude pool must fail over to a same-cluster sibling")
+	require.NotEmpty(t, rescue.endpoints, "the OpenAI sibling must be dispatched")
+	assert.Contains(t, rec.Body.String(), "served after retry")
+}
+
+func TestProxyOpenAIChatCompletion_SubscriptionOnlyKeepsPoolExhaustion(t *testing.T) {
+	leaser := &scriptedSubscriptionLeaser{}
+	rescue := &responsesRetryClient{}
+	svc := NewService(
+		staticRouter{decision: claudeOpusPinnedDecision()},
+		map[string]providers.Client{
+			providers.ProviderAnthropic: &fakeClient{name: providers.ProviderAnthropic},
+			providers.ProviderOpenAI:    rescue,
+		},
+		nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil,
+	).WithManagedSubscriptions(leaser).
+		WithDeploymentKeyedProviders(map[string]struct{}{
+			providers.ProviderAnthropic: {},
+			providers.ProviderOpenAI:    {},
+		})
+
+	ctx := billing.WithSubscriptionOnly(managedSubscriptionContext(auth.SubscriptionProviderClaude))
+	ctx = context.WithValue(ctx, InstallationIDContextKey{}, "33333333-3333-3333-3333-333333333333")
+	rec := httptest.NewRecorder()
+	body := openaiChatBody()
+
+	err := svc.ProxyOpenAIChatCompletion(ctx, body, rec, httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(body))))
+
+	require.ErrorIs(t, err, ErrSubscriptionPoolExhausted)
+	assert.Empty(t, rescue.endpoints, "subscription-only must not spend a paid sibling")
+}
+
+func TestProxyMessages_SubscriptionPoolExhaustionRescuesSibling(t *testing.T) {
+	leaser := &scriptedSubscriptionLeaser{}
+	rescue := &responsesRetryClient{}
+	svc := NewService(
+		staticRouter{decision: claudeOpusPinnedDecision()},
+		map[string]providers.Client{
+			providers.ProviderAnthropic: &fakeClient{name: providers.ProviderAnthropic},
+			providers.ProviderOpenAI:    rescue,
+		},
+		nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil,
+	).WithManagedSubscriptions(leaser).
+		WithDeploymentKeyedProviders(map[string]struct{}{
+			providers.ProviderAnthropic: {},
+			providers.ProviderOpenAI:    {},
+		})
+
+	ctx := context.WithValue(managedSubscriptionContext(auth.SubscriptionProviderClaude),
+		InstallationIDContextKey{}, "33333333-3333-3333-3333-333333333333")
+	rec := httptest.NewRecorder()
+	body := anthropicMessagesBody()
+
+	err := svc.ProxyMessages(ctx, body, rec, httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(string(body))))
+
+	require.NoError(t, err)
+	require.NotEmpty(t, rescue.endpoints)
+	assert.Contains(t, rec.Body.String(), "served after retry")
+}
+
+func TestMaybeExpirePoolArmPin_StickyLoopEscalation(t *testing.T) {
+	store := &evictionStubPinStore{}
+	svc := newEvictionTestService(store)
+	installationID := uuid.New()
+	sessionKey := nonZeroSessionKey()
+
+	svc.maybeExpirePoolArmPin(context.Background(), true, translate.ReasonLoopEscalation, installationID, sessionKey, sessionpin.DefaultRole)
+
+	require.Len(t, store.upserts, 1)
+	assert.Equal(t, "subscription_pool_exhausted", store.upserts[0].Reason)
+}

--- a/internal/proxy/pin_eviction.go
+++ b/internal/proxy/pin_eviction.go
@@ -157,6 +157,32 @@ func (s *Service) maybeExpireDeadArmPin(
 	}
 }
 
+// maybeExpirePoolArmPin expires a sticky pin when the managed subscription
+// pool for the pinned provider is empty. The pin is not a quality signal and
+// has no HTTP status, so the two-strike 4xx counter never sees it; without
+// this, Codex retries keep hitting the same dead Claude arm. Never expires a
+// user force-model pin.
+func (s *Service) maybeExpirePoolArmPin(
+	ctx context.Context,
+	poolArmDead bool,
+	decisionReason string,
+	installationID uuid.UUID,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+	role string,
+) {
+	if !poolArmDead || s.pinStore == nil || installationID == uuid.Nil || sessionKey == ([sessionpin.SessionKeyLen]byte{}) || strings.HasPrefix(decisionReason, translate.ReasonUserForceModel) {
+		return
+	}
+	log := observability.FromContext(ctx)
+	if err := s.expireSessionPin(ctx, installationID, sessionKey, role, "subscription_pool_exhausted"); err != nil {
+		log.Error("pin eviction after subscription pool exhaustion failed", "err", err, "role", role)
+		return
+	}
+	log.Info("session pin evicted after subscription pool exhaustion",
+		"role", role,
+	)
+}
+
 // maybeEvictPinAfterUpstreamErr applies the two-strike eviction policy for a
 // turn run against a sticky pin: a successful turn resets the strike counter,
 // a non-retryable upstream 4xx increments it, and hitting
@@ -197,6 +223,17 @@ func (s *Service) maybeEvictPinAfterUpstreamErr(
 		if err := s.pinStore.ResetUpstreamErrors(context.Background(), sessionKey, role, router.StrategyFromContext(ctx)); err != nil {
 			log.Error("pin error-counter reset failed", "err", err, "role", role)
 		}
+		return
+	}
+
+	if isSubscriptionPoolError(proxyErr) {
+		if err := s.expireSessionPin(ctx, installationID, sessionKey, role, "subscription_pool_exhausted"); err != nil {
+			log.Error("pin eviction after subscription pool exhaustion failed", "err", err, "role", role)
+			return
+		}
+		log.Info("session pin evicted after subscription pool exhaustion",
+			"role", role,
+		)
 		return
 	}
 

--- a/internal/proxy/pin_eviction.go
+++ b/internal/proxy/pin_eviction.go
@@ -160,8 +160,9 @@ func (s *Service) maybeExpireDeadArmPin(
 // maybeExpirePoolArmPin expires a sticky pin when the managed subscription
 // pool for the pinned provider is empty. The pin is not a quality signal and
 // has no HTTP status, so the two-strike 4xx counter never sees it; without
-// this, Codex retries keep hitting the same dead Claude arm. Never expires a
-// user force-model pin.
+// this, Codex retries keep hitting the same dead Claude arm. Also expires a
+// pin written on this first unpinned turn (writeNewPin), so the next request
+// does not sticky-hit the same empty pool. Never expires a user force-model pin.
 func (s *Service) maybeExpirePoolArmPin(
 	ctx context.Context,
 	poolArmDead bool,
@@ -223,17 +224,6 @@ func (s *Service) maybeEvictPinAfterUpstreamErr(
 		if err := s.pinStore.ResetUpstreamErrors(context.Background(), sessionKey, role, router.StrategyFromContext(ctx)); err != nil {
 			log.Error("pin error-counter reset failed", "err", err, "role", role)
 		}
-		return
-	}
-
-	if isSubscriptionPoolError(proxyErr) {
-		if err := s.expireSessionPin(ctx, installationID, sessionKey, role, "subscription_pool_exhausted"); err != nil {
-			log.Error("pin eviction after subscription pool exhaustion failed", "err", err, "role", role)
-			return
-		}
-		log.Info("session pin evicted after subscription pool exhaustion",
-			"role", role,
-		)
 		return
 	}
 

--- a/internal/proxy/pin_eviction_internal_test.go
+++ b/internal/proxy/pin_eviction_internal_test.go
@@ -406,7 +406,7 @@ func TestMaybeExpireDeadArmPin(t *testing.T) {
 	}
 }
 
-func TestMaybeEvictPin_SubscriptionPoolExhaustedExpiresImmediately(t *testing.T) {
+func TestMaybeEvictPin_SubscriptionPoolExhaustedLeavesStrikeCounter(t *testing.T) {
 	store := &evictionStubPinStore{incrementNext: []int{1}}
 	svc := newEvictionTestService(store)
 	installationID := uuid.New()
@@ -423,13 +423,7 @@ func TestMaybeEvictPin_SubscriptionPoolExhaustedExpiresImmediately(t *testing.T)
 	)
 
 	assert.Zero(t, store.incrementCalls, "pool exhaustion has no upstream status and must not use the 4xx strike counter")
-	require.Len(t, store.upserts, 1, "an empty subscription pool must expire the pin on the first failed turn")
-	expired := store.upserts[0]
-	assert.Equal(t, installationID, expired.InstallationID)
-	assert.Empty(t, expired.Provider)
-	assert.Empty(t, expired.Model)
-	assert.Equal(t, "subscription_pool_exhausted", expired.Reason)
-	assert.True(t, expired.PinnedUntil.Before(time.Now()))
+	assert.Empty(t, store.upserts, "pool-arm expiry is maybeExpirePoolArmPin, keyed off the primary attempt, not the final rescue error")
 }
 
 func TestMaybeExpirePoolArmPin(t *testing.T) {

--- a/internal/proxy/pin_eviction_internal_test.go
+++ b/internal/proxy/pin_eviction_internal_test.go
@@ -405,3 +405,58 @@ func TestMaybeExpireDeadArmPin(t *testing.T) {
 		})
 	}
 }
+
+func TestMaybeEvictPin_SubscriptionPoolExhaustedExpiresImmediately(t *testing.T) {
+	store := &evictionStubPinStore{incrementNext: []int{1}}
+	svc := newEvictionTestService(store)
+	installationID := uuid.New()
+	sessionKey := nonZeroSessionKey()
+
+	svc.maybeEvictPinAfterUpstreamErr(
+		context.Background(),
+		true,
+		ErrSubscriptionPoolExhausted,
+		"loop_escalation",
+		installationID,
+		sessionKey,
+		sessionpin.DefaultRole,
+	)
+
+	assert.Zero(t, store.incrementCalls, "pool exhaustion has no upstream status and must not use the 4xx strike counter")
+	require.Len(t, store.upserts, 1, "an empty subscription pool must expire the pin on the first failed turn")
+	expired := store.upserts[0]
+	assert.Equal(t, installationID, expired.InstallationID)
+	assert.Empty(t, expired.Provider)
+	assert.Empty(t, expired.Model)
+	assert.Equal(t, "subscription_pool_exhausted", expired.Reason)
+	assert.True(t, expired.PinnedUntil.Before(time.Now()))
+}
+
+func TestMaybeExpirePoolArmPin(t *testing.T) {
+	installationID := uuid.New()
+	sessionKey := nonZeroSessionKey()
+
+	cases := []struct {
+		name           string
+		dead           bool
+		decisionReason string
+		wantFired      bool
+	}{
+		{"pool exhaustion evicts the pin", true, "loop_escalation", true},
+		{"healthy pool leaves the pin", false, "loop_escalation", false},
+		{"force-model pin is never evicted", true, translate.ReasonUserForceModel, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &evictionStubPinStore{}
+			svc := newEvictionTestService(store)
+			svc.maybeExpirePoolArmPin(context.Background(), tc.dead, tc.decisionReason, installationID, sessionKey, sessionpin.DefaultRole)
+			if tc.wantFired {
+				require.Len(t, store.upserts, 1)
+				assert.Equal(t, "subscription_pool_exhausted", store.upserts[0].Reason)
+			} else {
+				assert.Empty(t, store.upserts)
+			}
+		})
+	}
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -7058,6 +7058,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			})
 			bindings = subBindings
 			codexFailoverUsed = proxyErr == nil
+			subscriptionPoolFailure = isSubscriptionPoolError(proxyErr)
 			cyberRefusalSeen = cyberRefusalSeen || providers.IsUpstreamCyberPolicyRefusal(proxyErr)
 		}
 	}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -7395,7 +7395,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			StopReason:               stringPtrOrEmpty(respSummary.StopReason),
 			// A subscription->Weave retry keeps the same provider, so OR it in to
 			// match the OTel span + completion log.
-			FailoverUsed: boolPtrTrue(finalProvider != primaryProvider || codexFailoverUsed),
+			FailoverUsed: boolPtrTrue(finalProvider != primaryProvider || codexFailoverUsed || siblingFailoverUsed),
 			// (session_key, role) join key — see the Anthropic-path write site.
 			SessionKey: sessionKey[:],
 			Role:       routeRes.PinRole,

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -4710,9 +4710,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		// dead for this request shape — the pin must not stay on it even when a
 		// rescue served the turn (which would nill proxyErr and reset the counter).
 		s.maybeExpireDeadArmPin(ctx, deadArmRejected, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes))
-		if poolArmDead && !isSubscriptionPoolError(proxyErr) {
-			s.maybeExpirePoolArmPin(ctx, poolArmDead, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes))
-		}
+		s.maybeExpirePoolArmPin(ctx, poolArmDead, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes))
 
 		// Two-strike provider disable: complements the 4xx eviction above;
 		// 529 is retryable in-turn so it never trips that counter.
@@ -7054,7 +7052,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 				flushErr:        flushErrAsOpenAI,
 				// A failed retry keeps the same model; hold the error so the
 				// cyber-refusal rescue below can still serve the turn.
-				deferFlushOnExhaustion: cyberRetryViable,
+				deferFlushOnExhaustion: cyberRetryViable || siblingViable,
 				purpose:                routeRes.dispatchPurpose(surfacePurpose),
 				origin:                 routeRes.dispatchOrigin(decision),
 			})
@@ -7118,14 +7116,15 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			cyberRetryRan = true
 			respSummary = translate.ResponseSummary{}
 			winnerIdx, proxyErr = s.dispatchWithFallback(retryCtx, failoverInputs{
-				w:               contentSink,
-				buf:             preludeBuf,
-				initialDecision: cyberRetryTarget,
-				bindings:        retryBindings,
-				attempt:         retryAttempt,
-				flushErr:        flushErrAsOpenAI,
-				purpose:         routeRes.dispatchPurpose(surfacePurpose),
-				origin:          routeRes.rescueOrigin(),
+				w:                      contentSink,
+				buf:                    preludeBuf,
+				initialDecision:        cyberRetryTarget,
+				bindings:               retryBindings,
+				attempt:                retryAttempt,
+				flushErr:               flushErrAsOpenAI,
+				deferFlushOnExhaustion: siblingViable,
+				purpose:                routeRes.dispatchPurpose(surfacePurpose),
+				origin:                 routeRes.rescueOrigin(),
 			})
 			subscriptionPoolFailure = isSubscriptionPoolError(proxyErr)
 			decision = cyberRetryTarget
@@ -7323,9 +7322,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// See ProxyMessages for the two-strike eviction rationale.
 	if !routeRes.BlindExperimentPassthrough {
 		s.maybeEvictPinAfterUpstreamErr(ctx, stickyHit, proxyErr, decision.Reason, installationIDFromContext(ctx), routeRes.SessionKey, stickyStateRole(routeRes))
-		if poolArmDead && !isSubscriptionPoolError(proxyErr) {
-			s.maybeExpirePoolArmPin(ctx, poolArmDead, decision.Reason, installationIDFromContext(ctx), routeRes.SessionKey, stickyStateRole(routeRes))
-		}
+		s.maybeExpirePoolArmPin(ctx, poolArmDead, decision.Reason, installationIDFromContext(ctx), routeRes.SessionKey, stickyStateRole(routeRes))
 		// See ProxyMessages for the two-strike provider-disable rationale.
 		s.maybeDisableProviderAfterOverload(ctx, stickyHit, proxyErr, finalProvider, decision.Reason, installationIDFromContext(ctx), routeRes.SessionKey, stickyStateRole(routeRes), routeRes.PinRole)
 	}
@@ -7442,7 +7439,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		)
 	}
 
-	log.Info("ProxyOpenAIChatCompletion complete", append([]any{"requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "primary_model", primaryModel, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider || codexFailoverUsed, "subscription_failover", codexFailoverUsed, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "embedded_tokens", len(promptText) / 4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_err_body", providers.UpstreamErrorBodyMessage(proxyErr), "upstream_status", upstreamStatus(proxyErr), "upstream_finish_reason", respSummary.UpstreamFinishReason, "resp_stop_reason", respSummary.StopReason, "routing_marker", marker, "prior_served_model", routeRes.PriorServedModel, "hard_pinned", routeRes.HardPinned}, plannerLogFields(routeRes)...)...)
+	log.Info("ProxyOpenAIChatCompletion complete", append([]any{"requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "primary_model", primaryModel, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider || codexFailoverUsed || siblingFailoverUsed, "subscription_failover", codexFailoverUsed, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "embedded_tokens", len(promptText) / 4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_err_body", providers.UpstreamErrorBodyMessage(proxyErr), "upstream_status", upstreamStatus(proxyErr), "upstream_finish_reason", respSummary.UpstreamFinishReason, "resp_stop_reason", respSummary.StopReason, "routing_marker", marker, "prior_served_model", routeRes.PriorServedModel, "hard_pinned", routeRes.HardPinned}, plannerLogFields(routeRes)...)...)
 	s.reportPolicyOutcome(ctx, routeRes, decision, effortServed, finalProvider, fastServed, feats.Tokens, in, out, cacheCreation, cacheRead, routeMs, proxyMs, proxyErr, nil)
 
 	// Subscription-only mode disables paid failover by pinning dispatch to the

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -4157,6 +4157,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		})
 		subscriptionPoolFailure = isSubscriptionPoolError(proxyErr)
 	}
+	poolArmDead := subscriptionPoolFailure
 
 	// The deferred upstream error must reach the client exactly once: each
 	// rescue hands ownership to the next, and whichever declines to run flushes.
@@ -4372,6 +4373,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		(providers.IsRetryable(proxyErr) ||
 			providers.IsUpstreamModelNotFound(proxyErr) ||
 			providers.IsUpstreamProviderBillingBlocked(proxyErr) ||
+			isSubscriptionPoolError(proxyErr) ||
 			crossBindingRejected) {
 		siblingOpts := opts
 		siblingOpts.TargetModel = siblingDecision.Model
@@ -4708,6 +4710,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		// dead for this request shape — the pin must not stay on it even when a
 		// rescue served the turn (which would nill proxyErr and reset the counter).
 		s.maybeExpireDeadArmPin(ctx, deadArmRejected, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes))
+		if poolArmDead && !isSubscriptionPoolError(proxyErr) {
+			s.maybeExpirePoolArmPin(ctx, poolArmDead, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes))
+		}
 
 		// Two-strike provider disable: complements the 4xx eviction above;
 		// 529 is retryable in-turn so it never trips that counter.
@@ -6927,6 +6932,14 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		!billing.SubscriptionOnlyFromContext(ctx) &&
 		s.openaiFallbackKeyAvailable(ctx)
 
+	siblingDecision, siblingFound := s.siblingFailoverDecision(ctx, decision, overflowEstimateOAI, env.SignatureTokenSavings(), outputReserveOAI)
+	siblingViable := s.ResolveSiblingFailover(ctx) &&
+		siblingFound &&
+		!routeRes.BlindExperimentPassthrough &&
+		!strings.HasPrefix(decision.Reason, translate.ReasonUserForceModel) &&
+		(s.shouldFailover(ctx) || s.gatewaySiblingAllowed(ctx, siblingDecision)) &&
+		!billing.SubscriptionOnlyFromContext(ctx)
+
 	primaryProvider := decision.Provider
 	primaryModel := decision.Model
 	primaryDecision := decision
@@ -6962,11 +6975,12 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		bindings:               bindings,
 		attempt:                attempt,
 		flushErr:               flushErrAsOpenAI,
-		deferFlushOnExhaustion: cyberRetryViable || codexRetryViable,
+		deferFlushOnExhaustion: cyberRetryViable || codexRetryViable || siblingViable,
 		purpose:                routeRes.dispatchPurpose(surfacePurpose),
 		origin:                 routeRes.dispatchOrigin(decision),
 	})
 	subscriptionPoolFailure := isSubscriptionPoolError(proxyErr)
+	poolArmDead := subscriptionPoolFailure
 	cyberRefusalSeen = cyberRefusalSeen || providers.IsUpstreamCyberPolicyRefusal(proxyErr)
 
 	// The deferred upstream error must reach the client exactly once: the rescue
@@ -7051,7 +7065,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	}
 	// The Codex retry declined to run and no other rescue owns the held error;
 	// surface it now so it's never dropped.
-	if codexRetryViable && !codexRetryRan && !cyberRetryViable && proxyErr != nil && !preludeBuf.Committed() {
+	if codexRetryViable && !codexRetryRan && !cyberRetryViable && !siblingViable && proxyErr != nil && !preludeBuf.Committed() {
 		flushDeferredErr()
 	}
 
@@ -7120,7 +7134,68 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		}
 	}
 	// The rescue declined to run; surface the held error now so it's never dropped.
-	if cyberRetryViable && !cyberRetryRan && proxyErr != nil && !preludeBuf.Committed() {
+	if cyberRetryViable && !cyberRetryRan && !siblingViable && proxyErr != nil && !preludeBuf.Committed() {
+		flushDeferredErr()
+	}
+
+	siblingFailoverUsed := false
+	siblingRescueRan := false
+	siblingRescueOwed := siblingViable && !deferredErrFlushed
+	if siblingRescueOwed && proxyErr != nil && !preludeBuf.Committed() &&
+		(providers.IsRetryable(proxyErr) ||
+			providers.IsUpstreamModelNotFound(proxyErr) ||
+			providers.IsUpstreamProviderBillingBlocked(proxyErr) ||
+			isSubscriptionPoolError(proxyErr)) {
+		siblingOpts := opts
+		siblingOpts.TargetModel = siblingDecision.Model
+		siblingOpts.TargetProvider = siblingDecision.Provider
+		siblingOpts.Capabilities = router.Lookup(siblingDecision.Model)
+		siblingOpts.ModelSwitched = true
+		effortServed = s.resolveEffort(ctx, siblingDecision, siblingOpts.Capabilities, routeRes.EscalateEffort)
+		effortServed.apply(&siblingOpts)
+		siblingCtx := resolveAndInjectCredentials(ctx, siblingDecision.Provider, siblingDecision.Model, r.Header)
+		siblingOpts.FastMode = fastModeForAttempt(siblingCtx, siblingDecision.Model, siblingDecision.Provider)
+		siblingBindings := s.resolveBindingsForDispatch(siblingCtx, siblingDecision)
+		siblingMarker := suppressMarkerIfRequested(ctx, r.Header, siblingRoutingMarkerFor(routeRes, siblingDecision.Model))
+		siblingAttempt, siblingBuildErr := buildAttempt(siblingDecision, siblingOpts, siblingMarker)
+		switch {
+		case siblingBuildErr != nil:
+			log.Error("Sibling failover: preparing the candidate request failed; surfacing original error",
+				"err", siblingBuildErr,
+				"sibling_model", siblingDecision.Model)
+		case len(siblingBindings) == 0:
+			log.Warn("Sibling failover: candidate has no usable binding; surfacing original error",
+				"sibling_model", siblingDecision.Model,
+				"sibling_provider", siblingDecision.Provider,
+				"err", proxyErr)
+		default:
+			log.Warn("Sibling failover: routed model exhausted, retrying a same-cluster candidate",
+				"failed_model", decision.Model,
+				"failed_provider", primaryProvider,
+				"sibling_model", siblingDecision.Model,
+				"sibling_provider", siblingDecision.Provider,
+				"upstream_status", upstreamStatus(proxyErr),
+				"err", proxyErr)
+			siblingRescueRan = true
+			respSummary = translate.ResponseSummary{}
+			winnerIdx, proxyErr = s.dispatchWithFallback(siblingCtx, failoverInputs{
+				w:               contentSink,
+				buf:             preludeBuf,
+				initialDecision: siblingDecision,
+				bindings:        siblingBindings,
+				attempt:         siblingAttempt,
+				flushErr:        flushErrAsOpenAI,
+				purpose:         routeRes.dispatchPurpose(surfacePurpose),
+				origin:          routeRes.rescueOrigin(),
+			})
+			subscriptionPoolFailure = isSubscriptionPoolError(proxyErr)
+			decision = siblingDecision
+			bindings = siblingBindings
+			marker = siblingMarker
+			siblingFailoverUsed = proxyErr == nil
+		}
+	}
+	if siblingRescueOwed && !siblingRescueRan && proxyErr != nil && !preludeBuf.Committed() {
 		flushDeferredErr()
 	}
 
@@ -7198,9 +7273,10 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		String("dispatch.primary_model", primaryModel).
 		String("dispatch.final_provider", finalProvider).
 		Int64("dispatch.fallback_attempts", int64(winnerIdx)).
-		Bool("dispatch.failover_used", finalProvider != primaryProvider || codexFailoverUsed).
+		Bool("dispatch.failover_used", finalProvider != primaryProvider || codexFailoverUsed || siblingFailoverUsed).
 		Bool("dispatch.subscription_failover", codexFailoverUsed).
-		Bool("dispatch.cyber_refusal_retry", cyberRetryRan)
+		Bool("dispatch.cyber_refusal_retry", cyberRetryRan).
+		Bool("dispatch.sibling_failover", siblingFailoverUsed)
 	applyPlannerAttrs(openaiUpstreamBuilder, routeRes)
 	applyRoutingStateAttrs(openaiUpstreamBuilder, routeRes, decision.ServedIdentity(), sessionKey)
 	applyEffortAttrs(openaiUpstreamBuilder, effortServed)
@@ -7247,6 +7323,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// See ProxyMessages for the two-strike eviction rationale.
 	if !routeRes.BlindExperimentPassthrough {
 		s.maybeEvictPinAfterUpstreamErr(ctx, stickyHit, proxyErr, decision.Reason, installationIDFromContext(ctx), routeRes.SessionKey, stickyStateRole(routeRes))
+		if poolArmDead && !isSubscriptionPoolError(proxyErr) {
+			s.maybeExpirePoolArmPin(ctx, poolArmDead, decision.Reason, installationIDFromContext(ctx), routeRes.SessionKey, stickyStateRole(routeRes))
+		}
 		// See ProxyMessages for the two-strike provider-disable rationale.
 		s.maybeDisableProviderAfterOverload(ctx, stickyHit, proxyErr, finalProvider, decision.Reason, installationIDFromContext(ctx), routeRes.SessionKey, stickyStateRole(routeRes), routeRes.PinRole)
 	}


### PR DESCRIPTION
## Summary
- fail over OpenAI and Anthropic requests when a managed subscription pool is exhausted
- expire sticky pins backed by an unavailable subscription pool so future turns can re-route
- preserve subscription-only fail-closed behavior

## Tests
- go test ./...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes routing failures when a managed subscription pool is exhausted: requests now fail over to a sibling provider instead of failing entirely, and sticky pins backed by the dead pool are expired so future turns re-route.

**Details**
- OpenAI and Anthropic requests fail over to a same-cluster sibling when the pinned provider's subscription pool is empty.
- Sticky pins are expired immediately on pool exhaustion, including after a rescue serves the turn.
- Subscription-only mode keeps failing closed and never spends a paid sibling.
- User force-model pins are never expired.
- OpenAI request telemetry now records whether a sibling failover was used.

<sup>Written for commit 111f61c3475f8eab2b7f04a557307cfecaf878a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weave-os/router/pull/1297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

