### PR TITLE
fix(otel): bound content capture and exporter memory

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -664,7 +664,16 @@ log records are emitted and behavior is unchanged.
 | Variable             | Default | Purpose |
 | -------------------- | ------- | ------- |
 | `WV_CAPTURE_CONTENT` | `off`   | `off` = no log records; `hashed` = metadata + SHA-256 content hashes (no raw text); `full` = metadata + raw request/response bodies. |
-| `WV_CAPTURE_MAX_BYTES` | `1048576` | Max buffered response bytes; larger responses are dropped and flagged `io.truncated=true` (the client still receives the full stream). |
+| `WV_CAPTURE_MAX_BYTES` | `1048576` | Max bytes per raw request/response capture, checked before string conversion/redaction and again after redaction. Oversized bodies are omitted, not clipped; inference still receives/sends every byte. |
+
+`io.request_truncated` and `io.response_truncated` identify omitted bodies;
+`io.truncated` is true when either is omitted. Full capture never sends an
+over-limit body to the redactor. Hash-only mode still hashes the entire request
+without retaining its text; an overflowed response has no hash (not the hash of
+an empty body). `io.request_bytes` records the original request length;
+`io.response_bytes` records the available captured response length, which is
+zero after response-buffer overflow. Capture settings do not change training
+consent or installation privacy ceilings.
 
 Captured bodies are in the client's native wire format (Anthropic / OpenAI /
 Gemini, matching the inbound surface). The `router.deployment_mode` resource
@@ -686,14 +695,28 @@ asking for `full` under a `hashed` deployment still gets `hashed`.
 | `OTEL_EXPORTER_OTLP_TIMEOUT`     | `10000`      | Per-export HTTP timeout in ms. |
 | `OTEL_SERVICE_NAME`              | `router`     | `service.name` resource attribute. |
 | `OTEL_RESOURCE_ATTRIBUTES`       | *(none)*     | Comma-separated `key=value` resource attributes. |
-| `OTEL_BSP_MAX_QUEUE_SIZE`        | `1000`       | Span queue capacity. Spans drop when full. |
-| `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` | `50`         | Max spans per OTLP POST. |
+| `OTEL_BSP_MAX_QUEUE_SIZE`        | `1000`       | Capacity of each span/log queue. Records drop when full. |
+| `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` | `50`         | Max records per OTLP POST, also subject to the byte cap below. |
 | `OTEL_BSP_SCHEDULE_DELAY`        | `500`        | Partial-batch flush interval in ms. |
 | `OTEL_EXPORT_WORKERS`            | `2`          | Export-goroutine count (spans and logs each get this many workers). |
 
 The first five follow the [OTel SDK env spec](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/);
 `OTEL_BSP_*` follows the [Batch Span Processor spec](https://opentelemetry.io/docs/specs/otel/trace/sdk/#batch-span-processor).
 `OTEL_EXPORT_WORKERS` is a router-specific extension.
+
+The content exporter keeps the existing fixed worker pools and additionally
+limits each POST to **4 MiB** and shared retained payloads to **64 MiB**. The
+byte reservation covers serialization on admission, both queues, worker
+batches, and their serialized HTTP-body copies. Records are serialized into
+owned bytes before enqueue returns; a record that cannot fit in one POST is
+dropped. Queue slots and batch bookkeeping remain count-bounded separately;
+request-scoped capture buffers and HTTP/TLS transport overhead are not part of
+this payload budget. There are no additional byte-limit environment settings.
+Full or closing queues drop optional telemetry without waiting or retrying.
+Each HTTP export keeps its configured timeout. `Shutdown(ctx)` drains within
+the caller's deadline, then cancels active exports and releases pending work;
+it does not continue exporting the remaining queue after that deadline. APM
+remains on its independent SDK exporter.
 
 ## Cluster-routing artifacts
 

--- a/internal/observability/global_logger_budget_test.go
+++ b/internal/observability/global_logger_budget_test.go
@@ -31,7 +31,7 @@ var globalLoggerBudget = map[string]int{
 
 	// The exporter itself: logging its own transport failures. A ctx here
 	// would be the export's, not the request's.
-	"internal/observability/otel": 8,
+	"internal/observability/otel": 7,
 	"internal/observability/apm":  1,
 
 	// Background Pub/Sub listeners; no inbound request.

--- a/internal/observability/otel/batch.go
+++ b/internal/observability/otel/batch.go
@@ -1,0 +1,58 @@
+package otel
+
+import (
+	"fmt"
+
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+)
+
+// OTLP traces and logs share the envelope layout: export.resource_* (1),
+// resource.scope_* (2), scope.records (2). Keeping records encoded avoids
+// retaining caller-owned graphs or decoding another copy just to batch them.
+type batchEnvelope struct {
+	resource []byte
+	scope    []byte
+}
+
+func newBatchEnvelope(resource *resourcev1.Resource, scope *commonv1.InstrumentationScope) (batchEnvelope, error) {
+	resourceBody, err := proto.Marshal(resource)
+	if err != nil {
+		return batchEnvelope{}, fmt.Errorf("marshal OTLP resource: %w", err)
+	}
+	scopeBody, err := proto.Marshal(scope)
+	if err != nil {
+		return batchEnvelope{}, fmt.Errorf("marshal OTLP scope: %w", err)
+	}
+	return batchEnvelope{
+		resource: protowire.AppendBytes(protowire.AppendTag(nil, 1, protowire.BytesType), resourceBody),
+		scope:    protowire.AppendBytes(protowire.AppendTag(nil, 1, protowire.BytesType), scopeBody),
+	}, nil
+}
+
+func recordFieldSize(size int) int { return 1 + protowire.SizeBytes(size) }
+
+func (e batchEnvelope) size(recordsSize int) int {
+	scopeSize := len(e.scope) + recordsSize
+	resourceSize := len(e.resource) + recordFieldSize(scopeSize)
+	return recordFieldSize(resourceSize)
+}
+
+func (e batchEnvelope) marshal(records []queuedRecord, recordsSize int) []byte {
+	scopeSize := len(e.scope) + recordsSize
+	resourceSize := len(e.resource) + recordFieldSize(scopeSize)
+	body := make([]byte, 0, recordFieldSize(resourceSize))
+	body = protowire.AppendTag(body, 1, protowire.BytesType)
+	body = protowire.AppendVarint(body, uint64(resourceSize))
+	body = append(body, e.resource...)
+	body = protowire.AppendTag(body, 2, protowire.BytesType)
+	body = protowire.AppendVarint(body, uint64(scopeSize))
+	body = append(body, e.scope...)
+	for _, record := range records {
+		body = protowire.AppendTag(body, 2, protowire.BytesType)
+		body = protowire.AppendBytes(body, record.body)
+	}
+	return body
+}

--- a/internal/observability/otel/batch_test.go
+++ b/internal/observability/otel/batch_test.go
@@ -1,0 +1,53 @@
+package otel
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	logsv1 "go.opentelemetry.io/proto/otlp/logs/v1"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestBatchEnvelope_MatchesGeneratedProtobuf(t *testing.T) {
+	resource := buildResource("test", map[string]string{"deployment": "test"})
+	scope := &commonv1.InstrumentationScope{Name: "workweave-router"}
+	envelope, err := newBatchEnvelope(resource, scope)
+	require.NoError(t, err)
+	for _, size := range []int{0, 127, 128, 16383, 16384, 1 << 20} {
+		t.Run(strconv.Itoa(size), func(t *testing.T) {
+			span := &tracev1.Span{Name: "span", Attributes: NewAttrBuilder(1).String("content", strings.Repeat("s", size)).Build()}
+			log := &logsv1.LogRecord{Body: stringValue(strings.Repeat("l", size))}
+			for _, tc := range []struct {
+				name     string
+				record   proto.Message
+				exported proto.Message
+			}{
+				{"traces", span, &coltracepb.ExportTraceServiceRequest{ResourceSpans: []*tracev1.ResourceSpans{{
+					Resource: resource, ScopeSpans: []*tracev1.ScopeSpans{{Scope: scope, Spans: []*tracev1.Span{span, span}}},
+				}}}},
+				{"logs", log, &collogspb.ExportLogsServiceRequest{ResourceLogs: []*logsv1.ResourceLogs{{
+					Resource: resource, ScopeLogs: []*logsv1.ScopeLogs{{Scope: scope, LogRecords: []*logsv1.LogRecord{log, log}}},
+				}}}},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					encoded, err := proto.Marshal(tc.record)
+					require.NoError(t, err)
+					records := []queuedRecord{{body: encoded}, {body: encoded}}
+					recordsSize := 2 * recordFieldSize(len(encoded))
+					body := envelope.marshal(records, recordsSize)
+					want, err := proto.Marshal(tc.exported)
+					require.NoError(t, err)
+					require.Equal(t, want, body)
+					require.Equal(t, len(body), cap(body), "batch must allocate only one exact-sized output")
+					require.Equal(t, len(body), envelope.size(recordsSize))
+				})
+			}
+		})
+	}
+}

--- a/internal/observability/otel/emitter.go
+++ b/internal/observability/otel/emitter.go
@@ -3,6 +3,7 @@ package otel
 import (
 	"bytes"
 	"context"
+	"maps"
 	"net/http"
 	"strings"
 	"sync"
@@ -11,14 +12,16 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
-	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
-	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 	logsv1 "go.opentelemetry.io/proto/otlp/logs/v1"
-	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 
 	"weave-os/router/internal/observability"
+)
+
+const (
+	maxBufferedBytes = 64 << 20
+	maxExportBytes   = 4 << 20
 )
 
 // EmitterConfig controls the emitter's async export pipeline.
@@ -34,35 +37,38 @@ type EmitterConfig struct {
 	ExportTimeout time.Duration
 }
 
-// Emitter batches OTLP spans and exports them via HTTP POST. Safe for concurrent
-// use. A nil *Emitter means OTel is disabled; all methods no-op.
+type queuedRecord struct {
+	body     []byte
+	reserved int64
+}
+
+// Emitter batches OTLP spans and logs for best-effort HTTP export. Safe for
+// concurrent use. A nil *Emitter means OTel is disabled; all methods no-op.
 type Emitter struct {
-	queue       chan *tracev1.Span
-	logQueue    chan *logsv1.LogRecord
+	queue       chan queuedRecord
+	logQueue    chan queuedRecord
 	client      *http.Client
 	endpoint    string
 	logEndpoint string
 	headers     map[string]string
-	resource    *resourcev1.Resource
+	envelope    batchEnvelope
 	batchSz     int
 	flushInt    time.Duration
+	retained    atomic.Int64
 	dropped     atomic.Int64
 	wg          sync.WaitGroup
-	// closeMu coordinates Shutdown's queue close against in-flight Enqueue
-	// calls so a late Enqueue cannot panic with "send on closed channel".
-	// Enqueue acquires RLock for the lifetime of the send; Shutdown takes
-	// Lock to flip closed and close(queue) atomically.
-	closeMu sync.RWMutex
-	closed  atomic.Bool
+	ctx         context.Context
+	cancel      context.CancelFunc
+	done        chan struct{}
+	closeMu     sync.RWMutex
+	closed      bool
 }
 
-// NewEmitter starts the worker pool and returns a ready emitter. Returns
-// (nil, nil) when cfg.Endpoint is empty (OTel disabled).
+// NewEmitter starts the worker pool. Returns (nil, nil) when Endpoint is empty.
 func NewEmitter(cfg EmitterConfig) (*Emitter, error) {
 	if cfg.Endpoint == "" {
 		return nil, nil
 	}
-
 	if cfg.Workers <= 0 {
 		cfg.Workers = 2
 	}
@@ -82,217 +88,183 @@ func NewEmitter(cfg EmitterConfig) (*Emitter, error) {
 		cfg.ServiceName = "router"
 	}
 
+	envelope, err := newBatchEnvelope(buildResource(cfg.ServiceName, cfg.ResourceAttrs), &commonv1.InstrumentationScope{Name: "workweave-router"})
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithCancel(context.Background())
 	e := &Emitter{
-		queue:       make(chan *tracev1.Span, cfg.QueueSize),
-		logQueue:    make(chan *logsv1.LogRecord, cfg.QueueSize),
+		queue:       make(chan queuedRecord, cfg.QueueSize),
+		logQueue:    make(chan queuedRecord, cfg.QueueSize),
 		client:      &http.Client{Timeout: cfg.ExportTimeout},
 		endpoint:    strings.TrimRight(cfg.Endpoint, "/") + "/v1/traces",
 		logEndpoint: strings.TrimRight(cfg.Endpoint, "/") + "/v1/logs",
-		headers:     cfg.Headers,
-		resource:    buildResource(cfg.ServiceName, cfg.ResourceAttrs),
+		headers:     maps.Clone(cfg.Headers),
+		envelope:    envelope,
 		batchSz:     cfg.BatchSize,
 		flushInt:    cfg.FlushInterval,
+		ctx:         ctx,
+		cancel:      cancel,
+		done:        make(chan struct{}),
 	}
 
 	e.wg.Add(cfg.Workers * 2)
 	for range cfg.Workers {
-		go e.worker()
-		go e.logWorker()
+		go e.worker(e.queue, e.endpoint)
+		go e.worker(e.logQueue, e.logEndpoint)
 	}
-
+	go func() {
+		e.wg.Wait()
+		e.cancel()
+		e.client.CloseIdleConnections()
+		if n := e.dropped.Load(); n > 0 {
+			observability.Get().Warn("Dropped OTLP records during emitter lifetime", "count", n)
+		}
+		close(e.done)
+	}()
 	return e, nil
 }
 
-// NewBuffer returns a request-scoped span/log buffer wrapping e, or nil when e
-// is nil (OTel disabled).
-func (e *Emitter) NewBuffer() *Buffer {
-	return NewBuffer(e)
-}
+// NewBuffer returns a request-scoped span/log buffer, or nil when disabled.
+func (e *Emitter) NewBuffer() *Buffer { return NewBuffer(e) }
 
-// Enqueue submits a span to the export queue. Non-blocking: drops on queue-full
-// or post-shutdown. Nil receiver is a no-op.
+// Enqueue snapshots s before returning. It never waits for export or capacity;
+// records exceeding the count/byte limits or submitted after shutdown drop.
 func (e *Emitter) Enqueue(s *tracev1.Span) {
-	if e == nil {
-		return
-	}
-	e.closeMu.RLock()
-	defer e.closeMu.RUnlock()
-	if e.closed.Load() {
-		e.dropped.Add(1)
-		return
-	}
-	select {
-	case e.queue <- s:
-	default:
-		e.dropped.Add(1)
+	if e != nil {
+		e.enqueue(e.queue, s)
 	}
 }
 
-// EnqueueLog submits a log record to the export queue. Non-blocking: drops on
-// queue-full or post-shutdown. Nil receiver is a no-op.
+// EnqueueLog has the same admission and ownership contract as Enqueue.
 func (e *Emitter) EnqueueLog(r *logsv1.LogRecord) {
-	if e == nil {
-		return
+	if e != nil {
+		e.enqueue(e.logQueue, r)
 	}
+}
+
+func (e *Emitter) enqueue(queue chan<- queuedRecord, record proto.Message) {
 	e.closeMu.RLock()
 	defer e.closeMu.RUnlock()
-	if e.closed.Load() {
+	if e.closed {
 		e.dropped.Add(1)
 		return
 	}
+
+	size := proto.Size(record)
+	exportSize := e.envelope.size(recordFieldSize(size))
+	if exportSize > maxExportBytes {
+		e.dropped.Add(1)
+		return
+	}
+	// Reserve before serialization, covering concurrent producers, queued and
+	// in-flight records, and the second copy in the HTTP batch. Per-record
+	// envelope overhead overestimates the one shared envelope in a batch.
+	reserved := int64(2 * exportSize)
+	for {
+		retained := e.retained.Load()
+		if reserved > maxBufferedBytes-retained {
+			e.dropped.Add(1)
+			return
+		}
+		if e.retained.CompareAndSwap(retained, retained+reserved) {
+			break
+		}
+	}
+	body, err := proto.MarshalOptions{}.MarshalAppend(make([]byte, 0, size), record)
+	if err != nil {
+		e.retained.Add(-reserved)
+		e.dropped.Add(1)
+		observability.Get().Warn("Failed to marshal OTLP record", "err", err)
+		return
+	}
 	select {
-	case e.logQueue <- r:
+	case queue <- queuedRecord{body: body, reserved: reserved}:
 	default:
+		e.retained.Add(-reserved)
 		e.dropped.Add(1)
 	}
 }
 
-// Shutdown closes the queue and waits for workers to drain. Blocks until all
-// workers finish or ctx expires. Idempotent; nil receiver is a no-op.
-func (e *Emitter) Shutdown(c context.Context) error {
+// Shutdown stops admission and drains within ctx. Expiration cancels active
+// HTTP exports and discards pending records. Repeated calls can await cleanup.
+func (e *Emitter) Shutdown(ctx context.Context) error {
 	if e == nil {
 		return nil
 	}
-
 	e.closeMu.Lock()
-	if e.closed.Swap(true) {
-		e.closeMu.Unlock()
-		return nil
+	if !e.closed {
+		e.closed = true
+		close(e.queue)
+		close(e.logQueue)
 	}
-	close(e.queue)
-	close(e.logQueue)
 	e.closeMu.Unlock()
 
-	done := make(chan struct{})
-	go func() {
-		e.wg.Wait()
-		close(done)
-	}()
-
 	select {
-	case <-done:
-	case <-c.Done():
-		return c.Err()
+	case <-e.done:
+		return nil
+	case <-ctx.Done():
+		e.cancel()
+		return ctx.Err()
 	}
-
-	if n := e.dropped.Load(); n > 0 {
-		observability.Get().Warn("Dropped spans during emitter lifetime", "count", n)
-	}
-
-	return nil
 }
 
-func (e *Emitter) worker() {
+func (e *Emitter) worker(queue <-chan queuedRecord, endpoint string) {
 	defer e.wg.Done()
-
-	batch := make([]*tracev1.Span, 0, e.batchSz)
+	batch := make([]queuedRecord, 0, min(e.batchSz, cap(queue)))
+	batchBytes := 0
 	timer := time.NewTimer(e.flushInt)
 	defer timer.Stop()
 
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		if e.ctx.Err() == nil {
+			e.post(endpoint, e.envelope.marshal(batch, batchBytes))
+		} else {
+			e.dropped.Add(int64(len(batch)))
+		}
+		for i := range batch {
+			reserved := batch[i].reserved
+			batch[i] = queuedRecord{}
+			e.retained.Add(-reserved)
+		}
+		batch = batch[:0]
+		batchBytes = 0
+		timer.Reset(e.flushInt)
+	}
+
 	for {
 		select {
-		case span, ok := <-e.queue:
+		case record, ok := <-queue:
 			if !ok {
-				if len(batch) > 0 {
-					e.exportBatch(batch)
-				}
+				flush()
 				return
 			}
-			batch = append(batch, span)
+			if e.ctx.Err() != nil {
+				e.retained.Add(-record.reserved)
+				e.dropped.Add(1)
+				continue
+			}
+			size := recordFieldSize(len(record.body))
+			if e.envelope.size(batchBytes+size) > maxExportBytes {
+				flush()
+			}
+			batch = append(batch, record)
+			batchBytes += size
 			if len(batch) >= e.batchSz {
-				e.exportBatch(batch)
-				batch = batch[:0]
-				// Go 1.23+ drains the channel inside Stop/Reset automatically;
-				// the old `if !timer.Stop() { <-timer.C }` idiom deadlocks.
-				timer.Reset(e.flushInt)
+				flush()
 			}
-
 		case <-timer.C:
-			if len(batch) > 0 {
-				e.exportBatch(batch)
-				batch = batch[:0]
-			}
+			flush()
 			timer.Reset(e.flushInt)
 		}
 	}
 }
 
-// logWorker mirrors worker for the log-record export pipeline.
-func (e *Emitter) logWorker() {
-	defer e.wg.Done()
-
-	batch := make([]*logsv1.LogRecord, 0, e.batchSz)
-	timer := time.NewTimer(e.flushInt)
-	defer timer.Stop()
-
-	for {
-		select {
-		case rec, ok := <-e.logQueue:
-			if !ok {
-				if len(batch) > 0 {
-					e.exportLogBatch(batch)
-				}
-				return
-			}
-			batch = append(batch, rec)
-			if len(batch) >= e.batchSz {
-				e.exportLogBatch(batch)
-				batch = batch[:0]
-				timer.Reset(e.flushInt)
-			}
-
-		case <-timer.C:
-			if len(batch) > 0 {
-				e.exportLogBatch(batch)
-				batch = batch[:0]
-			}
-			timer.Reset(e.flushInt)
-		}
-	}
-}
-
-func (e *Emitter) exportBatch(spans []*tracev1.Span) {
-	req := &coltracepb.ExportTraceServiceRequest{
-		ResourceSpans: []*tracev1.ResourceSpans{{
-			Resource: e.resource,
-			ScopeSpans: []*tracev1.ScopeSpans{{
-				Scope: &commonv1.InstrumentationScope{Name: "workweave-router"},
-				Spans: spans,
-			}},
-		}},
-	}
-
-	body, err := proto.Marshal(req)
-	if err != nil {
-		observability.Get().Warn("Failed to marshal OTLP export request", "err", err)
-		return
-	}
-	e.post(e.endpoint, body)
-}
-
-func (e *Emitter) exportLogBatch(records []*logsv1.LogRecord) {
-	req := &collogspb.ExportLogsServiceRequest{
-		ResourceLogs: []*logsv1.ResourceLogs{{
-			Resource: e.resource,
-			ScopeLogs: []*logsv1.ScopeLogs{{
-				Scope:      &commonv1.InstrumentationScope{Name: "workweave-router"},
-				LogRecords: records,
-			}},
-		}},
-	}
-
-	body, err := proto.Marshal(req)
-	if err != nil {
-		observability.Get().Warn("Failed to marshal OTLP log export request", "err", err)
-		return
-	}
-	e.post(e.logEndpoint, body)
-}
-
-// post sends a marshaled OTLP protobuf body to endpoint. Failures are logged,
-// not returned: telemetry export is best-effort and never blocks the request.
 func (e *Emitter) post(endpoint string, body []byte) {
-	httpReq, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(e.ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
 		observability.Get().Warn("Failed to create OTLP export HTTP request", "err", err)
 		return
@@ -301,14 +273,12 @@ func (e *Emitter) post(endpoint string, body []byte) {
 	for k, v := range e.headers {
 		httpReq.Header.Set(k, v)
 	}
-
 	resp, err := e.client.Do(httpReq)
 	if err != nil {
 		observability.Get().Warn("OTLP export request failed", "err", err)
 		return
 	}
 	defer resp.Body.Close()
-
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		observability.Get().Warn("OTLP export returned non-2xx status", "status", resp.StatusCode)
 	}

--- a/internal/observability/otel/emitter_internal_test.go
+++ b/internal/observability/otel/emitter_internal_test.go
@@ -1,0 +1,232 @@
+package otel
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	logsv1 "go.opentelemetry.io/proto/otlp/logs/v1"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+func stringValue(s string) *commonv1.AnyValue {
+	return &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: s}}
+}
+
+func TestEmitter_ByteBudgetIncludesBothBlockedExports(t *testing.T) {
+	started := make(chan string, 2)
+	release := make(chan struct{})
+	var active, peak, requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		requests.Add(1)
+		n := active.Add(1)
+		defer active.Add(-1)
+		for old := peak.Load(); n > old; old = peak.Load() {
+			if peak.CompareAndSwap(old, n) {
+				break
+			}
+		}
+		started <- r.URL.Path
+		select {
+		case <-r.Context().Done():
+		case <-release:
+		}
+	}))
+	defer server.Close()
+	defer close(release)
+	em, err := NewEmitter(EmitterConfig{
+		Endpoint: server.URL, Workers: 1, QueueSize: 1000, BatchSize: 1,
+		ExportTimeout: time.Minute,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, em.Shutdown(context.Background())) })
+
+	// One maximum-sized captured request plus response per record.
+	attrs := NewAttrBuilder(2).
+		String("io.request_body", strings.Repeat("q", 1<<20)).
+		String("io.response_body", strings.Repeat("a", 1<<20)).Build()
+	span := &tracev1.Span{Name: "captured", Attributes: attrs}
+	log := &logsv1.LogRecord{Body: stringValue("router.call"), Attributes: attrs}
+	em.Enqueue(span)
+	em.EnqueueLog(log)
+	for range 2 {
+		select {
+		case <-started:
+		case <-time.After(3 * time.Second):
+			t.Fatal("export did not start")
+		}
+	}
+	finished := make(chan struct{})
+	go func() {
+		for range 1000 {
+			em.Enqueue(span)
+			em.EnqueueLog(log)
+		}
+		close(finished)
+	}()
+	select {
+	case <-finished:
+	case <-time.After(3 * time.Second):
+		t.Fatal("admission waited for blocked export")
+	}
+	assert.Greater(t, em.retained.Load(), int64(60<<20))
+	assert.LessOrEqual(t, em.retained.Load(), int64(64<<20))
+	assert.Greater(t, em.dropped.Load(), int64(1980))
+	assert.Less(t, len(em.queue)+len(em.logQueue), 20, "byte capacity, not 1000-record capacity, must bind")
+	assert.Equal(t, int64(2), peak.Load())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, em.Shutdown(ctx), context.DeadlineExceeded)
+	select {
+	case <-em.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("shutdown left exporter workers running")
+	}
+	assert.Zero(t, em.retained.Load(), "queued and in-flight reservations must be released")
+	assert.Equal(t, int64(2), requests.Load(), "shutdown must discard, not export, the backlog")
+	require.Eventually(t, func() bool { return active.Load() == 0 }, time.Second, time.Millisecond)
+}
+
+func TestEmitter_BatchByteCapAndSnapshotOwnership(t *testing.T) {
+	var mu sync.Mutex
+	var sizes []int
+	var contents []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if !assert.NoError(t, err) {
+			return
+		}
+		var exported collogspb.ExportLogsServiceRequest
+		if !assert.NoError(t, proto.Unmarshal(body, &exported)) {
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		sizes = append(sizes, len(body))
+		for _, resource := range exported.ResourceLogs {
+			for _, scope := range resource.ScopeLogs {
+				for _, record := range scope.LogRecords {
+					contents = append(contents, record.Body.GetStringValue())
+				}
+			}
+		}
+	}))
+	defer server.Close()
+	em, err := NewEmitter(EmitterConfig{
+		Endpoint: server.URL, Workers: 1, QueueSize: 100, BatchSize: 50, FlushInterval: time.Minute,
+	})
+	require.NoError(t, err)
+	original := strings.Repeat("a", 1<<20)
+	record := &logsv1.LogRecord{Body: stringValue(original)}
+	for range 8 {
+		em.EnqueueLog(record)
+	}
+	record.Body.Value = &commonv1.AnyValue_StringValue{StringValue: "mutated"}
+	require.NoError(t, em.Shutdown(context.Background()))
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []int{3, 3, 2}, func() []int {
+		counts := make([]int, len(sizes))
+		for i, size := range sizes {
+			assert.LessOrEqual(t, size, 4<<20)
+			counts[i] = size / (1 << 20)
+		}
+		return counts
+	}())
+	require.Len(t, contents, 8)
+	for _, content := range contents {
+		assert.Equal(t, original, content)
+	}
+	assert.Zero(t, em.retained.Load())
+	assert.Zero(t, em.dropped.Load())
+}
+
+func TestEmitter_ReleasesRejectedAndFailedRecords(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		requests.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+	em, err := NewEmitter(EmitterConfig{Endpoint: server.URL, Workers: 1, BatchSize: 1})
+	require.NoError(t, err)
+	em.EnqueueLog(&logsv1.LogRecord{Body: stringValue(strings.Repeat("x", 4<<20))})
+	em.Enqueue(&tracev1.Span{Name: strings.Repeat("x", 32<<20)})
+	em.EnqueueLog(&logsv1.LogRecord{Body: stringValue(string([]byte{0xff}))})
+	assert.Equal(t, int64(3), em.dropped.Load())
+	assert.Zero(t, em.retained.Load())
+	em.EnqueueLog(&logsv1.LogRecord{Body: stringValue("valid")})
+	require.NoError(t, em.Shutdown(context.Background()))
+	assert.Equal(t, int64(1), requests.Load(), "failed export is not retried")
+	assert.Zero(t, em.retained.Load())
+	em.Enqueue(&tracev1.Span{Name: "late"})
+	em.EnqueueLog(&logsv1.LogRecord{Body: stringValue("late")})
+	assert.Equal(t, int64(5), em.dropped.Load())
+	assert.Zero(t, em.retained.Load())
+}
+
+func TestEmitter_ExportTimeoutReleasesCapacity(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	defer server.Close()
+	defer close(release)
+	em, err := NewEmitter(EmitterConfig{
+		Endpoint: server.URL, Workers: 1, BatchSize: 1, ExportTimeout: 30 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	em.EnqueueLog(&logsv1.LogRecord{Body: stringValue("times out")})
+	require.Eventually(t, func() bool { return em.retained.Load() == 0 }, 2*time.Second, time.Millisecond)
+	// No shutdown deadline is needed: the per-export deadline also releases work.
+	require.NoError(t, em.Shutdown(context.Background()))
+}
+
+func TestEmitter_ConcurrentAdmissionAndShutdown(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+	}))
+	defer server.Close()
+	em, err := NewEmitter(EmitterConfig{Endpoint: server.URL, Workers: 2, QueueSize: 5, BatchSize: 3})
+	require.NoError(t, err)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for range 8 {
+		wg.Go(func() {
+			<-start
+			for range 100 {
+				em.Enqueue(&tracev1.Span{Name: "concurrent"})
+				em.EnqueueLog(&logsv1.LogRecord{Body: stringValue("concurrent")})
+			}
+		})
+	}
+	for range 4 {
+		wg.Go(func() {
+			<-start
+			assert.NoError(t, em.Shutdown(context.Background()))
+		})
+	}
+	close(start)
+	wg.Wait()
+	assert.Zero(t, em.retained.Load())
+	assert.Empty(t, em.queue)
+	assert.Empty(t, em.logQueue)
+}

--- a/internal/observability/safego_test.go
+++ b/internal/observability/safego_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,7 +16,7 @@ import (
 // recovered and logged rather than propagating out of the goroutine (which
 // would crash the process).
 func TestSafeGoRecoversFromPanic(t *testing.T) {
-	var buf bytes.Buffer
+	var buf lockedLogBuffer
 	log := slog.New(slog.NewTextHandler(&buf, nil))
 
 	assert.NotPanics(t, func() {
@@ -34,7 +35,7 @@ func TestSafeGoRecoversFromPanic(t *testing.T) {
 // a bounded context derived from context.Background(), independent of any
 // caller-supplied ctx.
 func TestSafeGoRunsFnToCompletion(t *testing.T) {
-	var buf bytes.Buffer
+	var buf lockedLogBuffer
 	log := slog.New(slog.NewTextHandler(&buf, nil))
 	done := make(chan struct{})
 
@@ -53,7 +54,7 @@ func TestSafeGoRunsFnToCompletion(t *testing.T) {
 
 // waitForLog polls buf until it contains substr or fails the test after a
 // bounded wait, since the goroutine under test runs concurrently.
-func waitForLog(t *testing.T, buf *bytes.Buffer, substr string) {
+func waitForLog(t *testing.T, buf *lockedLogBuffer, substr string) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
@@ -63,4 +64,21 @@ func waitForLog(t *testing.T, buf *bytes.Buffer, substr string) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("expected log containing %q, got: %s", substr, buf.String())
+}
+
+type lockedLogBuffer struct {
+	mu   sync.Mutex
+	body bytes.Buffer
+}
+
+func (b *lockedLogBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.body.Write(p)
+}
+
+func (b *lockedLogBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.body.String()
 }

--- a/internal/proxy/cache_writer.go
+++ b/internal/proxy/cache_writer.go
@@ -36,7 +36,7 @@ func (c *captureWriter) Write(p []byte) (int, error) {
 	if !c.overflow {
 		if c.body.Len()+len(p) > c.maxBytes {
 			c.overflow = true
-			c.body.Reset()
+			c.body = bytes.Buffer{}
 		} else {
 			c.body.Write(p)
 		}

--- a/internal/proxy/fire_telemetry_panic_internal_test.go
+++ b/internal/proxy/fire_telemetry_panic_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -69,7 +70,7 @@ func TestFireTelemetryRecoversFromPanic(t *testing.T) {
 	// first Get() call races SetDefault and resets the handler.
 	observability.Get()
 
-	var buf bytes.Buffer
+	var buf lockedLogBuffer
 	prev := slog.Default()
 	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
 	defer slog.SetDefault(prev)
@@ -90,4 +91,21 @@ func TestFireTelemetryRecoversFromPanic(t *testing.T) {
 
 	assert.Contains(t, buf.String(), "Background goroutine panicked")
 	assert.Contains(t, buf.String(), "fireTelemetry")
+}
+
+type lockedLogBuffer struct {
+	mu   sync.Mutex
+	body bytes.Buffer
+}
+
+func (b *lockedLogBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.body.Write(p)
+}
+
+func (b *lockedLogBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.body.String()
 }

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -135,7 +135,7 @@ type Service struct {
 	// records carry full request/response bodies, content hashes, or are
 	// suppressed entirely. Default CaptureOff (no log records emitted).
 	captureMode ContentCaptureMode
-	// captureMaxBytes caps the buffered response body when capture is on;
+	// captureMaxBytes caps each raw request/response capture;
 	// larger bodies are dropped and flagged io.truncated.
 	captureMaxBytes int
 	// redactor scrubs captured content before export. Nil passes through.
@@ -1822,7 +1822,7 @@ func (s *Service) WithRouterFeedbackStore(store RouterFeedbackStore) *Service {
 }
 
 // WithContentCapture configures high-fidelity `router.call` OTLP log emission.
-// mode selects off/hashed/full; maxBytes caps the buffered response body;
+// mode selects off/hashed/full; maxBytes caps each raw body capture;
 // redactor (optional) scrubs content before export. No-op effect when the
 // emitter is disabled. Default (unset) is CaptureOff.
 func (s *Service) WithContentCapture(mode ContentCaptureMode, maxBytes int, redactor Redactor) *Service {

--- a/internal/proxy/turn_logs.go
+++ b/internal/proxy/turn_logs.go
@@ -26,7 +26,7 @@ const (
 	// CaptureHashed emits log records with metadata + SHA-256 content hashes
 	// but no raw text — dedup/cache analysis without exposing prompts.
 	CaptureHashed
-	// CaptureFull emits log records with full raw request/response bodies
+	// CaptureFull emits log records with size-limited raw request/response bodies
 	// (after the redaction hook). Default for Weave-managed deploys.
 	CaptureFull
 )
@@ -164,11 +164,18 @@ func (d *deferredCallLog) run() {
 	}
 }
 
-func (s *Service) redact(content []byte, kind ContentKind) string {
-	if s.redactor == nil {
-		return string(content)
+func (s *Service) captureContent(content []byte, kind ContentKind) (string, bool) {
+	if len(content) > s.captureMaxBytes {
+		return "", true
 	}
-	return s.redactor(string(content), kind)
+	captured := string(content)
+	if s.redactor != nil {
+		captured = s.redactor(captured, kind)
+	}
+	if len(captured) > s.captureMaxBytes {
+		return "", true
+	}
+	return captured, false
 }
 
 func sha256Hex(b []byte) string {
@@ -186,20 +193,31 @@ func (s *Service) recordCallLog(ctx context.Context, base []*commonv1.KeyValue, 
 		return
 	}
 
-	content := otel.NewAttrBuilder(7).
+	content := otel.NewAttrBuilder(9).
 		Int64("latency.route_ms", routeMs).
 		Int64("io.request_bytes", int64(len(reqBody))).
-		Int64("io.response_bytes", int64(len(respBody))).
-		Bool("io.truncated", respTruncated)
+		Int64("io.response_bytes", int64(len(respBody)))
 
+	var reqTruncated bool
 	switch mode {
 	case CaptureFull:
-		content.String("io.request_body", s.redact(reqBody, ContentKindRequest)).
-			String("io.response_body", s.redact(respBody, ContentKindResponse))
+		var requestContent string
+		requestContent, reqTruncated = s.captureContent(reqBody, ContentKindRequest)
+		content.String("io.request_body", requestContent)
+		if !respTruncated {
+			var responseContent string
+			responseContent, respTruncated = s.captureContent(respBody, ContentKindResponse)
+			content.String("io.response_body", responseContent)
+		}
 	case CaptureHashed:
-		content.String("io.request_sha256", sha256Hex(reqBody)).
-			String("io.response_sha256", sha256Hex(respBody))
+		content.String("io.request_sha256", sha256Hex(reqBody))
+		if !respTruncated {
+			content.String("io.response_sha256", sha256Hex(respBody))
+		}
 	}
+	content.Bool("io.request_truncated", reqTruncated).
+		Bool("io.response_truncated", respTruncated).
+		Bool("io.truncated", reqTruncated || respTruncated)
 
 	attrs := append(slices.Clone(base), content.Build()...)
 	sev := otel.SeverityInfo

--- a/internal/proxy/turn_logs_internal_test.go
+++ b/internal/proxy/turn_logs_internal_test.go
@@ -397,3 +397,151 @@ func TestApplyPlannerAttrs_EmitsDetailsWhenEvaluated(t *testing.T) {
 	assert.InDelta(t, 0.003, attrs["planner.eviction_cost_usd"].GetDoubleValue(), 1e-12)
 	assert.Equal(t, "switch", attrs["planner.shadow_outcome"].GetStringValue())
 }
+
+func (c *logCollector) callAttrs(t *testing.T) map[string]*commonv1.AnyValue {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, body := range c.bodies {
+		var exported collogspb.ExportLogsServiceRequest
+		require.NoError(t, proto.Unmarshal(body, &exported))
+		for _, resource := range exported.ResourceLogs {
+			for _, scope := range resource.ScopeLogs {
+				for _, record := range scope.LogRecords {
+					if record.Body.GetStringValue() == "router.call" {
+						return attrsByKey(record.Attributes)
+					}
+				}
+			}
+		}
+	}
+	t.Fatal("no router.call log exported")
+	return nil
+}
+
+func TestRecordCallLog_RequestCaptureBoundaries(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		size      int
+		truncated bool
+	}{
+		{"empty", 0, false},
+		{"at cap", 1 << 20, false},
+		{"over cap", 1<<20 + 1, true},
+		{"maximum inbound", MaxRequestBodyBytes, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			coll := newLogCollector(t)
+			var requestRedactions int
+			redactor := func(content string, kind ContentKind) string {
+				if kind == ContentKindRequest {
+					requestRedactions++
+				}
+				return strings.ReplaceAll(content, "q", "r")
+			}
+			s, em := newServiceWithEmitter(t, CaptureFull, redactor, coll.server.URL)
+			request := []byte(strings.Repeat("q", tc.size))
+			buf := em.NewBuffer()
+			ctx := buf.WithContext(context.Background())
+			base := otel.NewAttrBuilder(1).String("training.allowed", "false").Build()
+			s.recordCallLog(ctx, base, 1, false, request, []byte("response"), false)
+			otel.Flush(ctx)
+			require.NoError(t, em.Shutdown(context.Background()))
+			attrs := coll.callAttrs(t)
+			assert.Equal(t, int64(tc.size), attrs["io.request_bytes"].GetIntValue())
+			assert.Equal(t, tc.truncated, attrs["io.request_truncated"].GetBoolValue())
+			assert.Equal(t, tc.truncated, attrs["io.truncated"].GetBoolValue())
+			assert.False(t, attrs["io.response_truncated"].GetBoolValue())
+			assert.Equal(t, "response", attrs["io.response_body"].GetStringValue())
+			assert.Equal(t, "false", attrs["training.allowed"].GetStringValue())
+			if tc.truncated {
+				assert.Empty(t, attrs["io.request_body"].GetStringValue())
+				assert.Zero(t, requestRedactions, "over-cap content must never reach the redactor")
+			} else {
+				assert.Equal(t, strings.Repeat("r", tc.size), attrs["io.request_body"].GetStringValue())
+				assert.Equal(t, 1, requestRedactions)
+			}
+			assert.Equal(t, strings.Repeat("q", tc.size), string(request), "capture must not redact the inference body in place")
+			assert.Len(t, base, 1)
+		})
+	}
+}
+
+func TestCaptureContent_OversizedRequestDoesNotAllocate(t *testing.T) {
+	s := &Service{captureMaxBytes: 1 << 20}
+	body := make([]byte, MaxRequestBodyBytes)
+	allocations := testing.AllocsPerRun(10, func() {
+		captured, truncated := s.captureContent(body, ContentKindRequest)
+		if captured != "" || !truncated {
+			panic("oversized body was retained")
+		}
+	})
+	assert.Zero(t, allocations, "must check the cap before allocating a 32 MiB string")
+}
+
+func TestRecordCallLog_RedactorCannotExpandPastCap(t *testing.T) {
+	coll := newLogCollector(t)
+	s, em := newServiceWithEmitter(t, CaptureFull, func(content string, kind ContentKind) string {
+		return strings.Repeat("x", 5)
+	}, coll.server.URL)
+	s.captureMaxBytes = 4
+	ctx := em.NewBuffer().WithContext(context.Background())
+	s.recordCallLog(ctx, nil, 1, false, []byte("req"), []byte("resp"), false)
+	otel.Flush(ctx)
+	require.NoError(t, em.Shutdown(context.Background()))
+	attrs := coll.callAttrs(t)
+	assert.Empty(t, attrs["io.request_body"].GetStringValue())
+	assert.Empty(t, attrs["io.response_body"].GetStringValue())
+	assert.True(t, attrs["io.request_truncated"].GetBoolValue())
+	assert.True(t, attrs["io.response_truncated"].GetBoolValue())
+	assert.True(t, attrs["io.truncated"].GetBoolValue())
+}
+
+func TestRecordCallLog_HashingPreservesLargeRequestWithoutFalseResponseHash(t *testing.T) {
+	coll := newLogCollector(t)
+	s, em := newServiceWithEmitter(t, CaptureHashed, func(string, ContentKind) string {
+		t.Fatal("hash-only capture must not redact raw text")
+		return ""
+	}, coll.server.URL)
+	body := []byte(strings.Repeat("q", MaxRequestBodyBytes))
+	ctx := em.NewBuffer().WithContext(context.Background())
+	s.recordCallLog(ctx, nil, 1, false, body, nil, true)
+	otel.Flush(ctx)
+	require.NoError(t, em.Shutdown(context.Background()))
+	attrs := coll.callAttrs(t)
+	assert.Equal(t, sha256Hex(body), attrs["io.request_sha256"].GetStringValue())
+	assert.NotContains(t, attrs, "io.request_body")
+	assert.NotContains(t, attrs, "io.response_sha256", "no captured response must not be misrepresented as a hash of empty content")
+	assert.False(t, attrs["io.request_truncated"].GetBoolValue())
+	assert.True(t, attrs["io.response_truncated"].GetBoolValue())
+	assert.True(t, attrs["io.truncated"].GetBoolValue())
+}
+
+func TestRecordCallLog_InstallationOffSkipsAllContentWork(t *testing.T) {
+	coll := newLogCollector(t)
+	s, em := newServiceWithEmitter(t, CaptureFull, func(string, ContentKind) string {
+		t.Fatal("capture-off content reached the redactor")
+		return ""
+	}, coll.server.URL)
+	ctx := context.WithValue(context.Background(), InstallationCaptureModeContextKey{}, CaptureOff)
+	ctx = em.NewBuffer().WithContext(ctx)
+	s.recordCallLog(ctx, nil, 1, false, []byte("secret"), []byte("secret"), false)
+	otel.Flush(ctx)
+	require.NoError(t, em.Shutdown(context.Background()))
+	assert.Zero(t, coll.count(t))
+}
+
+func TestCaptureWriter_OverflowReleasesBackingBuffer(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	writer := newCaptureWriter(recorder, 1<<20)
+	chunk := []byte(strings.Repeat("x", 1<<19))
+	for range 3 {
+		_, err := writer.Write(chunk)
+		require.NoError(t, err)
+		writer.Flush()
+	}
+	assert.True(t, writer.overflow)
+	assert.Zero(t, writer.body.Cap(), "Reset alone would retain the old backing array")
+	assert.Equal(t, strings.Repeat("x", 3<<19), recorder.Body.String())
+	assert.True(t, recorder.Flushed)
+}

--- a/internal/proxy/turn_logs_surface_test.go
+++ b/internal/proxy/turn_logs_surface_test.go
@@ -1,0 +1,158 @@
+package proxy_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"weave-os/router/internal/observability/otel"
+	"weave-os/router/internal/providers"
+	"weave-os/router/internal/proxy"
+	"weave-os/router/internal/router"
+)
+
+func TestContentCapture_LeavesInferenceBytesUnchangedWithBlockedCollector(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		provider string
+		model    string
+		body     string
+		response string
+		invoke   func(*proxy.Service, context.Context, []byte, http.ResponseWriter, *http.Request) error
+	}{
+		{
+			"messages", providers.ProviderAnthropic, "claude-haiku-4-5",
+			`{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"hello"}],"max_tokens":64}`,
+			`{"id":"msg_test","type":"message","role":"assistant","model":"claude-haiku-4-5","content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":1}}`,
+			(*proxy.Service).ProxyMessages,
+		},
+		{
+			"chat", providers.ProviderOpenAI, "gpt-4o",
+			`{"model":"gpt-4o","messages":[{"role":"user","content":"hello"}],"stop":["STOP"]}`,
+			`{"id":"chat_test","object":"chat.completion","model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":1}}`,
+			(*proxy.Service).ProxyOpenAIChatCompletion,
+		},
+		{
+			"responses", providers.ProviderOpenAI, "gpt-5.5",
+			`{"model":"gpt-5.5","input":"hello"}`,
+			`{"id":"resp_test","object":"response","model":"gpt-5.5","status":"completed","output":[{"id":"msg_test","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"hello"}]}],"usage":{"input_tokens":10,"output_tokens":1}}`,
+			(*proxy.Service).ProxyOpenAIResponses,
+		},
+		{
+			"gemini", providers.ProviderGoogle, "gemini-2.5-pro",
+			`{"model":"gemini-2.5-pro","contents":[{"role":"user","parts":[{"text":"hello"}]}]}`,
+			`{"candidates":[{"content":{"role":"model","parts":[{"text":"hello"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":1}}`,
+			(*proxy.Service).ProxyGeminiGenerateContent,
+		},
+		{
+			"messages-stream", providers.ProviderAnthropic, "claude-haiku-4-5",
+			`{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"hello"}],"max_tokens":64,"stream":true}`,
+			"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_test\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-haiku-4-5\",\"content\":[],\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\n" +
+				"event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n" +
+				"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n\n" +
+				"event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n" +
+				"event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":1}}\n\n" +
+				"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+			(*proxy.Service).ProxyMessages,
+		},
+		{
+			"chat-stream", providers.ProviderOpenAI, "gpt-4o",
+			`{"model":"gpt-4o","messages":[{"role":"user","content":"hello"}],"stop":["STOP"],"stream":true}`,
+			"data: {\"id\":\"chat_test\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"hello\"},\"finish_reason\":null}]}\n\n" +
+				"data: {\"id\":\"chat_test\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":1}}\n\n" +
+				"data: [DONE]\n\n",
+			(*proxy.Service).ProxyOpenAIChatCompletion,
+		},
+		{
+			"responses-stream", providers.ProviderOpenAI, "gpt-5.5",
+			`{"model":"gpt-5.5","input":"hello","stream":true}`,
+			"event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_test\",\"model\":\"gpt-5.5\",\"status\":\"in_progress\",\"output\":[]}}\n\n" +
+				"event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"item_id\":\"msg_test\",\"output_index\":0,\"content_index\":0,\"delta\":\"hello\"}\n\n" +
+				"event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_test\",\"model\":\"gpt-5.5\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":10,\"output_tokens\":1}}}\n\n",
+			(*proxy.Service).ProxyOpenAIResponses,
+		},
+		{
+			"gemini-stream", providers.ProviderGoogle, "gemini-2.5-pro",
+			`{"model":"gemini-2.5-pro","contents":[{"role":"user","parts":[{"text":"hello"}]}],"stream":true}`,
+			"data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"hello\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":10,\"candidatesTokenCount\":1}}\n\n",
+			(*proxy.Service).ProxyGeminiGenerateContent,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			release := make(chan struct{})
+			started := make(chan struct{}, 2)
+			collector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.Copy(io.Discard, r.Body)
+				select {
+				case started <- struct{}{}:
+				default:
+				}
+				select {
+				case <-release:
+				case <-r.Context().Done():
+				}
+			}))
+			defer collector.Close()
+			defer close(release)
+			em, err := otel.NewEmitter(otel.EmitterConfig{Endpoint: collector.URL, Workers: 1, QueueSize: 2, BatchSize: 1, ExportTimeout: time.Minute})
+			require.NoError(t, err)
+			defer func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+				defer cancel()
+				_ = em.Shutdown(ctx)
+			}()
+			var upstream, client []byte
+			for _, mode := range []proxy.ContentCaptureMode{proxy.CaptureOff, proxy.CaptureFull, proxy.CaptureHashed} {
+				provider := &fakeProvider{proxyResponse: func(w http.ResponseWriter) {
+					if strings.HasSuffix(tc.name, "-stream") {
+						w.Header().Set("Content-Type", "text/event-stream")
+					} else {
+						w.Header().Set("Content-Type", "application/json")
+					}
+					_, _ = io.WriteString(w, tc.response)
+					if flusher, ok := w.(http.Flusher); ok {
+						flusher.Flush()
+					}
+				}}
+				svc := proxy.NewService(&fakeRouter{decision: router.Decision{Provider: tc.provider, Model: tc.model}},
+					map[string]providers.Client{tc.provider: provider}, em, false, nil, nil, false, tc.provider, tc.model, nil).
+					WithContentCapture(mode, 4, nil)
+				body := []byte(tc.body)
+				recorder := httptest.NewRecorder()
+				ctx := context.WithValue(context.Background(), proxy.InstallationHideTerminalSurfacesContextKey{}, true)
+				ctx = em.NewBuffer().WithContext(ctx)
+				req := httptest.NewRequest(http.MethodPost, "/v1/"+tc.name, strings.NewReader(tc.body))
+				finished := make(chan error, 1)
+				go func() { finished <- tc.invoke(svc, ctx, body, recorder, req) }()
+				select {
+				case err := <-finished:
+					require.NoError(t, err)
+				case <-time.After(3 * time.Second):
+					t.Fatal("inference waited for the collector")
+				}
+				require.Len(t, provider.proxyBodies, 1)
+				assert.Equal(t, tc.body, string(body))
+				if mode == proxy.CaptureOff {
+					upstream = provider.proxyBodies[0]
+					client = recorder.Body.Bytes()
+					require.NotEmpty(t, client)
+					// Hold at least the upstream span export before captured calls run.
+					select {
+					case <-started:
+					case <-time.After(3 * time.Second):
+						t.Fatal("collector not reached")
+					}
+				} else {
+					assert.Equal(t, upstream, provider.proxyBodies[0])
+					assert.Equal(t, string(client), recorder.Body.String())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Apply the existing raw-content ceiling to requests before string conversion or redaction, and bound redactor output too. Preserve full-request hashes and installation privacy ceilings; flag each omitted body and do not emit a false empty-response hash.
- Keep the existing OTLP channels and fixed workers, with a shared **64 MiB payload budget** across admission, queues, batches, and serialized HTTP copies. Cap each export at **4 MiB**. Queue owned encoded records instead of retaining caller protobuf graphs.
- Preserve `Shutdown(ctx)` and constructor signatures; cancel blocked exports at the shutdown deadline and release the backlog. Release overflowed response-capture backing buffers immediately.
- Add boundary, saturation, lifecycle, race, wire-equivalence, and streaming/nonstreaming inference-byte regressions. Fix two existing test log-buffer races exposed by the race run and tighten the global-logger ratchet.

No routing, authentication, billing, APM exporter, or shared-worker changes. No new environment settings or dependencies. Overload remains explicitly best effort: oversized/full/closing admission drops optional telemetry, without waiting or retrying. The payload budget excludes request-scoped capture buffers and HTTP/TLS overhead; those limits are documented separately.

## Validation

- `wv router tc`
- `wv router t`
- `go test -vet=all -count=1 ./...`
- `bash scripts/changed_non_go_files_test.sh`
- `go test -race -count=1 ./internal/observability/... ./internal/proxy`
- `dots workflow precommit --json` (format + `go vet ./...`)
- `golangci-lint run`
- `make inference-boundary`
- `make check-agent-guides check-docs`

No generator/migration inputs changed. No production changes. Docker replay smoke is left to the existing PR workflow; it was not run locally.

🤖 Generated with [Weave Router](https://router.workweave.ai)
